### PR TITLE
feat: support resumable multi-agent handoffs

### DIFF
--- a/.agents/HANDOFF_TEMPLATE.md
+++ b/.agents/HANDOFF_TEMPLATE.md
@@ -1,0 +1,53 @@
+# Agent handoff: Issue ISSUE_NUMBER
+
+## Identity and scope
+
+- Source agent ID: AGENT_ID
+- Capabilities used: CAPABILITIES
+- Branch: BRANCH_NAME
+- Checkpoint parent: CHECKPOINT_PARENT
+- Updated at (UTC): UPDATED_AT
+- Credentials included: no
+
+## Objective
+
+TODO
+
+## Completed
+
+- TODO
+
+## Files changed
+
+- TODO
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `TODO` | TODO | TODO |
+
+## Failed attempts
+
+- TODO, or `None`.
+
+## Unresolved decisions and blockers
+
+- TODO, or `None`.
+
+## Next executable steps
+
+1. TODO
+
+## Capabilities required for the next Agent
+
+- TODO
+
+## Environment assumptions
+
+- TODO
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device identifiers, or precise user locations are included.
+- TODO

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -50,6 +50,25 @@ body:
     validations:
       required: true
   - type: textarea
+    id: capabilities
+    attributes:
+      label: Required capabilities
+      description: List non-secret capability tags. Never list API keys, token identifiers, or account details.
+      placeholder: |
+        - go
+        - tls-h2
+        - security-review
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and access constraints
+      description: Hardware, architecture, fixtures, or tools required. Credentials remain local to each Agent.
+      placeholder: "No external credentials; synthetic fixtures only"
+    validations:
+      required: true
+  - type: textarea
     id: dependencies
     attributes:
       label: Dependencies and blockers
@@ -79,4 +98,6 @@ body:
         - label: Failure and rollback behavior is specified.
           required: true
         - label: This task respects Phase 0 fixture and license gates.
+          required: true
+        - label: Required capabilities are non-secret and no API key will be shared through Git or GitHub.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Closes #
 
 Role: `role:`
 
+Handoff capsule: `.handoffs/issue-<number>.md`
+
 ## Outcome
 
 Describe the user-visible or engineering outcome, not only the files changed.
@@ -31,4 +33,4 @@ Explain how to disable or revert this change without damaging Gateway 1.7.
 
 ## Handoff
 
-List follow-up Issues, new contracts, or blocked Agents.
+List follow-up Issues, new contracts, blocked Agents, and capabilities required for takeover. Do not include credentials.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+      - name: Scan committed content for secrets
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify repository
         run: ./scripts/ci/verify.sh
 
@@ -26,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v5
       - name: Validate branch and linked Issue
         env:
           BRANCH_NAME: ${{ github.head_ref }}
@@ -35,7 +40,18 @@ jobs:
             codex/issue-[0-9]*-*) ;;
             *) echo "Branch must match codex/issue-<number>-<slug>" >&2; exit 1 ;;
           esac
