### PR TITLE
docs: freeze WLOC threat and fail-open invariants

### DIFF
--- a/.handoffs/issue-3.md
+++ b/.handoffs/issue-3.md
@@ -1,0 +1,76 @@
+# Agent handoff: Issue 3
+
+## Identity and scope
+
+- Source agent ID: codex-threat-close
+- Capabilities used: security,docs
+- Branch: codex/issue-3-threat-invariants-codex-threat-close-20260811112704-8048fa7f
+- Checkpoint parent: a68bc55693309629510a4f8c873b0cf80587740c
+- Updated at (UTC): 2026-08-11T11:38:22Z
+- Credentials included: no
+
+## Objective
+
+Freeze the WLOC router PoC threat model and executable fail-open invariants before any live redirect, CA, private-protocol handling, or real-device testing.
+
+## Completed
+
+- Defined exact one-device, two-hostname, TCP 443 scope and Gateway/IPsec isolation.
+- Mapped every Critical/High threat to a control and future evidence owner.
+- Specified kernel-expiring nft lease recovery independent of the userspace watchdog.
+- Defined TLS, ALPN, HTTP/2, CA, Geo, IPv4/IPv6, resource, privacy, emergency, and compliance gates.
+- Added code-owned invariant oracles and mutation-style negative tests.
+- Obtained independent security review with no remaining P0/P1/P2.
+
+## Files changed
+
+- `docs/security/threat-model.md`
+- `docs/security/fail-open.md`
+- `tests/security/__init__.py`
+- `tests/security/security_invariants.json`
+- `tests/security/test_security_invariants.py`
+- `.handoffs/issue-3.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `python3 -m unittest discover -s tests/security -p 'test_*.py'` | Passed | 12/12 security tests |
+| `./scripts/ci/verify.sh` | Passed | 18/18 Python tests, handoff tests, secret scan |
+| `git diff --check` | Passed | No whitespace errors |
+| Independent security review | Approved | `agent_id=issue3_security_review capabilities=security,test verdict=APPROVE` |
+
+## Failed attempts
+
+- Initial CI discovery did not recurse into `tests/security`; an owned `__init__.py` made the tests part of the full gate.
+- Initial watchdog model depended on the process that could itself die; replaced with kernel-expiring lease semantics.
+- Initial tests could co-weaken JSON and Markdown; added independent hard-coded oracles and mutation tests.
+
+## Unresolved decisions and blockers
+
+- A later implementation Issue must freeze the nft lease TTL and maximum redirect-removal/blackhole bound, then measure them on AX6S.
+- Issue #6 must choose complete dual stack or scoped WLOC-only AAAA suppression before redirect implementation.
+- This checkpoint does not authorize certificates, router rules, protocol patching, live traffic, or device testing.
+
+## Next executable steps
+
+1. Review and merge this documentation/test PR.
+2. Complete Issue #2 fixture governance and Issue #6 traffic-isolation ADR.
+3. Implement only synthetic/offline service slices until every applicable gate is closed.
+
+## Capabilities required for the next Agent
+
+- security
+- openwrt
+- network
+- test
+
+## Environment assumptions
+
+- Python 3 and POSIX shell are available for offline verification.
+- No router, device, credential, CA key, provider account, or private fixture is needed.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, raw captures, device identifiers, precise locations, or production traffic are included.
+- Phase 0 records requirements only; it does not claim that future nft, watchdog, TLS, or CA controls are implemented.

--- a/docs/security/fail-open.md
+++ b/docs/security/fail-open.md
@@ -1,0 +1,82 @@
+# WLOC fail-open and recovery invariants
+
+Status: Phase 0 executable documentation contract. It authorizes offline documentation and tests only, not a live redirect, CA, MITM, production traffic, or real-device test.
+
+Fail-open means that a failure removes the dedicated interception path for subsequent connections or returns an already authenticated response without modification. It never means weakening TLS verification, inventing a location, accepting untrusted bytes, or promising that an in-flight connection survives.
+
+## Non-negotiable response rule
+
+There is never a default or fallback coordinate. Invalid, missing, conflicting, stale, wrong-exit, unknown, malformed, oversized, or unsupported data cannot create a patch. A verified original response is an Apple response obtained only after successful upstream certificate and hostname verification and preserved without protocol modification.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-ENGINE" -->
+
+`engine_unhealthy`: remove redirect before stopping or restarting the engine. The external supervisor first blocks new installs, atomically removes the fully named `wificalling_location` redirect/table objects, verifies absence, drains or terminates the process, and cleans bounded temporary state. It never flushes the global ruleset and never changes `wificalling_gateway` or sing-box.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-WATCHDOG" -->
+
+`watchdog_unhealthy`: stop renewing the kernel-expiring lease; active stop also removes redirect. A PID alone is not health. Loss of the external supervisor, missed service probes, crash loops, OOM, startup failure, or uncertain rule ownership makes the disabled/no-live-lease state authoritative. Respawn is bounded and cannot renew a lease until health, scope, CA state, and the reviewed IPv6 mode all pass.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-LEASE" -->
+
+Every redirect is gated by membership of the assigned-device key in short-TTL nft set elements. The supervisor renews the lease only while engine, scope, and IPv6 health pass. On supervisor death or loss of scheduling, renewal ceases and the kernel automatically expires the lease without help from a userspace process. A rule may remain present but cannot redirect without a matching live lease; startup and reboot begin with no lease.
+
+The lease is defense in depth, not a substitute for deterministic cleanup: active stop still deletes the redirect and verifies absence before engine shutdown. Phase 0 specifies this behavior but does not implement it or assign an invented TTL. A future implementation Issue must freeze the TTL and maximum blackhole time, then measure both on AX6S under engine `kill -9`, supervisor `kill -9`, OOM, scheduler delay, and crash-loop conditions.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-GEO" -->
+
+`geo_invalid_or_unavailable`: forward the verified original response without modification. A cache may be used only while unexpired and bound to the same node and current verified exit IP. Invalid ranges/schema/timezone, provider disagreement, WAN-IP observation, exit changes, expiry, or clock uncertainty cannot create a default coordinate.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-PROTOCOL" -->
+
+`protocol_unknown_or_invalid`: forward the verified original response without modification. Unknown versions/fields without a provably safe round-trip, malformed or truncated input, limit violations, decompression bombs, parser errors, and patch errors are never guessed or partially modified. The body is not logged or cached on failure.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-TLS" -->
+
+`upstream_tls_invalid`: controlled failure; never disable certificate verification. An invalid chain, unknown CA, expired/not-yet-valid certificate, hostname mismatch, ALPN mismatch, or upstream verification error yields no patched or forwarded attacker response. Only a minimal error category and an exact approved hostname may be audited.
+
+<!-- SECURITY_INVARIANT id="FAILOPEN-IPV6" -->
+
+`ipv6_mode_not_ready`: do not install redirect. The same rule applies when DNS/destination sets, assigned-device identity, CA state, service health, or watchdog ownership is unknown. IPv4-only readiness cannot silently override an unreviewed IPv6 path, and IPv6 must not be disabled globally.
+
+## Ordered lifecycle
+
+Enable order is fail-closed until the final step:
+
+1. validate exact device, exact hostname policy, TCP 443, configuration limits, and independent Gateway table name;
+2. verify the chosen IPv4/IPv6 mode and current A/AAAA set ownership;
+3. verify router-local CA permissions and exact-SAN policy without exporting private keys;
+4. start the engine in pass-through mode and prove TLS/H2/upstream health;
+5. arm and prove the external watchdog while the kernel-expiring lease is absent;
+6. install the dedicated redirect with a mandatory live-lease match and verify its exact scope;
+7. create/renew the short lease only after every prior gate remains healthy.
+
+Disable or fault order always prioritizes network recovery:
+
+1. stop lease renewal and remove the live lease element;
+2. prevent new redirect installation;
+3. atomically remove the dedicated redirect and verify absence;
+4. disarm watchdog ownership only after absence is established;
+5. drain or terminate the engine;
+6. remove only WLOC temporary sets, leaf cache, and process state.
+
+If redirect absence cannot be verified, the operation reports a hard degraded state and does not claim recovery. Reboot is a final recovery mechanism for the `/tmp` PoC, not a substitute for tested stop/rollback behavior.
+
+## Failure matrix
+
+| Failure | Position/response behavior | Network behavior | Required evidence before live testing |
+|---|---|---|---|
+| Geo provider unavailable with matching unexpired cache | Use only a policy-approved cached city-level result | Keep healthy scoped service | cache binding and expiry tests |
+| Geo invalid, conflicting, stale, or absent | Return authenticated original bytes unchanged | Keep healthy scoped service | schema/conflict/expiry/wrong-exit tests |
+| Protocol unknown, invalid, failed, or over limit | Return authenticated original bytes unchanged when safely available | No retry amplification | round-trip, malformed, oversize, bomb, and fuzz tests |
+| Apple upstream TLS or ALPN invalid | No position and no unverified response | Controlled failure for that request | negative chain/hostname/ALPN tests |
+| Engine health fails while supervisor runs | No new MITM | Stop renewal, remove lease, then actively remove redirect before process action | engine kill/OOM/startup/crash-loop tests |
+| Supervisor dies or cannot run | No new MITM after lease expiry | Kernel expires the short lease; a residual rule is inert without a matching lease | supervisor kill/OOM and measured lease-expiry tests |
+| DNS set, device binding, CA, or IPv6 mode uncertain | No MITM | Keep redirect absent | state-gate and negative isolation tests |
+
+## Recovery service-level gate
+
+The implementation Issue must set a numeric lease TTL and maximum blackhole time and test them under engine `kill -9`, supervisor `kill -9`, OOM, startup failure, watchdog loss, scheduler delay, crash loop, stop, rollback, dnsmasq reload, and reboot. The measurement must show that matching lease elements expire in the AX6S kernel and that any residual redirect rule is inert. Phase 0 deliberately does not invent either value. No real-device gate may pass with an unmeasured or aspirational recovery bound.
+
+Audit records may contain only bounded categories, generations, coarse time, exact approved hostname, and byte counts. They never include response/request bodies, precise coordinates, device addresses, CA/leaf keys, node credentials, or provider tokens.
+
+This behavior does not guarantee emergency-call location, does not certify carrier compliance, and does not prove Wi-Fi Calling activation. It applies only to the authorized test device and LAN after all later gates are independently approved.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,135 @@
+# WLOC router PoC threat model
+
+Status: Phase 0 canonical security specification. This approval is for offline documentation and tests only. It does not authorize protocol patching, certificate generation, router rules, production traffic, or real-device testing.
+
+This model covers one explicitly authorized test device and LAN, the isolated WLOC component, its future router integration boundary, and its upstream dependencies. It intentionally does not describe Apple private protocol fields.
+
+## Security objectives and scope
+
+<!-- SECURITY_INVARIANT id="SCOPE-01" -->
+
+Interception is allowed only when all three predicates match: one assigned test device, one of the two exact hostnames `gs-loc.apple.com` or `gs-loc-cn.apple.com`, and TCP 443. Matching only an IP address, a hostname suffix, a wildcard, a port, or a device subnet is insufficient. A second exact hostname check is required at TLS ingress because DNS addresses can be shared or poisoned.
+
+<!-- SECURITY_INVARIANT id="GATEWAY-01" -->
+
+The component may create only the dedicated `wificalling_location` table and its fully named objects. It must never modify, reuse, flush, or depend on the `wificalling_gateway` table. UDP 500/4500, ordinary HTTPS, router management, sing-box management/health traffic, and every non-assigned LAN device remain outside the WLOC path. Gateway 1.7 and its running sing-box configuration are read-only dependencies.
+
+The primary security objective is containment and recovery, not guaranteed location modification. Unknown inputs and component failures preserve the original network path or the verified original response; they never expand trust or synthesize a plausible-looking result.
+
+## Assets and trust boundaries
+
+Protected assets are the assigned device's traffic and availability, the router-local CA and leaf keys, Apple upstream identity, node credentials, Geo cache integrity, the dedicated redirect state, Gateway 1.7 state, and privacy-sensitive logs or support bundles.
+
+```mermaid
+flowchart LR
+    D["Authorized test device"] -->|"exact hosts; TCP 443; A/AAAA"| N["Dedicated DNS and nftables scope"]
+    N --> T["TLS / ALPN / HTTP/2 ingress"]
+    T --> P["Bounded protocol handling"]
+    P -->|"validated upstream TLS"| A["Apple WLOC upstream"]
+    G["Gateway 1.7 device-to-node mapping"] --> E["Isolated exit probe"]
+    E --> X["Untrusted exit-IP service"]
+    X --> R["Bounded Geo resolver/cache"]
+    Q["Untrusted Geo providers"] --> R
+    R --> P
+    W["procd / external watchdog"] --> K["Kernel-expiring redirect lease"]
+    K --> N
+    W --> T
+    T --> L["Allowlisted audit events"]
+```
+
+Trust crosses at:
+
+1. the Authorized test device and untrusted LAN into the exact redirect scope;
+2. DNS/IP selection into a second hostname allowlist check;
+3. TLS / ALPN / HTTP/2 ingress into bounded parsing;
+4. the untrusted proxy path into the independently authenticated Apple WLOC upstream;
+5. untrusted exit and Geo providers into schema-, exit-, and expiry-bound data;
+6. root-only secrets into lower-privilege UI, logs, backups, and support tooling; and
+7. process health into the external watchdog that owns redirect removal.
+
+Root compromise is outside the PoC's confidentiality guarantee, but even a root-local failure must not spread secrets to Git, CI, ordinary backups, support bundles, or other LAN devices.
+
+## Critical and High threat register
+
+Each row names the mandatory control and the future executable or operational evidence required before its implementation phase may exit. This document records requirements, not a claim that those future tests already pass.
+
+| ID | Severity and abuse case | Mandatory control | Required evidence owner |
+|---|---|---|---|
+| S-01 | Critical: forged Apple upstream or invalid certificate is accepted | Verify the full upstream certificate chain, validity, SNI, and exact hostname with the system or reviewed trust store; never retry with verification disabled | TLS integration: invalid chain, expiry, unknown CA, and hostname mismatch |
+| S-02 | High: a spoofed or drifted source enters the redirect | Bind exactly one assigned device to validated address/lease identity and disable interception on binding drift | Network integration: other device, spoofed source, and DHCP drift |
+| S-03 | High: poisoned DNS or a shared CDN IP captures another origin | Populate sets from only the two exact names, then require an exact ingress hostname before leaf issuance or proxying | DNS/TLS integration: rotation, shared IP, absent/wrong SNI, ordinary HTTPS |
+| T-01 | Critical: WLOC changes the stable Gateway data plane | Operate only fully named `wificalling_location` objects; keep Gateway and sing-box state read-only | OpenWrt integration: before/after semantic diff and zero UDP 500/4500 hits |
+| T-02 | High: unknown or malformed protocol is patched or damaged | Patch only an authorized, frozen structure; preserve unknown fields and original bytes otherwise | Protocol: fixture round-trip, malformed, unknown version, order, and fuzz |
+| T-03 | High: poisoned, stale, conflicting, or wrong-exit Geo creates a location | Validate schema/ranges/timezone, bind cache to node plus exit IP, enforce expiry, and mark conflicts uncertain | Geo: bad schema, range, conflict, expiry, clock rollback, and exit change |
+| I-01 | Critical: CA or leaf private key escapes router-local storage | Generate locally with secure umask, store root-owned mode `0600`, export public certificate only, and exclude private keys from backup/support paths | CA: permissions, backup/support extraction, repository and artifact scans |
+| I-02 | Critical: node credentials or provider tokens leak | Pass minimum secrets through bounded root-only inputs; never put them in commands, logs, UCI plaintext, or artifacts; clean temporary state | Exit/Geo: canary scans across failures, process state, temp paths, and artifacts |
+| I-03 | High: WLOC body, device identity, or precise location is logged | Construct events only from the log allowlist; do not dump bodies; rotate pseudonyms and logs | Observability: normal/debug/error/crash/rotation canary tests |
+| D-01 | High: oversized, compressed, recursive, or malformed input exhausts memory/CPU | Enforce wire, decoded, ratio, allocation, field/depth, and work limits before allocation or parsing | Protocol: oversize, decompression bomb, repetition/depth, fuzz, RSS and deadline |
+| D-02 | High: TLS/H2 connection or stream pressure exhausts AX6S | Use bounded queues and limits for connections, streams, headers, frames, flow control, and all deadlines | Proxy: slow client, stream flood, RST_STREAM, GOAWAY, and timeout pressure |
+| D-03 | Critical: dead engine or dead supervisor plus a retained redirect causes a persistent blackhole | Gate every redirect match on a kernel-expiring lease; renew it only while engine, scope, and IPv6 health pass; active stop still removes redirect first | AX6S runtime: kill/OOM the engine and supervisor, stop renewal, and measure lease expiry plus the maximum blackhole time |
+| D-04 | High: IPv6 bypass or split state causes interception gaps or blackholes | Require one reviewed IPv6 mode before enabling; couple A/AAAA lifecycle and never disable IPv6 globally | Network: dual-stack, IPv6-only, DNS rotation/reload, and ordinary IPv6 isolation |
+| E-01 | Critical: the router CA signs an arbitrary identity | Keep signer local and non-networked; require each leaf SAN to equal exactly one approved hostname; reject wildcard, IP, or extra SANs | CA: SAN table tests, cache audit, rotation, and old-cache purge |
+| E-02 | High: control/config input injects shell, nft, UCI, or paths | Strict enum/schema/length validation, no shell concatenation, and atomic writes to fixed paths | Control: metacharacter, newline, path traversal, malformed UCI, and overlength |
+
+## CA, TLS, upstream, and HTTP/2 controls
+
+<!-- SECURITY_INVARIANT id="TLS-01" -->
+
+No CA or leaf private key is committed or generated during Phase 0. Future keys must be generated on the authorized router, stored separately from Gateway credentials as root:root mode `0600`, and excluded from UI, logs, support bundles, and ordinary backups. The UI may expose only the public CA certificate and a SHA-256 fingerprint verified over a separate trusted path. Each leaf SAN is exactly one approved hostname; wildcard, IP, suffix, extra-SAN, and arbitrary signing are forbidden. Rotation first removes redirect, then clears the old leaf cache and tells the user to revoke trust on the device.
+
+Downstream support is limited to the reviewed TLS 1.2 and TLS 1.3 baseline. ALPN is explicit: `h2` enters the bounded HTTP/2 stack, an approved HTTP/1.1 result enters only its own parser, and unknown negotiation fails without guessing. The upstream certificate chain, validity, SNI, and hostname are verified independently even when traffic crosses sing-box. Debug modes and retry paths cannot disable verification. A certificate failure produces a controlled WLOC failure, never a fabricated or unverified response.
+
+<!-- SECURITY_INVARIANT id="H2-01" -->
+
+HTTP/2 limits cover SETTINGS, HTTP/2 concurrent streams, header-list bytes, frame/body bytes, flow-control windows, connection lifetime, RST_STREAM, and GOAWAY. Origin and security context key connection reuse; an allowlisted WLOC origin cannot share a pool with another origin.
+
+## IPv4 and IPv6 isolation
+
+<!-- SECURITY_INVARIANT id="IPV6-01" -->
+
+Before any real-device test, a reviewed deployment ADR must choose either a complete dual-stack implementation (IPv4 and IPv6 device/destination sets and redirect with one lifecycle) or scoped AAAA suppression for only the assigned device and two WLOC names. The service must not globally disable IPv6. If neither complete dual-stack nor scoped AAAA suppression is configured and verified, redirect remains absent. Tests must cover dual-stack, IPv6-only connectivity, TTL-driven add/delete, dnsmasq reload, address rotation, device-address drift, ordinary IPv6, and other devices.
+
+## Kernel expiry lease for watchdog loss
+
+The future OpenWrt implementation requires a safety mechanism independent of the continued life of any userspace engine or watchdog. Redirect can match only when the assigned device key is present in dedicated short-TTL nft set elements. The nftables redirect expression must require both the normal device/destination/TCP scope and membership in this live lease set; creating a rule without that match is prohibited.
+
+The external supervisor renews the lease only while engine, scope, and IPv6 health pass. If the supervisor is killed, OOM-terminated, wedged, or unable to check health, renewal stops and the kernel automatically expires the lease. A rule may remain present but cannot redirect without a matching live lease. Startup and reboot begin with no lease, so neither stale userspace state nor a surviving rule enables interception.
+
+This is a required design and test gate, not a claim that a lease mechanism is implemented in Phase 0. The owning implementation Issue must freeze the short TTL and maximum blackhole bound, account for timer/scheduling behavior, and measure the bound on the AX6S by killing or OOM-terminating both engine and supervisor. Active stop still deletes the redirect and verifies absence before stopping the engine; lease expiry is an independent last-resort safety net, not a replacement for cleanup.
+
+## Resource exhaustion controls
+
+<!-- SECURITY_INVARIANT id="RESOURCE-01" -->
+
+All external inputs are hostile and must have explicit, implementation-owned bounds for:
+
+- connections and per-device connections;
+- HTTP/2 concurrent streams and bounded queues;
+- wire body bytes and decoded body bytes;
+- decompression ratio;
+- allocation and parse work, depth, and field count;
+- handshake, upstream, read, and idle timeouts;
+- respawn rate; and
+- a 1 MiB log cap with rotation.
+
+Over-limit content is not parsed, cached, or logged as a body. Exhausted audit storage cannot justify continued interception: the safe response is to disable MITM and remove redirect. Numeric values must be frozen by the owning implementation Issue and demonstrated on the AX6S before real-device testing.
+
+## Logging, support bundles, and privacy
+
+<!-- SECURITY_INVARIANT id="PRIVACY-01" -->
+
+The event allowlist is limited to event type, one exact approved hostname, success/failure category, bounded byte counts, coarse country/city, a rotating non-reversible device pseudonym, state generation, and coarse time. Logs are rotated under the 1 MiB cap.
+
+Logs and support bundles must exclude request or response bodies, Wi-Fi/BSSID/cell data, device MAC or IP, precise coordinates, CA or leaf private keys, node credentials, provider tokens, complete share links, packet captures, raw provider responses, and temporary node configuration. Support bundles are reconstructed from allowed fields rather than copying files and attempting regex cleanup. Canary tests cover normal, debug, error, crash, and rotation paths.
+
+## Emergency, authorization, and compliance limits
+
+<!-- SECURITY_INVARIANT id="COMPLIANCE-01" -->
+
+This PoC is restricted to the owner's authorized test device and LAN. It does not guarantee emergency-call location, does not certify carrier compliance, and does not prove Wi-Fi Calling activation. City-level IP Geo is neither GPS nor the user's verified physical location and must not drive navigation, dispatch, emergency response, or another safety-critical decision. Calling tests, if later authorized, are regression observations rather than emergency-service certification.
+
+The feature is off by default. Real-device work additionally requires closed license and authorized-fixture gates, independent security review, verified CA fingerprint and revocation instructions, a defined test window and rollback owner, an approved IPv6 mode, resource measurements, and executable isolation/failure evidence.
+
+## Review and rollback
+
+Any added device, hostname, protocol variant, TLS/H2 library, Geo provider, remote administration surface, persistent package, log field, Gateway integration behavior, IPv6 strategy, or relaxed resource bound requires threat-model review. A security control may be relaxed only by a reviewed superseding ADR. Until all later implementation gates pass, this specification authorizes no certificate, redirect, live traffic, or device access.

--- a/tests/security/security_invariants.json
+++ b/tests/security/security_invariants.json
@@ -1,0 +1,68 @@
+{
+  "schema": "wloc.security-invariants/v1",
+  "scope": {
+    "assigned_devices": 1,
+    "hostnames": [
+      "gs-loc.apple.com",
+      "gs-loc-cn.apple.com"
+    ],
+    "transport": "TCP 443",
+    "dedicated_table": "wificalling_location",
+    "protected_table": "wificalling_gateway",
+    "forbidden_udp_ports": [500, 4500]
+  },
+  "failure_dispositions": {
+    "engine_unhealthy": "remove redirect before stopping or restarting the engine",
+    "watchdog_unhealthy": "stop renewing the kernel-expiring lease; active stop also removes redirect",
+    "geo_invalid_or_unavailable": "forward the verified original response without modification",
+    "protocol_unknown_or_invalid": "forward the verified original response without modification",
+    "upstream_tls_invalid": "controlled failure; never disable certificate verification",
+    "ipv6_mode_not_ready": "do not install redirect"
+  },
+  "resource_limits": [
+    "connections",
+    "per-device connections",
+    "HTTP/2 concurrent streams",
+    "wire body bytes",
+    "decoded body bytes",
+    "decompression ratio",
+    "allocation and parse work",
+    "handshake, upstream, read, and idle timeouts",
+    "respawn rate",
+    "1 MiB log cap"
+  ],
+  "invariants": [
+    {"id": "SCOPE-01", "document": "threat-model.md"},
+    {"id": "GATEWAY-01", "document": "threat-model.md"},
+    {"id": "TLS-01", "document": "threat-model.md"},
+    {"id": "H2-01", "document": "threat-model.md"},
+    {"id": "IPV6-01", "document": "threat-model.md"},
+    {"id": "RESOURCE-01", "document": "threat-model.md"},
+    {"id": "PRIVACY-01", "document": "threat-model.md"},
+    {"id": "COMPLIANCE-01", "document": "threat-model.md"},
+    {"id": "FAILOPEN-ENGINE", "document": "fail-open.md"},
+    {"id": "FAILOPEN-WATCHDOG", "document": "fail-open.md"},
+    {"id": "FAILOPEN-LEASE", "document": "fail-open.md"},
+    {"id": "FAILOPEN-GEO", "document": "fail-open.md"},
+    {"id": "FAILOPEN-PROTOCOL", "document": "fail-open.md"},
+    {"id": "FAILOPEN-TLS", "document": "fail-open.md"},
+    {"id": "FAILOPEN-IPV6", "document": "fail-open.md"}
+  ],
+  "critical_high_threats": [
+    {"id": "S-01", "control": "verify the Apple upstream chain, validity, SNI and hostname", "evidence": "negative TLS-chain and hostname tests"},
+    {"id": "S-02", "control": "bind interception to one assigned device and reject binding drift", "evidence": "non-assigned-device and DHCP-drift tests"},
+    {"id": "S-03", "control": "use exact DNS sets and a second exact hostname check", "evidence": "wrong-SNI, shared-IP and DNS-rotation tests"},
+    {"id": "T-01", "control": "use only the dedicated WLOC table and keep Gateway state read-only", "evidence": "before-and-after Gateway ruleset semantic comparison"},
+    {"id": "T-02", "control": "patch only an authorized known protocol and otherwise preserve original bytes", "evidence": "fixture round-trip, unknown-version and malformed-input tests"},
+    {"id": "T-03", "control": "validate Geo schema, ranges, exit binding and expiry", "evidence": "invalid, conflicting, stale and wrong-exit Geo tests"},
+    {"id": "I-01", "control": "keep CA and leaf private keys router-local with mode 0600", "evidence": "permission, backup, support-bundle and repository scans"},
+    {"id": "I-02", "control": "exclude node credentials and provider tokens from logs and artifacts", "evidence": "canary scans over error and crash outputs"},
+    {"id": "I-03", "control": "log only allowlisted coarse metadata", "evidence": "normal, debug, error, crash and rotation privacy tests"},
+    {"id": "D-01", "control": "bound wire, decoded, decompressed and parser work before allocation", "evidence": "oversize, compression-bomb and fuzz tests"},
+    {"id": "D-02", "control": "bound TLS and H2 connections, streams, queues and timeouts", "evidence": "slow-client, stream-flood, RST and GOAWAY tests"},
+    {"id": "D-03", "control": "gate redirect matches on a kernel-expiring lease renewed only while engine, scope and IPv6 are healthy", "evidence": "AX6S kill, OOM and supervisor-loss tests measure kernel lease expiry and maximum blackhole time"},
+    {"id": "D-04", "control": "require an approved IPv6 mode before redirect", "evidence": "dual-stack, IPv6-only, AAAA-rotation and ordinary-IPv6 isolation tests"},
+    {"id": "E-01", "control": "issue leaf SANs for only the two exact hostnames", "evidence": "wildcard, extra-SAN, IP-SAN and wrong-host tests"},
+    {"id": "E-02", "control": "strictly validate control inputs without shell concatenation", "evidence": "injection, traversal, newline and overlength tests"}
+  ]
+}

--- a/tests/security/test_security_invariants.py
+++ b/tests/security/test_security_invariants.py
@@ -1,0 +1,220 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SECURITY_DIR = ROOT / "docs" / "security"
+CONTRACT_PATH = Path(__file__).with_name("security_invariants.json")
+
+
+def assert_hard_security_semantics(testcase, threat_model, fail_open, contract):
+    """Check critical policy against code-owned expectations, not contract-owned values."""
+    testcase.assertEqual(
+        contract["scope"],
+        {
+            "assigned_devices": 1,
+            "hostnames": ["gs-loc.apple.com", "gs-loc-cn.apple.com"],
+            "transport": "TCP 443",
+            "dedicated_table": "wificalling_location",
+            "protected_table": "wificalling_gateway",
+            "forbidden_udp_ports": [500, 4500],
+        },
+    )
+
+    combined = threat_model + fail_open
+    hard_phrases = (
+        "short-TTL nft set elements",
+        "kernel-expiring lease",
+        "supervisor renews the lease only while engine, scope, and IPv6 health pass",
+        "kernel automatically expires the lease",
+        "rule may remain present but cannot redirect without a matching live lease",
+        "startup and reboot begin with no lease",
+        "active stop still deletes the redirect and verifies absence",
+        "never disable certificate verification",
+        "never a default or fallback coordinate",
+        "ipv6_mode_not_ready`: do not install redirect",
+        "must never modify, reuse, flush, or depend on the `wificalling_gateway` table",
+        "UDP 500/4500",
+    )
+    for phrase in hard_phrases:
+        testcase.assertIn(phrase, combined)
+
+    d03 = next(item for item in contract["critical_high_threats"] if item["id"] == "D-03")
+    testcase.assertEqual(
+        d03,
+        {
+            "id": "D-03",
+            "control": "gate redirect matches on a kernel-expiring lease renewed only while engine, scope and IPv6 are healthy",
+            "evidence": "AX6S kill, OOM and supervisor-loss tests measure kernel lease expiry and maximum blackhole time",
+        },
+    )
+
+
+class SecurityInvariantDocumentationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+        threat_model_path = SECURITY_DIR / "threat-model.md"
+        fail_open_path = SECURITY_DIR / "fail-open.md"
+        cls.threat_model = threat_model_path.read_text(encoding="utf-8") if threat_model_path.exists() else ""
+        cls.fail_open = fail_open_path.read_text(encoding="utf-8") if fail_open_path.exists() else ""
+
+    def test_contract_is_versioned_and_scope_is_exact(self):
+        self.assertEqual(self.contract["schema"], "wloc.security-invariants/v1")
+        scope = self.contract["scope"]
+        self.assertEqual(scope["assigned_devices"], 1)
+        self.assertEqual(
+            scope["hostnames"],
+            ["gs-loc.apple.com", "gs-loc-cn.apple.com"],
+        )
+        self.assertEqual(scope["transport"], "TCP 443")
+        self.assertEqual(scope["forbidden_udp_ports"], [500, 4500])
+        self.assertEqual(scope["dedicated_table"], "wificalling_location")
+        self.assertEqual(scope["protected_table"], "wificalling_gateway")
+
+    def test_every_invariant_has_a_canonical_document_anchor(self):
+        documents = {
+            "threat-model.md": self.threat_model,
+            "fail-open.md": self.fail_open,
+        }
+        for invariant in self.contract["invariants"]:
+            marker = f'<!-- SECURITY_INVARIANT id="{invariant["id"]}" -->'
+            with self.subTest(invariant=invariant["id"]):
+                self.assertIn(marker, documents[invariant["document"]])
+
+    def test_scope_excludes_gateway_and_wifi_calling_ipsec(self):
+        required = (
+            "one assigned test device",
+            "gs-loc.apple.com",
+            "gs-loc-cn.apple.com",
+            "TCP 443",
+            "UDP 500/4500",
+            "wificalling_location",
+            "wificalling_gateway",
+        )
+        for text in required:
+            with self.subTest(text=text):
+                self.assertIn(text, self.threat_model)
+        self.assertIn("must never modify", self.threat_model)
+
+    def test_trust_boundaries_are_diagrammed(self):
+        self.assertIn("```mermaid", self.threat_model)
+        for boundary in ("Authorized test device", "TLS / ALPN / HTTP/2", "Apple WLOC upstream", "Geo providers", "watchdog"):
+            with self.subTest(boundary=boundary):
+                self.assertIn(boundary, self.threat_model)
+
+    def test_each_critical_or_high_threat_maps_to_control_and_evidence(self):
+        threats = self.contract["critical_high_threats"]
+        self.assertGreaterEqual(len(threats), 15)
+        self.assertEqual(len({item["id"] for item in threats}), len(threats))
+        for threat in threats:
+            with self.subTest(threat=threat["id"]):
+                self.assertTrue(threat["control"].strip())
+                self.assertTrue(threat["evidence"].strip())
+                self.assertIn(f'| {threat["id"]} |', self.threat_model)
+
+    def test_fail_open_dispositions_are_explicit(self):
+        for cause, disposition in self.contract["failure_dispositions"].items():
+            with self.subTest(cause=cause):
+                self.assertIn(cause, self.fail_open)
+                self.assertIn(disposition, self.fail_open)
+        self.assertIn("never a default or fallback coordinate", self.fail_open)
+        self.assertIn("verified original response", self.fail_open)
+
+    def test_tls_h2_ca_and_resource_controls_are_explicit(self):
+        required = (
+            "TLS 1.2 and TLS 1.3",
+            "ALPN",
+            "HTTP/2",
+            "upstream certificate",
+            "leaf SAN",
+            "0600",
+        )
+        for text in required + tuple(self.contract["resource_limits"]):
+            with self.subTest(text=text):
+                self.assertIn(text, self.threat_model)
+
+    def test_ipv4_ipv6_decision_is_a_real_device_gate(self):
+        for text in ("IPv4", "IPv6", "complete dual-stack", "scoped AAAA suppression", "must not globally disable IPv6"):
+            with self.subTest(text=text):
+                self.assertIn(text, self.threat_model)
+        self.assertIn("do not install redirect", self.fail_open)
+
+    def test_logs_and_support_bundles_use_an_allowlist(self):
+        required = (
+            "allowlist",
+            "request or response bodies",
+            "device MAC or IP",
+            "precise coordinates",
+            "CA or leaf private keys",
+            "node credentials",
+            "provider tokens",
+            "1 MiB",
+        )
+        for text in required:
+            with self.subTest(text=text):
+                self.assertIn(text, self.threat_model)
+
+    def test_emergency_and_compliance_limitations_are_unambiguous(self):
+        required = (
+            "does not guarantee emergency-call location",
+            "does not certify carrier compliance",
+            "does not prove Wi-Fi Calling activation",
+            "authorized test device and LAN",
+            "offline documentation and tests only",
+        )
+        combined = self.threat_model + self.fail_open
+        for text in required:
+            with self.subTest(text=text):
+                self.assertIn(text, combined)
+
+    def test_hard_security_semantics_do_not_trust_the_contract_as_oracle(self):
+        assert_hard_security_semantics(
+            self,
+            self.threat_model,
+            self.fail_open,
+            self.contract,
+        )
+
+    def test_mutating_a_critical_phrase_or_scope_is_detected(self):
+        mutations = (
+            (
+                self.threat_model,
+                self.fail_open.replace(
+                    "never disable certificate verification",
+                    "disable certificate verification after a retry",
+                ),
+                self.contract,
+            ),
+            (
+                self.threat_model,
+                self.fail_open.replace(
+                    "never a default or fallback coordinate",
+                    "use a default coordinate when unavailable",
+                ),
+                self.contract,
+            ),
+            (
+                self.threat_model,
+                self.fail_open,
+                {
+                    **deepcopy(self.contract),
+                    "scope": {**self.contract["scope"], "forbidden_udp_ports": [4500]},
+                },
+            ),
+        )
+        for threat_model, fail_open, contract in mutations:
+            with self.subTest():
+                with self.assertRaises(AssertionError):
+                    assert_hard_security_semantics(
+                        self,
+                        threat_model,
+                        fail_open,
+                        contract,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Summary
- freezes the standalone WLOC threat model and exact traffic scope
- specifies kernel-expiring redirect leases and ordered fail-open recovery
- adds executable, mutation-resistant security invariant tests

## Verification
- `python3 -m unittest discover -s tests/security -p "test_*.py"` (12/12)
- `./scripts/ci/verify.sh` (18/18 plus secret scan)
- independent security review: APPROVE, no P0/P1/P2

## Risks and rollback
- documentation/tests only; no CA, redirect, live traffic, or device behavior
- relaxations require a reviewed superseding ADR

Handoff capsule: `.handoffs/issue-3.md`
