### PR TITLE
docs: record agent handoff deployment

### DIFF
--- a/.handoffs/issue-13.md
+++ b/.handoffs/issue-13.md
@@ -1,0 +1,59 @@
+# Agent handoff: Issue 13
+
+## Identity and scope
+
+- Source agent ID: codex-finalize
+- Capabilities used: docs
+- Branch: codex/issue-13-deployment-record-codex-finalize-20260811060010-47c52e37
+- Checkpoint parent: dcd7f20fd5bc66f74cbfe9a56e7cfa513a66ac8b
+- Updated at (UTC): 2026-08-11T06:01:00Z
+- Credentials included: no
+
+## Objective
+
+Record completion of the resumable Agent workflow deployment after merge and main-branch verification.
+
+## Completed
+
+- Marked the takeover deployment phase complete.
+- Recorded PR #12 merge, main CI success, four-Agent takeover exercise, and temporary worktree cleanup.
+
+## Files changed
+
+- `task_plan.md`
+- `progress.md`
+- `.handoffs/issue-13.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./scripts/ci/verify.sh` | Passed | State tests, local secret scan, capsule validation and repository gates |
+| GitHub Actions on merged `dcd7f20` | Passed | `repository-gates` run `31463453132` |
+
+## Failed attempts
+
+- None in this documentation checkpoint.
+
+## Unresolved decisions and blockers
+
+- Hard branch/ref protection still requires GitHub Pro or a single-writer coordination service.
+
+## Next executable steps
+
+1. Select a `status:ready` development Issue whose capability labels match the next Agent.
+2. Run `agent-takeover.sh` and work only in the generated continuation worktree.
+
+## Capabilities required for the next Agent
+
+- docs
+
+## Environment assumptions
+
+- GitHub CLI, Git, Python 3 and POSIX shell are available.
+- Agents authenticate independently and never exchange API keys.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device identifiers, or precise user locations are included.
+- This checkpoint contains documentation state only.

--- a/progress.md
+++ b/progress.md
@@ -56,3 +56,7 @@
 - 已由第三个 Agent ID `codex-ci-fix` 从第二个 Agent 的 `8fcc71c...` handoff 接管，并添加最小 `pull-requests: read` 权限。
 - PR #11 的 PR 契约再次通过；Gitleaks 因默认 shallow checkout 缺少扫描范围父提交而失败。
 - 已由第四个 Agent ID `codex-ci-history` 从 `127c25d...` 接管，并为验证 Job 启用完整 Git 历史。
+- PR #12 的 PR contract、完整历史 Gitleaks 和 repository verify 全部通过，已 squash 合并为 `dcd7f20`；合并后的 main CI 也通过。
+- 本轮实际由四个不同 Agent ID 连续接管 Issue #9，每次均从权威 handoff commit 启动，完成了随时接管闭环验证。
+- 三个临时 continuation worktree 已在确认干净后删除，原始工作区已恢复到 `main`。
+- 使用新机制创建并接管 Issue #13，记录可接管 Agent 工作流部署完成。

--- a/task_plan.md
+++ b/task_plan.md
@@ -20,7 +20,7 @@
 | 11. 可接管协作模型 | 完成 | 能力声明、短租约、检查点与接管状态机 |
 | 12. 交接工具与模板 | 完成 | handoff capsule、lease/publish/takeover 脚本与 CI 校验 |
 | 13. GitHub 任务迁移 | 完成 | 状态/能力标签、现有 Issue 能力约束与新流程 |
-| 14. 端到端验证与交付 | 进行中 | 模拟释放/接管、PR/CI、远程状态验证 |
+| 14. 端到端验证与交付 | 完成 | 模拟释放/接管、PR/CI、远程状态验证 |
 
 ## 约束与原则
 
@@ -60,3 +60,4 @@
 | 再次以完整历史和显式 `agent_type` 启动 Reviewer 失败 | 2 | 遵循已有记录，移除 `agent_type` 后成功启动只读 Reviewer；后续不得重复该组合 |
 | PR #10 的固定 SHA Gitleaks Action 返回 HTTP 403 | 1 | 增加最小 `pull-requests: read` workflow 权限；保留 `contents: read`，不授予写权限 |
 | PR #11 的 Gitleaks 因浅克隆缺少父提交而失败 | 1 | 验证 Job 的 `actions/checkout@v5` 设置 `fetch-depth: 0`，使完整 PR commit range 可扫描 |
+| 清理已合并 continuation 分支时最后一个本地分支不存在 | 1 | `gh pr merge --delete-branch` 已自动移除该分支；其他三个临时分支和 worktree 均已按精确路径清理 |


### PR DESCRIPTION
## Task

Closes #13

Role: `role:integration`

Handoff capsule: `.handoffs/issue-13.md`

## Outcome

Record completion of the resumable multi-Agent workflow deployment and its four-Agent takeover validation.

## Verification evidence

```text
./scripts/ci/verify.sh
6 tests passed
pre-push secret scan passed
repository gates passed
```

## Security and privacy

- [x] Documentation-only change.
- [x] No credentials or private fixture data.
- [x] Valid handoff capsule included.

## Rollback

Revert this documentation commit without changing coordination refs or product code.

## Handoff

The next development Agent should choose a ready Issue whose capability labels match its local tools and expertise.