-          printf '%s' "$PR_BODY" | grep -Eq '(Closes|Fixes|Resolves) #[0-9]+' || {
-            echo "PR body must link its task with Closes #<number>" >&2
+          issue_id=$(printf '%s' "$BRANCH_NAME" | sed -E 's#^codex/issue-([0-9]+)-.*#\1#')
+          printf '%s' "$PR_BODY" | grep -Eq "(Closes|Fixes|Resolves) #${issue_id}([^0-9]|$)" || {
+            echo "PR body must close branch Issue #$issue_id" >&2
             exit 1
           }
+          capsule=".handoffs/issue-${issue_id}.md"
+          test -s "$capsule" || {
+            echo "PR must contain $capsule" >&2
+            exit 1
+          }
+          printf '%s' "$PR_BODY" | grep -Fq "Handoff capsule: \`$capsule\`" || {
+            echo "PR body must reference $capsule" >&2
+            exit 1
+          }
+          ./scripts/ci/verify-handoffs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,23 @@ tmp/
 *.log
 *.out
 *.test
+.env
+.env.*
+!.env.example
+!.env.*.example
+credentials
+credentials.*
+secrets
+secrets.*
 
 # Never commit generated secrets or captured production traffic.
 *.key
 *.pem
 *.p12
 *.pfx
+*.crt.key
+id_rsa
+id_ed25519
 fixtures/private/
 captures/
 

--- a/.handoffs/README.md
+++ b/.handoffs/README.md
@@ -1,0 +1,5 @@
+# Handoff capsules
+
+Each active Issue uses one `.handoffs/issue-<number>.md` file on its working branch. Copy `.agents/HANDOFF_TEMPLATE.md`, replace every placeholder, commit the capsule with the resumable code, and publish it with `scripts/agent-handoff.sh`.
+
+The exact resumable commit is recorded by the resulting `agent-handoff:v1` GitHub Issue comment. Capsules contain no credentials. An API key belongs only to the Agent's local environment.

--- a/.handoffs/issue-9.md
+++ b/.handoffs/issue-9.md
@@ -1,0 +1,75 @@
+# Agent handoff: Issue 9
+
+## Identity and scope
+
+- Source agent ID: codex-bootstrap
+- Capabilities used: ci,security,docs
+- Branch: codex/issue-9-handoff-leases
+- Checkpoint parent: 225c731d1c127a2452240e781d9ff5d0c1a0d27f
+- Updated at (UTC): 2026-08-11T05:50:00Z
+- Credentials included: no
+
+## Objective
+
+Replace permanent single-Agent ownership with resumable leases and exact commit handoffs for Agents that use different local API keys and have different capabilities.
+
+## Completed
+
+- Defined non-secret capability labels and credential isolation rules.
+- Added 15–1440 minute Git compare-and-swap leases with expiry and renewal behavior.
+- Added takeover from the latest immutable handoff commit into a fresh continuation branch/worktree.
+- Added checkpoint publication, capsule validation, PR requirements, documentation, and offline tests.
+- Replaced comment parsing with strict two-line marker/JSON state commits and atomic Git refs.
+- Added pinned Gitleaks scanning and exact PR branch/Issue/capsule correlation.
+- Migrated Issues 1–9 to explicit capability contracts.
+
+## Files changed
+
+- `AGENTS.md`, `README.md`, and `docs/MULTI_AGENT_WORKFLOW.md`
+- `.agents/HANDOFF_TEMPLATE.md` and `.handoffs/`
+- `scripts/agent-lease.sh`, `scripts/agent-takeover.sh`, and `scripts/agent-handoff.sh`
+- GitHub Issue/PR/CI configuration and script tests
+- Planning and progress records
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./scripts/ci/verify.sh` | Passed | Includes Shell syntax, handoff validation, secret-pattern checks, and offline tool tests |
+| `ruby -e 'require "yaml"; ...'` | Passed | All GitHub YAML parsed |
+| `git diff --check` | Passed | No whitespace errors |
+| `./scripts/agent-lease.sh 9 codex-bootstrap 'ci,security,docs' 120` | Passed | Atomic ref `agent-leases/issue-9` points to strict state commit `7e513a3892ea8bee03562a7adfd426398ebf3c30` |
+| `python3 -m unittest discover -s tests -p 'test_*.py'` | Passed | Includes stale-generation CAS rejection and strict state-envelope tests |
+
+## Failed attempts
+
+- Initial label/comment lease design failed independent review because it was vulnerable to TOCTOU and forged comment state; replaced with Git ref compare-and-swap.
+
+## Unresolved decisions and blockers
+
+- Private-repository branch protection still requires GitHub Pro; Agent state refs prevent accidental concurrent leases but do not replace GitHub repository authorization.
+- A reviewer should confirm that capability labels on Issues 1–8 are neither too broad nor too restrictive before product development starts.
+
+## Next executable steps
+
+1. Run repository verification from a clean checkout of this commit.
+2. Review lease-expiry parsing on both macOS and Linux runners.
+3. Open and review the Issue #9 pull request.
+4. After merge, start a fresh Agent on one `status:ready` Issue using `agent-takeover.sh`.
+
+## Capabilities required for the next Agent
+
+- ci
+- security
+- docs
+
+## Environment assumptions
+
+- Git, GitHub CLI, Python 3, and POSIX shell are available.
+- Each Agent authenticates GitHub and its model provider independently.
+- No credential, hardware device, or private fixture is required to review this workflow change.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device identifiers, or precise user locations are included.
+- Agent IDs are non-secret operational aliases and must not encode provider account or credential information.

--- a/.handoffs/issue-9.md
+++ b/.handoffs/issue-9.md
@@ -2,11 +2,11 @@
 
 ## Identity and scope
 
-- Source agent ID: codex-bootstrap
+- Source agent ID: codex-resume-test
 - Capabilities used: ci,security,docs
-- Branch: codex/issue-9-handoff-leases
-- Checkpoint parent: 225c731d1c127a2452240e781d9ff5d0c1a0d27f
-- Updated at (UTC): 2026-08-11T05:50:00Z
+- Branch: codex/issue-9-resume-check-codex-resume-test-20260811055034-ea1011f3
+- Checkpoint parent: 6a291f7747aac8a3327ed835fb5f8a324d18ec03
+- Updated at (UTC): 2026-08-11T05:52:00Z
 - Credentials included: no
 
 ## Objective
@@ -22,6 +22,10 @@ Replace permanent single-Agent ownership with resumable leases and exact commit 
 - Replaced comment parsing with strict two-line marker/JSON state commits and atomic Git refs.
 - Added pinned Gitleaks scanning and exact PR branch/Issue/capsule correlation.
 - Migrated Issues 1–9 to explicit capability contracts.
+- Verified a second Agent ID could resume from the exact published handoff commit in a new worktree.
+- Added capsule-to-authoritative-state identity validation after the takeover exercise.
+- Made handoff publication a single atomic update of lease and handoff refs; stale publishers cannot overwrite a new lease.
+- Added pre-push high-confidence secret scanning in addition to pinned Gitleaks CI.
 
 ## Files changed
 
@@ -39,7 +43,8 @@ Replace permanent single-Agent ownership with resumable leases and exact commit 
 | `ruby -e 'require "yaml"; ...'` | Passed | All GitHub YAML parsed |
 | `git diff --check` | Passed | No whitespace errors |
 | `./scripts/agent-lease.sh 9 codex-bootstrap 'ci,security,docs' 120` | Passed | Atomic ref `agent-leases/issue-9` points to strict state commit `7e513a3892ea8bee03562a7adfd426398ebf3c30` |
-| `python3 -m unittest discover -s tests -p 'test_*.py'` | Passed | Includes stale-generation CAS rejection and strict state-envelope tests |
+| `python3 -m unittest discover -s tests -p 'test_*.py'` | Passed | Includes stale-generation rejection, atomic two-ref handoff rejection, capsule identity, and strict envelope tests |
+| `./scripts/agent-takeover.sh 9 codex-resume-test resume-check 'ci,security,docs' 30` | Passed | New worktree started exactly at `6a291f7747aac8a3327ed835fb5f8a324d18ec03` |
 
 ## Failed attempts
 
@@ -52,10 +57,9 @@ Replace permanent single-Agent ownership with resumable leases and exact commit 
 
 ## Next executable steps
 
-1. Run repository verification from a clean checkout of this commit.
-2. Review lease-expiry parsing on both macOS and Linux runners.
-3. Open and review the Issue #9 pull request.
-4. After merge, start a fresh Agent on one `status:ready` Issue using `agent-takeover.sh`.
+1. Run repository verification from a clean checkout of this continuation commit.
+2. Open and review the Issue #9 pull request.
+3. After merge, start a fresh Agent on one `status:ready` Issue using `agent-takeover.sh`.
 
 ## Capabilities required for the next Agent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Build `wificalling-location-gateway` as an isolated, fail-open OpenWrt component
 
 ## Source of truth
 
-1. A GitHub Issue is the only unit of assignable work.
+1. A GitHub Issue is the only unit of assignable work and the durable coordination record.
 2. `DEVELOPMENT_TEST_PLAN.md` defines architecture, safety gates, and phase exit criteria.
 3. The Issue defines the owned paths, dependencies, acceptance tests, and non-goals.
 4. A pull request is the only integration path into `main`.
@@ -22,19 +22,29 @@ Build `wificalling-location-gateway` as an isolated, fail-open OpenWrt component
 | `role:test` | `tests/`, `scripts/ci/` | Test harness, fuzzing, packaging and resource gates |
 | `role:integration` | `docs/`, packaging metadata, Gateway contract | Cross-module contracts and release integration |
 
-Issue-specific ownership overrides this table. An Agent must not edit another active Issue's owned paths without an explicit handoff recorded on both Issues.
+Issue-specific ownership overrides this table. Ownership is a time-limited lease, not permanent assignment. An Agent must not edit another active lease's paths unless it is performing a recorded takeover from an expired or released lease.
+
+## Identity, credentials, and capabilities
+
+- Each Agent uses its own API key and authentication environment. Never copy credentials between Agents.
+- API keys, tokens, `.env` files, provider account names, and credential fingerprints are not handoff data and must not enter GitHub.
+- Agents identify themselves with a non-secret `agent_id` and declare only capability tags such as `go`, `tls-h2`, `protobuf`, `openwrt`, `security`, `ios-device`, `ci`, or `docs`.
+- An Agent may take over a task only when it satisfies every `cap:*` label or records a limited research/review scope that does not execute the restricted work.
+- Lease authority is the atomically updated `agent-leases/issue-<n>` Git ref; handoff authority is `agent-handoffs/issue-<n>`. Issue labels and comments are display-only projections.
+- The immutable continuity anchor is the pushed source commit recorded by the authoritative handoff Git ref.
 
 ## Required workflow
 
-1. Claim one `status:ready` Issue and move it to `status:claimed`.
-2. Create `codex/issue-<number>-<slug>` in an independent worktree.
+1. Lease one `status:ready` or `status:handoff` Issue with a non-secret Agent ID and capability list.
+2. Create `codex/issue-<number>-<slug>-<agent>` in an independent worktree, based on the latest handoff commit when one exists.
 3. Read this file, the Issue, and relevant sections of `DEVELOPMENT_TEST_PLAN.md`.
 4. Write tests or executable verification before implementation when product code is in scope.
 5. Keep commits focused and use Conventional Commits.
-6. Open a PR containing `Closes #<number>`, evidence, risks, and rollback notes.
-7. A different role reviews the PR. The author never self-approves a safety-sensitive change.
+6. Before pausing, lease expiry, or PR creation, update `.handoffs/issue-<number>.md`, commit it, push the branch, and publish the exact commit.
+7. Open a PR containing `Closes #<number>`, evidence, risks, rollback notes, and the handoff capsule path.
+8. A different role reviews the PR. The author never self-approves a safety-sensitive change.
 
-Use `scripts/agent-worktree.sh <issue> <agent> <slug>` to create a worktree and `scripts/claim-issue.sh <issue>` to claim the GitHub task.
+Use `scripts/agent-takeover.sh <issue> <agent> <slug> <capabilities> [ttl-minutes]` to start or resume work. Use `scripts/agent-handoff.sh <issue> <agent> <capabilities>` to release a resumable checkpoint.
 
 ## Hard gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Issue-specific ownership overrides this table. Ownership is a time-limited lease
 - An Agent may take over a task only when it satisfies every `cap:*` label or records a limited research/review scope that does not execute the restricted work.
 - Lease authority is the atomically updated `agent-leases/issue-<n>` Git ref; handoff authority is `agent-handoffs/issue-<n>`. Issue labels and comments are display-only projections.
 - The immutable continuity anchor is the pushed source commit recorded by the authoritative handoff Git ref.
+- State refs are a cooperative lock for Agents that already have repository write access, not an authorization boundary. Hard protection requires GitHub Pro branch/ruleset protection or a single-writer coordination service.
 
 ## Required workflow
 
@@ -49,7 +50,7 @@ Use `scripts/agent-takeover.sh <issue> <agent> <slug> <capabilities> [ttl-minute
 ## Hard gates
 
 - Do not implement WLOC response patching before the Phase 0 authorized-fixture and license ADR Issues are closed.
-- Never commit CA private keys, node credentials, captured device identifiers, raw production traffic, tokens, or precise user location.
+- Never commit CA private keys, node credentials, captured device identifiers, raw production traffic, tokens, or precise user location. Local pre-push scanning and CI reduce accidental leaks but cannot stop an authorized writer who bypasses the workflow.
 - All parser and network inputs require size, time, concurrency, and schema limits.
 - Unknown protocol, invalid Geo data, or engine failure must not produce a default fake coordinate.
 - WLOC interception must remain limited to the assigned test device, two exact Apple hostnames, and TCP 443.

--- a/README.md
+++ b/README.md
@@ -20,14 +20,25 @@ flowchart LR
 
 Seven tasks are ready for parallel work. Engine implementation remains blocked until the license boundary, authorized fixture contract, and threat model are closed.
 
-## Start an Agent
+## Start or resume an Agent
 
 ```sh
-./scripts/claim-issue.sh <issue-number>
-./scripts/agent-worktree.sh <issue-number> <agent-name> <slug>
+./scripts/agent-takeover.sh <issue> <agent-id> <slug> <capabilities> [ttl-minutes]
 ```
 
-Give the Agent the Issue URL and generated worktree path. Every Agent must follow [AGENTS.md](AGENTS.md), and every pull request must run:
+Example:
+
+```sh
+./scripts/agent-takeover.sh 4 terra-net exit-probe 'go,network,test' 120
+```
+
+Before the Agent pauses or another Agent takes over, update `.handoffs/issue-4.md`, commit it, then publish the checkpoint:
+
+```sh
+./scripts/agent-handoff.sh 4 terra-net 'go,network,test'
+```
+
+Each Agent keeps its own API key and login environment. Handoffs contain capability names and reproducible state only—never credentials. Every Agent must follow [AGENTS.md](AGENTS.md), and every pull request must run:
 
 ```sh
 ./scripts/ci/verify.sh

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -4,15 +4,18 @@
 
 GitHub Issues are the task queue. Labels express role, phase, and state; Milestones express release gates. The repository avoids a custom scheduler so humans and Agents see the same auditable state.
 
-Task states:
+Task states and leases:
 
 ```text
-status:triage -> status:ready -> status:claimed -> status:review -> status:done
-                                  |                   |
-                                  +-> status:blocked <-+
+status:triage -> status:ready -> status:active -> status:handoff -> status:active
+                                      |                    |
+                                      +-> status:review -> status:done
+                                      +-> status:blocked
 ```
 
 Only tasks with explicit owned paths, dependencies, acceptance criteria, non-goals, and rollback behavior may become `status:ready`.
+
+`status:active` mirrors a lease stored under `agent-leases/issue-<n>`. Lease acquisition uses Git's atomic `--force-with-lease` compare-and-swap, so two Agents cannot both publish the same lease generation. `status:handoff` mirrors `agent-handoffs/issue-<n>`. Issue labels and comments are readable projections only; the Git state refs and referenced source commit are authoritative.
 
 ## Parallel work lanes
 
@@ -27,25 +30,40 @@ Only tasks with explicit owned paths, dependencies, acceptance criteria, non-goa
 
 ## Starting an Agent
 
-1. Select one Issue carrying `status:ready` and one `role:*` label.
-2. Claim it:
+1. Select an Issue carrying `status:ready` or `status:handoff`.
+2. Confirm that the Agent satisfies all `cap:*` labels. Capabilities describe tools and expertise, never API keys.
+3. Start or take over the task:
 
    ```sh
-   ./scripts/claim-issue.sh 12
+   ./scripts/agent-takeover.sh 12 agent-terra fixture-contract 'protocol,test,security' 120
    ```
 
-3. Create an isolated worktree:
+4. The script leases the Issue and creates a new isolated continuation branch from either `origin/main` or the latest published handoff commit.
+5. Work in the generated worktree. Update `.handoffs/issue-12.md` after every meaningful checkpoint.
+6. Before stopping, commit all resumable state and release it:
 
    ```sh
-   ./scripts/agent-worktree.sh 12 protocol fixture-contract
+   ./scripts/agent-handoff.sh 12 agent-terra 'protocol,test,privacy'
    ```
 
-4. Start the Agent with the Issue URL, worktree path, owned paths, and instruction not to revert other Agents.
-5. Push the branch and open a PR. Move the Issue to `status:review`.
+7. Another capable Agent can run `agent-takeover.sh`; it starts from the exact published SHA, not from chat memory.
+8. When complete, open a PR and move the Issue to `status:review`.
 
 ## Handoffs
 
 If a task discovers work outside its owned paths, it opens a new Issue. Cross-role contracts must be committed as schema, interface, fixture, or ADR before dependent implementation begins. Chat messages are coordination hints, not durable requirements.
+
+Every handoff capsule records:
+
+- source Agent ID and non-secret capabilities;
+- branch and checkpoint parent;
+- completed work and changed files;
+- exact verification commands and results;
+- failed attempts and unresolved decisions;
+- next executable steps and required capabilities;
+- environment assumptions, blockers, and security notes.
+
+The capsule must explicitly state that no credentials are included. Uncommitted changes are not transferable state.
 
 ## Merge policy
 
@@ -54,6 +72,7 @@ If a task discovers work outside its owned paths, it opens a new Issue. Cross-ro
 - Code owner review for CA, proxy, OpenWrt, or workflow paths.
 - Resolve all review threads and preserve linear history.
 - Delete merged branches; prune worktrees locally after merge.
+- PRs must reference `.handoffs/issue-<number>.md` so a reviewer or replacement Agent can reproduce the final state.
 
 ## Current GitHub account limitation
 

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -15,7 +15,7 @@ status:triage -> status:ready -> status:active -> status:handoff -> status:activ
 
 Only tasks with explicit owned paths, dependencies, acceptance criteria, non-goals, and rollback behavior may become `status:ready`.
 
-`status:active` mirrors a lease stored under `agent-leases/issue-<n>`. Lease acquisition uses Git's atomic `--force-with-lease` compare-and-swap, so two Agents cannot both publish the same lease generation. `status:handoff` mirrors `agent-handoffs/issue-<n>`. Issue labels and comments are readable projections only; the Git state refs and referenced source commit are authoritative.
+`status:active` mirrors a lease stored under `agent-leases/issue-<n>`. Lease acquisition uses Git's atomic `--force-with-lease` compare-and-swap, so two cooperative Agents cannot both publish the same lease generation. Handoff publication atomically updates both lease and handoff refs. `status:handoff` mirrors `agent-handoffs/issue-<n>`. Issue labels and comments are readable projections only; the Git state refs and referenced source commit are authoritative.
 
 ## Parallel work lanes
 
@@ -64,6 +64,8 @@ Every handoff capsule records:
 - environment assumptions, blockers, and security notes.
 
 The capsule must explicitly state that no credentials are included. Uncommitted changes are not transferable state.
+
+The scripts run a local high-confidence secret scan before handoff pushes; pinned Gitleaks runs again in GitHub Actions. This prevents common accidental leaks when Agents follow the workflow. Because the current private repository cannot protect branches or state refs on this account tier, all write-capable Agents remain inside the trusted collaboration boundary.
 
 ## Merge policy
 

--- a/findings.md
+++ b/findings.md
@@ -56,3 +56,11 @@
 - 计划推荐 Go，而不是 C + TLS/nghttp2；多 Agent 首批任务应先覆盖协议证据、威胁模型、测试夹具、出口探测和 OpenWrt 隔离设计。
 - GitHub Projects v2 不是首期硬依赖；Issue + 标签 + Milestone + PR 已足以形成可审计任务队列，避免额外 project scope 和自动化复杂度。
 - GitHub API 明确拒绝为当前账号的私有仓库启用 branch protection（HTTP 403，要求 GitHub Pro 或公开仓库）。这不影响私有仓库、Issues、Actions 和 PR，但服务端无法强制禁止管理员直推。
+
+## 可接管 Agent 模型
+
+- 不同 Agent 使用不同 API Key 时，凭据不应集中保存或进入 Git/GitHub；接管只需要代码、测试证据、环境能力和任务状态。
+- GitHub assignee 无法区分共用同一 GitHub 身份但使用不同模型/API Key 的 Agent，因此 Agent ID 与能力必须写入结构化租约/交接记录。
+- GitHub Issue 标签更新不是强一致锁；租约属于协作锁。代码连续性的真正锚点是已推送的不可变 commit SHA。
+- 最小可靠交接单元应包含：Issue、分支、commit、完成项、未完成项、测试命令/结果、失败记录、下一步、所需能力、环境假设和安全事项。
+- 接管 Agent 可以能力不同，但不得绕过任务的 required capabilities；能力不足时可做研究或复核，不能执行受限实现。

--- a/progress.md
+++ b/progress.md
@@ -37,3 +37,14 @@
 - 修复后的 GitHub Actions `repository-gates` 已通过；根据运行器提示将 `actions/checkout` 升级到 v5。
 - 已限制仓库只使用 squash merge，并启用合并后自动删除 Agent 分支。
 - `actions/checkout@v5` 的最终远程 CI 通过；私有仓库、多 Agent 队列、脚本和文档均已部署。
+- 用户要求把单 Agent 独占模型改为不同 API Key/能力的 Agent 可随时接管模型。
+- 已创建 GitHub Issue #9，并在 `codex/issue-9-handoff-leases` 分支开始实现租约与检查点协议。
+- 已将协作模型改为非秘密能力声明、15–1440 分钟短租约、精确 commit 检查点和可续接分支。
+- 已新增 handoff capsule 模板、租约/接管/发布脚本、capsule CI 校验和无网络单元测试。
+- 已把 GitHub `status:claimed` 迁移为 `status:active`，新增 `status:handoff` 和 11 个能力标签。
+- 已为 Issues #1–#9 添加 required capabilities、环境约束和“凭据不交接”契约。
+- 已使用 Issue #9 成功验证真实租约创建、能力匹配、状态转换和结构化租约评论。
+- 独立 Reviewer 发现标签租约 TOCTOU、handoff 发布者校验、commit 可达性、PR 编号一致性和秘密扫描缺口。
+- 已将权威租约/交接状态升级为 Git 原子 CAS refs，并把 Issue 评论降级为只读投影；接管将验证远端可达性并在失败时回滚。
+- 已修复 Reviewer 的关键项：handoff 仅允许当前未过期租约持有人、远端 commit ancestry 校验、PR 三处 Issue 编号强一致、固定 commit 的 Gitleaks、失败清理和仓库根目录归一化。
+- 已新增 Python 状态机测试，实际创建并读取 `agent-leases/issue-9` 原子租约 ref 成功。

--- a/progress.md
+++ b/progress.md
@@ -48,3 +48,7 @@
 - 已将权威租约/交接状态升级为 Git 原子 CAS refs，并把 Issue 评论降级为只读投影；接管将验证远端可达性并在失败时回滚。
 - 已修复 Reviewer 的关键项：handoff 仅允许当前未过期租约持有人、远端 commit ancestry 校验、PR 三处 Issue 编号强一致、固定 commit 的 Gitleaks、失败清理和仓库根目录归一化。
 - 已新增 Python 状态机测试，实际创建并读取 `agent-leases/issue-9` 原子租约 ref 成功。
+- 已用 `codex-resume-test` 从权威 handoff commit 创建全新 continuation worktree，证明不同 Agent ID 可接管。
+- 接管演练后新增 capsule 的 Issue/Agent/branch/capabilities 与权威 handoff state 强一致校验。
+- 二次 Reviewer 发现 lease/handoff 双 ref 非原子和 takeover 读取顺序竞态；已改为双 ref `git push --atomic`，并在租约线性化后读取 handoff。
+- 已增加本地高置信秘密扫描；明确 CAS 是可信写入 Agent 的协作锁，不是访问控制边界。

--- a/scripts/agent-handoff.sh
+++ b/scripts/agent-handoff.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <issue-number> <agent-id> <capability-csv>" >&2
+    exit 2
+fi
+
+exec python3 "$(dirname "$0")/agent_state.py" handoff "$1" "$2" "$3"

--- a/scripts/agent-lease.sh
+++ b/scripts/agent-lease.sh
@@ -2,9 +2,9 @@
 set -eu
 
 if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-    echo "deprecated wrapper: use agent-lease.sh directly" >&2
     echo "usage: $0 <issue-number> <agent-id> <capability-csv> [ttl-minutes]" >&2
     exit 2
 fi
 
-exec "$(dirname "$0")/agent-lease.sh" "$@"
+ttl=${4:-120}
+exec python3 "$(dirname "$0")/agent_state.py" lease "$1" "$2" "$3" --ttl "$ttl"

--- a/scripts/agent-takeover.sh
+++ b/scripts/agent-takeover.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 4 ] || [ "$#" -gt 5 ]; then
+    echo "usage: $0 <issue-number> <agent-id> <slug> <capability-csv> [ttl-minutes]" >&2
+    exit 2
+fi
+
+ttl=${5:-120}
+exec python3 "$(dirname "$0")/agent_state.py" takeover "$1" "$2" "$3" "$4" --ttl "$ttl"

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -6,6 +6,8 @@ if [ "$#" -ne 3 ]; then
     exit 2
 fi
 
+echo 'note: this is a low-level fresh-work helper; prefer agent-takeover.sh for resumable tasks' >&2
+
 issue=$1
 agent=$2
 slug=$3

--- a/scripts/agent_state.py
+++ b/scripts/agent_state.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Atomic, credential-free Agent lease and handoff coordination."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import pathlib
+import re
+import secrets
+import subprocess
+import sys
+from typing import Any
+
+
+LEASE_MARKER = "agent-lease:v1"
+HANDOFF_MARKER = "agent-handoff:v1"
+AGENT_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+CAP_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+SLUG_RE = re.compile(r"^[a-z0-9-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class StateError(RuntimeError):
+    pass
+
+
+def run(*args: str, cwd: pathlib.Path | None = None, input_text: str | None = None,
+        check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+
+
+def output(*args: str, cwd: pathlib.Path | None = None, input_text: str | None = None) -> str:
+    return run(*args, cwd=cwd, input_text=input_text).stdout.strip()
+
+
+def repo_root() -> pathlib.Path:
+    return pathlib.Path(output("git", "rev-parse", "--show-toplevel")).resolve()
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+
+
+def iso(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_iso(value: str) -> dt.datetime:
+    return dt.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+
+
+def parse_caps(value: str) -> list[str]:
+    caps = value.split(",")
+    if not caps or any(not CAP_RE.fullmatch(cap) for cap in caps) or len(set(caps)) != len(caps):
+        raise StateError("capabilities must be unique comma-separated non-secret tags")
+    return caps
+
+
+def encode_state(marker: str, data: dict[str, Any]) -> str:
+    return f"{marker}\n{json.dumps(data, sort_keys=True, separators=(',', ':'))}\n"
+
+
+def parse_state(message: str, marker: str) -> dict[str, Any]:
+    lines = message.rstrip("\n").splitlines()
+    if len(lines) != 2 or lines[0] != marker:
+        raise StateError(f"invalid {marker} state envelope")
+    try:
+        data = json.loads(lines[1])
+    except json.JSONDecodeError as exc:
+        raise StateError(f"invalid {marker} JSON") from exc
+    if not isinstance(data, dict):
+        raise StateError(f"invalid {marker} state object")
+    return data
+
+
+def validate_issue(value: str) -> int:
+    if not value.isdigit() or int(value) <= 0:
+        raise StateError("issue-number must be a positive integer")
+    return int(value)
+
+
+def validate_agent(value: str) -> str:
+    if not AGENT_RE.fullmatch(value):
+        raise StateError("agent-id contains invalid characters")
+    return value
+
+
+def issue_data(issue: int) -> dict[str, Any]:
+    return json.loads(output("gh", "issue", "view", str(issue), "--json", "state,labels"))
+
+
+def required_caps(data: dict[str, Any]) -> set[str]:
+    return {
+        label["name"].removeprefix("cap:")
+        for label in data["labels"]
+        if label["name"].startswith("cap:")
+    }
+
+
+def validate_issue_for_lease(issue: int, caps: list[str]) -> dict[str, Any]:
+    data = issue_data(issue)
+    labels = {label["name"] for label in data["labels"]}
+    if data["state"] != "OPEN":
+        raise StateError(f"issue #{issue} is not open")
+    terminal = labels & {"status:blocked", "status:review", "status:done"}
+    if terminal:
+        raise StateError(f"issue #{issue} cannot be leased while labeled {sorted(terminal)[0]}")
+    missing = required_caps(data) - set(caps)
+    if missing:
+        raise StateError(f"agent is missing required capabilities: {','.join(sorted(missing))}")
+    return data
+
+
+def state_ref(kind: str, issue: int) -> str:
+    return f"refs/heads/agent-{kind}/issue-{issue}"
+
+
+def remote_ref_sha(ref: str) -> str | None:
+    text = output("git", "ls-remote", "--refs", "origin", ref)
+    if not text:
+        return None
+    parts = text.splitlines()
+    if len(parts) != 1:
+        raise StateError(f"ambiguous remote ref: {ref}")
+    sha, returned_ref = parts[0].split("\t", 1)
+    if returned_ref != ref or not SHA_RE.fullmatch(sha):
+        raise StateError(f"invalid remote ref response: {ref}")
+    return sha
+
+
+def read_remote_state(ref: str, marker: str) -> tuple[str | None, dict[str, Any] | None]:
+    sha = remote_ref_sha(ref)
+    if sha is None:
+        return None, None
+    run("git", "fetch", "--no-tags", "origin", ref)
+    message = output("git", "show", "-s", "--format=%B", sha)
+    return sha, parse_state(message, marker)
+
+
+def create_state_commit(ref: str, marker: str, data: dict[str, Any], expected: str | None) -> str:
+    tree = output("git", "mktree", input_text="")
+    args = ["git", "commit-tree", tree]
+    if expected:
+        args.extend(["-p", expected])
+    commit = output(*args, input_text=encode_state(marker, data))
+    lease_arg = f"--force-with-lease={ref}:{expected or ''}"
+    pushed = run("git", "push", "--porcelain", lease_arg, "origin", f"{commit}:{ref}", check=False)
+    if pushed.returncode != 0:
+        raise StateError(f"atomic state update lost a race for {ref}: {pushed.stderr.strip()}")
+    if remote_ref_sha(ref) != commit:
+        raise StateError(f"remote state verification failed for {ref}")
+    return commit
+
+
+def update_status(issue: int, target: str) -> None:
+    data = issue_data(issue)
+    labels = {label["name"] for label in data["labels"]}
+    for old in {"status:ready", "status:claimed", "status:active", "status:handoff"} - {target}:
+        if old in labels:
+            run("gh", "issue", "edit", str(issue), "--remove-label", old)
+    if target not in labels:
+        run("gh", "issue", "edit", str(issue), "--add-label", target)
+
+
+def add_comment(issue: int, marker: str, data: dict[str, Any]) -> None:
+    body = f"<!-- {marker} -->\n```json\n{json.dumps(data, indent=2, sort_keys=True)}\n```"
+    run("gh", "issue", "comment", str(issue), "--body", body)
+
+
+def acquire_lease(issue: int, agent: str, caps: list[str], ttl: int) -> tuple[str, dict[str, Any]]:
+    validate_issue_for_lease(issue, caps)
+    ref = state_ref("leases", issue)
+    old_sha, old = read_remote_state(ref, LEASE_MARKER)
+    now = utc_now()
+    if old:
+        if old.get("issue") != issue:
+            raise StateError("lease state Issue mismatch")
+        active = old.get("state") == "active" and parse_iso(str(old["expires_at"])) > now
+        if active and old.get("agent_id") != agent:
+            raise StateError(f"issue #{issue} is leased by {old.get('agent_id')} until {old.get('expires_at')}")
+    data = {
+        "agent_id": agent,
+        "capabilities": caps,
+        "expires_at": iso(now + dt.timedelta(minutes=ttl)),
+        "issue": issue,
+        "nonce": secrets.token_hex(16),
+        "started_at": iso(now),
+        "state": "active",
+    }
+    sha = create_state_commit(ref, LEASE_MARKER, data, old_sha)
+    update_status(issue, "status:active")
+    add_comment(issue, LEASE_MARKER, {**data, "state_commit": sha, "credentials_shared": False})
+    return sha, data
+
+
+def current_lease(issue: int, agent: str) -> tuple[str, dict[str, Any]]:
+    sha, data = read_remote_state(state_ref("leases", issue), LEASE_MARKER)
+    if not sha or not data:
+        raise StateError(f"issue #{issue} has no lease")
+    if data.get("issue") != issue or data.get("agent_id") != agent or data.get("state") != "active":
+        raise StateError("handoff publisher does not own the active lease")
+    if parse_iso(str(data["expires_at"])) <= utc_now():
+        raise StateError("active lease has expired")
+    return sha, data
+
+
+def release_lease(issue: int, lease_sha: str, lease: dict[str, Any], reason: str) -> str:
+    released = {**lease, "released_at": iso(utc_now()), "release_reason": reason, "state": "released"}
+    return create_state_commit(state_ref("leases", issue), LEASE_MARKER, released, lease_sha)
+
+
+def resolve_handoff(issue: int) -> tuple[str | None, dict[str, Any] | None]:
+    sha, data = read_remote_state(state_ref("handoffs", issue), HANDOFF_MARKER)
+    if data and data.get("issue") != issue:
+        raise StateError("handoff state Issue mismatch")
+    return sha, data
+
+
+def verify_handoff_source(root: pathlib.Path, issue: int, handoff: dict[str, Any]) -> str:
+    branch = str(handoff.get("branch", ""))
+    commit = str(handoff.get("commit", ""))
+    if not branch.startswith(f"codex/issue-{issue}-") or not SHA_RE.fullmatch(commit):
+        raise StateError("handoff branch or commit is invalid")
+    remote_branch_ref = f"refs/heads/{branch}"
+    tip = remote_ref_sha(remote_branch_ref)
+    if not tip:
+        raise StateError("handoff source branch is missing")
+    run("git", "fetch", "--no-tags", "origin", remote_branch_ref, cwd=root)
+    ancestor = run("git", "merge-base", "--is-ancestor", commit, tip, cwd=root, check=False)
+    if ancestor.returncode != 0:
+        raise StateError("handoff commit is not reachable from the declared remote branch")
+    capsule_path = f".handoffs/issue-{issue}.md"
+    capsule = run("git", "show", f"{commit}:{capsule_path}", cwd=root, check=False)
+    if capsule.returncode != 0 or not capsule.stdout.strip():
+        raise StateError("handoff commit does not contain its capsule")
+    return commit
+
+
+def command_lease(args: argparse.Namespace) -> None:
+    issue = validate_issue(args.issue)
+    agent = validate_agent(args.agent)
+    caps = parse_caps(args.capabilities)
+    sha, data = acquire_lease(issue, agent, caps, args.ttl)
+    print(f"leased issue #{issue} to {agent} until {data['expires_at']} ({sha})")
+
+
+def command_takeover(args: argparse.Namespace) -> None:
+    issue = validate_issue(args.issue)
+    agent = validate_agent(args.agent)
+    if not SLUG_RE.fullmatch(args.slug):
+        raise StateError("slug must contain lowercase letters, digits, or hyphens")
+    caps = parse_caps(args.capabilities)
+    root = repo_root()
+    _, handoff = resolve_handoff(issue)
+    if handoff:
+        start = verify_handoff_source(root, issue, handoff)
+    else:
+        run("git", "fetch", "--no-tags", "origin", "main", cwd=root)
+        start = output("git", "rev-parse", "origin/main", cwd=root)
+    lease_sha, lease = acquire_lease(issue, agent, caps, args.ttl)
+    stamp = utc_now().strftime("%Y%m%d%H%M%S")
+    suffix = lease["nonce"][:8]
+    branch = f"codex/issue-{issue}-{args.slug}-{agent}-{stamp}-{suffix}"
+    worktree = root.parent / f"wlg-agent-{issue}-{agent}-{stamp}-{suffix}"
+    created = False
+    try:
+        run("git", "worktree", "add", "-b", branch, str(worktree), start, cwd=root)
+        created = True
+        if handoff:
+            run(str(worktree / "scripts/ci/verify-handoffs.sh"), cwd=worktree)
+    except Exception:
+        if created:
+            run("git", "worktree", "remove", "--force", str(worktree), cwd=root, check=False)
+            run("git", "branch", "-D", branch, cwd=root, check=False)
+        try:
+            release_lease(issue, lease_sha, lease, "takeover_failed")
+            update_status(issue, "status:handoff" if handoff else "status:ready")
+        except Exception as cleanup_error:
+            print(f"warning: lease rollback failed: {cleanup_error}", file=sys.stderr)
+        raise
+    print(f"worktree: {worktree}\nbranch: {branch}\nstart: {start}")
+
+
+def command_handoff(args: argparse.Namespace) -> None:
+    issue = validate_issue(args.issue)
+    agent = validate_agent(args.agent)
+    caps = parse_caps(args.capabilities)
+    root = repo_root()
+    os.chdir(root)
+    validate_issue_for_lease(issue, caps)
+    lease_sha, lease = current_lease(issue, agent)
+    if set(caps) != set(lease.get("capabilities", [])):
+        raise StateError("handoff capabilities do not match the active lease")
+    branch = output("git", "branch", "--show-current", cwd=root)
+    if not branch.startswith(f"codex/issue-{issue}-"):
+        raise StateError(f"branch {branch} does not belong to issue #{issue}")
+    capsule = root / ".handoffs" / f"issue-{issue}.md"
+    if not capsule.is_file() or not capsule.stat().st_size:
+        raise StateError(f"missing handoff capsule: {capsule}")
+    run(str(root / "scripts/ci/verify.sh"), cwd=root)
+    if output("git", "status", "--short", cwd=root):
+        raise StateError("handoff requires a clean worktree; commit all resumable state first")
+    commit = output("git", "rev-parse", "HEAD", cwd=root)
+    run("git", "push", "-u", "origin", branch, cwd=root)
+    if remote_ref_sha(f"refs/heads/{branch}") != commit:
+        raise StateError("remote working branch tip does not match the local checkpoint")
+    old_handoff_sha, _ = resolve_handoff(issue)
+    handoff = {
+        "agent_id": agent,
+        "branch": branch,
+        "capabilities": caps,
+        "capsule": f".handoffs/issue-{issue}.md",
+        "commit": commit,
+        "issue": issue,
+        "lease_nonce": lease["nonce"],
+        "released_at": iso(utc_now()),
+    }
+    handoff_sha = create_state_commit(state_ref("handoffs", issue), HANDOFF_MARKER, handoff, old_handoff_sha)
+    release_lease(issue, lease_sha, lease, "handoff_published")
+    update_status(issue, "status:handoff")
+    add_comment(issue, HANDOFF_MARKER, {**handoff, "state_commit": handoff_sha, "credentials_shared": False})
+    print(f"published handoff for issue #{issue} at {commit} ({handoff_sha})")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    sub = result.add_subparsers(dest="command", required=True)
+    lease = sub.add_parser("lease")
+    lease.add_argument("issue")
+    lease.add_argument("agent")
+    lease.add_argument("capabilities")
+    lease.add_argument("--ttl", type=int, default=120, choices=range(15, 1441), metavar="MINUTES")
+    lease.set_defaults(func=command_lease)
+    takeover = sub.add_parser("takeover")
+    takeover.add_argument("issue")
+    takeover.add_argument("agent")
+    takeover.add_argument("slug")
+    takeover.add_argument("capabilities")
+    takeover.add_argument("--ttl", type=int, default=120, choices=range(15, 1441), metavar="MINUTES")
+    takeover.set_defaults(func=command_takeover)
+    handoff = sub.add_parser("handoff")
+    handoff.add_argument("issue")
+    handoff.add_argument("agent")
+    handoff.add_argument("capabilities")
+    handoff.set_defaults(func=command_handoff)
+    return result
+
+
+def main() -> int:
+    try:
+        args = parser().parse_args()
+        args.func(args)
+    except (StateError, subprocess.CalledProcessError, ValueError, KeyError) as exc:
+        if isinstance(exc, subprocess.CalledProcessError):
+            detail = exc.stderr.strip() or str(exc)
+        else:
+            detail = str(exc)
+        print(f"error: {detail}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_state.py
+++ b/scripts/agent_state.py
@@ -84,6 +84,30 @@ def parse_state(message: str, marker: str) -> dict[str, Any]:
     return data
 
 
+def capsule_field(text: str, prefix: str) -> str:
+    values = [line[len(prefix):] for line in text.splitlines() if line.startswith(prefix)]
+    if len(values) != 1 or not values[0]:
+        raise StateError(f"handoff capsule must contain exactly one {prefix.strip()} field")
+    return values[0]
+
+
+def parse_capsule(text: str) -> dict[str, Any]:
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+    match = re.fullmatch(r"# Agent handoff: Issue ([1-9][0-9]*)", first_line)
+    if not match:
+        raise StateError("handoff capsule has an invalid Issue heading")
+    credentials = capsule_field(text, "- Credentials included: ")
+    if credentials != "no":
+        raise StateError("handoff capsule must not include credentials")
+    return {
+        "agent_id": capsule_field(text, "- Source agent ID: "),
+        "branch": capsule_field(text, "- Branch: "),
+        "capabilities": parse_caps(capsule_field(text, "- Capabilities used: ")),
+        "credentials_included": credentials,
+        "issue": int(match.group(1)),
+    }
+
+
 def validate_issue(value: str) -> int:
     if not value.isdigit() or int(value) <= 0:
         raise StateError("issue-number must be a positive integer")
@@ -148,18 +172,33 @@ def read_remote_state(ref: str, marker: str) -> tuple[str | None, dict[str, Any]
     return sha, parse_state(message, marker)
 
 
-def create_state_commit(ref: str, marker: str, data: dict[str, Any], expected: str | None) -> str:
+def build_state_commit(marker: str, data: dict[str, Any], parent: str | None) -> str:
     tree = output("git", "mktree", input_text="")
     args = ["git", "commit-tree", tree]
-    if expected:
-        args.extend(["-p", expected])
-    commit = output(*args, input_text=encode_state(marker, data))
-    lease_arg = f"--force-with-lease={ref}:{expected or ''}"
-    pushed = run("git", "push", "--porcelain", lease_arg, "origin", f"{commit}:{ref}", check=False)
+    if parent:
+        args.extend(["-p", parent])
+    return output(*args, input_text=encode_state(marker, data))
+
+
+def push_state_updates(updates: list[tuple[str, str, str | None]]) -> None:
+    args = ["git", "push", "--porcelain"]
+    if len(updates) > 1:
+        args.append("--atomic")
+    args.extend(f"--force-with-lease={ref}:{expected or ''}" for ref, _, expected in updates)
+    args.append("origin")
+    args.extend(f"{commit}:{ref}" for ref, commit, _ in updates)
+    pushed = run(*args, check=False)
     if pushed.returncode != 0:
-        raise StateError(f"atomic state update lost a race for {ref}: {pushed.stderr.strip()}")
-    if remote_ref_sha(ref) != commit:
-        raise StateError(f"remote state verification failed for {ref}")
+        refs = ",".join(ref for ref, _, _ in updates)
+        raise StateError(f"atomic state update lost a race for {refs}: {pushed.stderr.strip()}")
+    for ref, commit, _ in updates:
+        if remote_ref_sha(ref) != commit:
+            raise StateError(f"remote state verification failed for {ref}")
+
+
+def create_state_commit(ref: str, marker: str, data: dict[str, Any], expected: str | None) -> str:
+    commit = build_state_commit(marker, data, expected)
+    push_state_updates([(ref, commit, expected)])
     return commit
 
 
@@ -244,6 +283,16 @@ def verify_handoff_source(root: pathlib.Path, issue: int, handoff: dict[str, Any
     capsule = run("git", "show", f"{commit}:{capsule_path}", cwd=root, check=False)
     if capsule.returncode != 0 or not capsule.stdout.strip():
         raise StateError("handoff commit does not contain its capsule")
+    capsule_state = parse_capsule(capsule.stdout)
+    expected = {
+        "agent_id": handoff.get("agent_id"),
+        "branch": branch,
+        "capabilities": handoff.get("capabilities"),
+        "credentials_included": "no",
+        "issue": issue,
+    }
+    if capsule_state != expected:
+        raise StateError("handoff capsule identity does not match authoritative state")
     return commit
 
 
@@ -262,19 +311,20 @@ def command_takeover(args: argparse.Namespace) -> None:
         raise StateError("slug must contain lowercase letters, digits, or hyphens")
     caps = parse_caps(args.capabilities)
     root = repo_root()
-    _, handoff = resolve_handoff(issue)
-    if handoff:
-        start = verify_handoff_source(root, issue, handoff)
-    else:
-        run("git", "fetch", "--no-tags", "origin", "main", cwd=root)
-        start = output("git", "rev-parse", "origin/main", cwd=root)
     lease_sha, lease = acquire_lease(issue, agent, caps, args.ttl)
     stamp = utc_now().strftime("%Y%m%d%H%M%S")
     suffix = lease["nonce"][:8]
     branch = f"codex/issue-{issue}-{args.slug}-{agent}-{stamp}-{suffix}"
     worktree = root.parent / f"wlg-agent-{issue}-{agent}-{stamp}-{suffix}"
     created = False
+    handoff: dict[str, Any] | None = None
     try:
+        _, handoff = resolve_handoff(issue)
+        if handoff:
+            start = verify_handoff_source(root, issue, handoff)
+        else:
+            run("git", "fetch", "--no-tags", "origin", "main", cwd=root)
+            start = output("git", "rev-parse", "origin/main", cwd=root)
         run("git", "worktree", "add", "-b", branch, str(worktree), start, cwd=root)
         created = True
         if handoff:
@@ -284,8 +334,9 @@ def command_takeover(args: argparse.Namespace) -> None:
             run("git", "worktree", "remove", "--force", str(worktree), cwd=root, check=False)
             run("git", "branch", "-D", branch, cwd=root, check=False)
         try:
-            release_lease(issue, lease_sha, lease, "takeover_failed")
-            update_status(issue, "status:handoff" if handoff else "status:ready")
+            released_sha = release_lease(issue, lease_sha, lease, "takeover_failed")
+            if remote_ref_sha(state_ref("leases", issue)) == released_sha:
+                update_status(issue, "status:handoff" if handoff else "status:ready")
         except Exception as cleanup_error:
             print(f"warning: lease rollback failed: {cleanup_error}", file=sys.stderr)
         raise
@@ -299,7 +350,7 @@ def command_handoff(args: argparse.Namespace) -> None:
     root = repo_root()
     os.chdir(root)
     validate_issue_for_lease(issue, caps)
-    lease_sha, lease = current_lease(issue, agent)
+    _, lease = current_lease(issue, agent)
     if set(caps) != set(lease.get("capabilities", [])):
         raise StateError("handoff capabilities do not match the active lease")
     branch = output("git", "branch", "--show-current", cwd=root)
@@ -308,6 +359,11 @@ def command_handoff(args: argparse.Namespace) -> None:
     capsule = root / ".handoffs" / f"issue-{issue}.md"
     if not capsule.is_file() or not capsule.stat().st_size:
         raise StateError(f"missing handoff capsule: {capsule}")
+    capsule_state = parse_capsule(capsule.read_text(encoding="utf-8"))
+    if capsule_state["issue"] != issue or capsule_state["agent_id"] != agent:
+        raise StateError("handoff capsule Issue or Agent does not match the active lease")
+    if capsule_state["branch"] != branch or set(capsule_state["capabilities"]) != set(caps):
+        raise StateError("handoff capsule branch or capabilities do not match the active lease")
     run(str(root / "scripts/ci/verify.sh"), cwd=root)
     if output("git", "status", "--short", cwd=root):
         raise StateError("handoff requires a clean worktree; commit all resumable state first")
@@ -315,6 +371,9 @@ def command_handoff(args: argparse.Namespace) -> None:
     run("git", "push", "-u", "origin", branch, cwd=root)
     if remote_ref_sha(f"refs/heads/{branch}") != commit:
         raise StateError("remote working branch tip does not match the local checkpoint")
+    lease_sha, lease = current_lease(issue, agent)
+    if set(caps) != set(lease.get("capabilities", [])):
+        raise StateError("renewed handoff capabilities do not match the active lease")
     old_handoff_sha, _ = resolve_handoff(issue)
     handoff = {
         "agent_id": agent,
@@ -326,8 +385,15 @@ def command_handoff(args: argparse.Namespace) -> None:
         "lease_nonce": lease["nonce"],
         "released_at": iso(utc_now()),
     }
-    handoff_sha = create_state_commit(state_ref("handoffs", issue), HANDOFF_MARKER, handoff, old_handoff_sha)
-    release_lease(issue, lease_sha, lease, "handoff_published")
+    handoff_ref = state_ref("handoffs", issue)
+    lease_ref = state_ref("leases", issue)
+    handoff_sha = build_state_commit(HANDOFF_MARKER, handoff, old_handoff_sha)
+    released = {**lease, "released_at": iso(utc_now()), "release_reason": "handoff_published", "state": "released"}
+    released_sha = build_state_commit(LEASE_MARKER, released, lease_sha)
+    push_state_updates([
+        (handoff_ref, handoff_sha, old_handoff_sha),
+        (lease_ref, released_sha, lease_sha),
+    ])
     update_status(issue, "status:handoff")
     add_comment(issue, HANDOFF_MARKER, {**handoff, "state_commit": handoff_sha, "credentials_shared": False})
     print(f"published handoff for issue #{issue} at {commit} ({handoff_sha})")

--- a/scripts/ci/verify-handoffs.sh
+++ b/scripts/ci/verify-handoffs.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+find .handoffs -type f -name 'issue-*.md' -print | while IFS= read -r capsule; do
+    for heading in \
+        '## Identity and scope' \
+        '## Objective' \
+        '## Completed' \
+        '## Verification' \
+        '## Failed attempts' \
+        '## Next executable steps' \
+        '## Capabilities required for the next Agent' \
+        '## Security and privacy notes'
+    do
+        grep -Fqx "$heading" "$capsule" || {
+            echo "$capsule is missing heading: $heading" >&2
+            exit 1
+        }
+    done
+
+    if grep -Eq 'TODO|ISSUE_NUMBER|AGENT_ID|CAPABILITIES|BRANCH_NAME|CHECKPOINT_PARENT|UPDATED_AT' "$capsule"; then
+        echo "$capsule contains an unresolved handoff placeholder" >&2
+        exit 1
+    fi
+
+    grep -Fq -- '- Credentials included: no' "$capsule" || {
+        echo "$capsule must explicitly state that credentials are not included" >&2
+        exit 1
+    }
+
+    if grep -Eiq '(api[_ -]?key|access[_ -]?token|client[_ -]?secret|private[_ -]?key)[[:space:]]*[:=][[:space:]]*[^[:space:]`*<]+' "$capsule"; then
+        echo "$capsule may contain credential material" >&2
+        exit 1
+    fi
+done

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -19,6 +19,7 @@ done
 ./scripts/ci/verify-handoffs.sh
 ./tests/scripts/test-agent-handoff-tools.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
+python3 ./scripts/scan_secrets.py
 
 if command -v shellcheck >/dev/null 2>&1; then
     find scripts -type f -name '*.sh' -exec shellcheck {} +

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -16,6 +16,10 @@ find scripts -type f -name '*.sh' -print | while IFS= read -r script; do
     sh -n "$script"
 done
 
+./scripts/ci/verify-handoffs.sh
+./tests/scripts/test-agent-handoff-tools.sh
+python3 -m unittest discover -s tests -p 'test_*.py'
+
 if command -v shellcheck >/dev/null 2>&1; then
     find scripts -type f -name '*.sh' -exec shellcheck {} +
 fi

--- a/scripts/scan_secrets.py
+++ b/scripts/scan_secrets.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Pre-push high-confidence secret scanner; CI also runs pinned Gitleaks."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+
+PATTERNS = {
+    "private key": re.compile(rb"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+    "GitHub token": re.compile(rb"(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})"),
+    "OpenAI-style key": re.compile(rb"\bsk-[A-Za-z0-9_-]{20,}\b"),
+    "AWS access key": re.compile(rb"\bAKIA[0-9A-Z]{16}\b"),
+    "JWT": re.compile(rb"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    "assigned secret": re.compile(
+        rb"(?i)(?:api[_ -]?key|access[_ -]?token|client[_ -]?secret|password)\s*[:=]\s*['\"]?[A-Za-z0-9_./+=-]{16,}"
+    ),
+}
+
+SKIP = {"scripts/scan_secrets.py"}
+
+
+def tracked_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line and line not in SKIP]
+
+
+def main() -> int:
+    findings: list[str] = []
+    for name in tracked_files():
+        path = pathlib.Path(name)
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            findings.append(f"cannot scan {name}: {exc}")
+            continue
+        if len(data) > 2_000_000 or b"\0" in data:
+            continue
+        for label, pattern in PATTERNS.items():
+            if pattern.search(data):
+                findings.append(f"{name}: possible {label}")
+    if findings:
+        print("pre-push secret scan failed:", file=sys.stderr)
+        for finding in findings:
+            print(f"- {finding}", file=sys.stderr)
+        return 1
+    print("pre-push secret scan passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/task_plan.md
+++ b/task_plan.md
@@ -17,6 +17,10 @@
 | 8. GitHub 私有仓库部署 | 完成 | 私有远程仓库、标签、里程碑、首批任务 |
 | 9. 协作机制验证 | 完成 | 本地校验、GitHub 状态、权限和分支保护检查 |
 | 10. 交付 | 完成 | 使用说明、Agent 启动方式、剩余人工权限项 |
+| 11. 可接管协作模型 | 完成 | 能力声明、短租约、检查点与接管状态机 |
+| 12. 交接工具与模板 | 完成 | handoff capsule、lease/publish/takeover 脚本与 CI 校验 |
+| 13. GitHub 任务迁移 | 完成 | 状态/能力标签、现有 Issue 能力约束与新流程 |
+| 14. 端到端验证与交付 | 进行中 | 模拟释放/接管、PR/CI、远程状态验证 |
 
 ## 约束与原则
 
@@ -40,6 +44,9 @@
 - 私有仓库采用 Issue 作为唯一任务源、每个 Agent 独立分支与 worktree、PR 作为唯一合并入口。
 - Phase 0 协议证据门禁未完成前，只允许基础设施、fixture 工具和威胁模型工作，不实现 WLOC response patch。
 - Agent 不共享工作目录，不直接向 `main` 推送，不修改未获分配的所有权目录。
+- Agent 身份、API Key 和登录凭据始终留在各自环境；仓库只记录非秘密能力声明和可复现环境要求。
+- Issue 所有权改为有期限的协作租约；租约可主动释放，过期租约可由符合能力要求的 Agent 接管。
+- 每次释放或长时间暂停前必须推送精确 commit，并更新 `.handoffs/issue-<n>.md`；聊天记录不能替代交接胶囊。
 
 ## 错误记录
 
@@ -50,3 +57,4 @@
 | 用户纠正后发现上一任务 ID 仍非目标任务 | 1 | 读取 `019feec1-a2dc-7a70-bdba-3c2fc0176b14` 全部 12 页、117 回合并替换权威计划 |
 | GitHub 私有仓库 `main` 分支保护返回 HTTP 403 | 1 | 当前账号需 GitHub Pro；保持仓库私有，使用 CI、CODEOWNERS、PR 契约和 Agent 规则作为替代，并把升级列为治理缺口 |
 | GitHub Actions 首轮 `verify` 因 ShellCheck SC1007/SC2038 失败 | 1 | 明确设置 `CDPATH=''`，并以 `find -exec ... +` 替代非空安全的 xargs 调用 |
+| 再次以完整历史和显式 `agent_type` 启动 Reviewer 失败 | 2 | 遵循已有记录，移除 `agent_type` 后成功启动只读 Reviewer；后续不得重复该组合 |

--- a/tests/scripts/test-agent-handoff-tools.sh
+++ b/tests/scripts/test-agent-handoff-tools.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/wlg-handoff-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+
+expect_failure() {
+    if "$@" >/dev/null 2>&1; then
+        echo "expected command to fail: $*" >&2
+        exit 1
+    fi
+}
+
+expect_failure "$repo_root/scripts/agent-lease.sh" not-a-number agent go
+expect_failure "$repo_root/scripts/agent-takeover.sh" 1 agent INVALID go
+expect_failure "$repo_root/scripts/agent-handoff.sh" 1 invalid/agent go
+expect_failure "$repo_root/scripts/claim-issue.sh" 1
+
+mkdir -p "$test_root/.handoffs"
+capsule="$test_root/.handoffs/issue-42.md"
+cp "$repo_root/.agents/HANDOFF_TEMPLATE.md" "$capsule"
+
+sed \
+    -e 's/ISSUE_NUMBER/42/g' \
+    -e 's/AGENT_ID/test-agent/g' \
+    -e 's/CAPABILITIES/go,test/g' \
+    -e 's/BRANCH_NAME/codex\/issue-42-test/g' \
+    -e 's/CHECKPOINT_PARENT/0123456789012345678901234567890123456789/g' \
+    -e 's/UPDATED_AT/2026-08-11T00:00:00Z/g' \
+    -e 's/TODO/None/g' \
+    "$capsule" > "$capsule.rendered"
+mv "$capsule.rendered" "$capsule"
+
+(cd "$test_root" && "$repo_root/scripts/ci/verify-handoffs.sh")
+
+printf '\nTODO\n' >> "$capsule"
+expect_failure sh -c "cd '$test_root' && '$repo_root/scripts/ci/verify-handoffs.sh'"
+
+echo 'agent handoff tool tests passed'

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("agent_state", ROOT / "scripts" / "agent_state.py")
+agent_state = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(agent_state)
+
+
+class StateEnvelopeTests(unittest.TestCase):
+    def test_round_trip_is_strict(self):
+        original = {"agent_id": "terra", "issue": 7, "state": "active"}
+        encoded = agent_state.encode_state(agent_state.LEASE_MARKER, original)
+        self.assertEqual(agent_state.parse_state(encoded, agent_state.LEASE_MARKER), original)
+
+    def test_rejects_quoted_or_appended_marker_content(self):
+        payload = (
+            "quoted text\nagent-lease:v1\n"
+            '{"agent_id":"attacker","issue":7,"state":"active"}\n'
+        )
+        with self.assertRaises(agent_state.StateError):
+            agent_state.parse_state(payload, agent_state.LEASE_MARKER)
+
+    def test_capability_tags_are_unique_and_non_secret_names(self):
+        self.assertEqual(agent_state.parse_caps("go,test,tls-h2"), ["go", "test", "tls-h2"])
+        for invalid in ("", "go,go", "go,has space", "go,$TOKEN"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(agent_state.StateError):
+                    agent_state.parse_caps(invalid)
+
+
+class AtomicRefTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        base = pathlib.Path(self.temp.name)
+        self.remote = base / "remote.git"
+        self.work = base / "work"
+        subprocess.run(["git", "init", "--bare", str(self.remote)], check=True, capture_output=True)
+        subprocess.run(["git", "init", str(self.work)], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(self.work), "config", "user.name", "Lease Test"], check=True)
+        subprocess.run(["git", "-C", str(self.work), "config", "user.email", "lease@example.invalid"], check=True)
+        subprocess.run(["git", "-C", str(self.work), "remote", "add", "origin", str(self.remote)], check=True)
+        self.previous_cwd = pathlib.Path.cwd()
+        os.chdir(self.work)
+
+    def tearDown(self):
+        os.chdir(self.previous_cwd)
+        self.temp.cleanup()
+
+    def test_force_with_lease_rejects_stale_generation(self):
+        ref = "refs/heads/agent-leases/issue-7"
+        first = agent_state.create_state_commit(
+            ref, agent_state.LEASE_MARKER, {"issue": 7, "state": "active", "generation": 1}, None
+        )
+        second = agent_state.create_state_commit(
+            ref, agent_state.LEASE_MARKER, {"issue": 7, "state": "active", "generation": 2}, first
+        )
+        self.assertNotEqual(first, second)
+        with self.assertRaises(agent_state.StateError):
+            agent_state.create_state_commit(
+                ref, agent_state.LEASE_MARKER, {"issue": 7, "state": "active", "generation": 3}, first
+            )
+        remote_sha, state = agent_state.read_remote_state(ref, agent_state.LEASE_MARKER)
+        self.assertEqual(remote_sha, second)
+        self.assertEqual(state["generation"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_state.py
+++ b/tests/test_agent_state.py
@@ -34,6 +34,26 @@ class StateEnvelopeTests(unittest.TestCase):
                 with self.assertRaises(agent_state.StateError):
                     agent_state.parse_caps(invalid)
 
+    def test_capsule_identity_is_strict_and_unique(self):
+        capsule = """# Agent handoff: Issue 9
+- Source agent ID: terra
+- Capabilities used: ci,security
+- Branch: codex/issue-9-test-terra
+- Credentials included: no
+"""
+        self.assertEqual(
+            agent_state.parse_capsule(capsule),
+            {
+                "agent_id": "terra",
+                "branch": "codex/issue-9-test-terra",
+                "capabilities": ["ci", "security"],
+                "credentials_included": "no",
+                "issue": 9,
+            },
+        )
+        with self.assertRaises(agent_state.StateError):
+            agent_state.parse_capsule(capsule + "- Branch: codex/issue-9-forged\n")
+
 
 class AtomicRefTests(unittest.TestCase):
     def setUp(self):
@@ -69,6 +89,41 @@ class AtomicRefTests(unittest.TestCase):
         remote_sha, state = agent_state.read_remote_state(ref, agent_state.LEASE_MARKER)
         self.assertEqual(remote_sha, second)
         self.assertEqual(state["generation"], 2)
+
+    def test_atomic_handoff_cannot_overwrite_a_new_lease(self):
+        lease_ref = "refs/heads/agent-leases/issue-9"
+        handoff_ref = "refs/heads/agent-handoffs/issue-9"
+        lease_a = agent_state.create_state_commit(
+            lease_ref,
+            agent_state.LEASE_MARKER,
+            {"agent_id": "a", "issue": 9, "state": "active"},
+            None,
+        )
+        lease_b = agent_state.create_state_commit(
+            lease_ref,
+            agent_state.LEASE_MARKER,
+            {"agent_id": "b", "issue": 9, "state": "active"},
+            lease_a,
+        )
+        stale_handoff = agent_state.build_state_commit(
+            agent_state.HANDOFF_MARKER,
+            {"agent_id": "a", "issue": 9},
+            None,
+        )
+        stale_release = agent_state.build_state_commit(
+            agent_state.LEASE_MARKER,
+            {"agent_id": "a", "issue": 9, "state": "released"},
+            lease_a,
+        )
+        with self.assertRaises(agent_state.StateError):
+            agent_state.push_state_updates(
+                [
+                    (handoff_ref, stale_handoff, None),
+                    (lease_ref, stale_release, lease_a),
+                ]
+            )
+        self.assertIsNone(agent_state.remote_ref_sha(handoff_ref))
+        self.assertEqual(agent_state.remote_ref_sha(lease_ref), lease_b)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Task

Closes #9

Role: `role:integration`

Handoff capsule: `.handoffs/issue-9.md`

## Outcome

Replace permanent Agent ownership with capability-aware, atomic Git leases and resumable handoff checkpoints. Each Agent keeps its own API key and resumes from an exact verified commit.

## Owned paths

- Agent workflow, scripts, tests, GitHub templates, CI, and handoff documentation

## Verification evidence

```text
./scripts/ci/verify.sh
6 tests passed
pre-push secret scan passed
repository gates passed
```

A second Agent ID resumed from the first handoff commit and published a new atomic checkpoint.

## Security and privacy

- [x] No secrets, keys, raw production captures, device identifiers, or precise user location.
- [x] State envelopes and capability inputs are strictly validated.
- [x] Handoff/lease generation updates use Git CAS and atomic multi-ref push.
- [x] Independent security review completed.

## Rollback

The original Issue/branch/PR workflow remains usable if lease scripts are disabled. Delete only the `agent-leases/*` and `agent-handoffs/*` coordination refs after all Agents stop.

## Handoff

Next Agents require the capabilities listed on each Issue. Credentials remain local and are never transferred.