### PR TITLE
feat: remediate fixture governance with fail-closed guard

### DIFF
--- a/.handoffs/issue-2.md
+++ b/.handoffs/issue-2.md
@@ -1,0 +1,93 @@
+# Agent handoff: Issue 2
+
+## Identity and scope
+
+- Source agent ID: zcode-fixture-verify
+- Capabilities used: protocol,security,test
+- Branch: codex/issue-2-fixture-governance-codex-fixture-close-20260811112953-43625025
+- Checkpoint parent: f2950b23928f06f7a46d9db2c589f06cd548f506
+- Updated at (UTC): 2026-08-11T14:20:00Z
+- Credentials included: no
+
+## Objective
+
+Close the Phase 0 fixture governance gate with a fail-closed validator. The
+remediation agent completed the code but hit its quota before reporting; this
+checkpoint records the completed differential review and full-repository
+verification that the main agent planned.
+
+## Completed
+
+- `fixtures/schema/manifest.schema.json`: canonical JSON schema for the
+  synthetic fixture manifest, pinned by `TRUSTED_SCHEMA_SHA256`; any other
+  digest is rejected as `UntrustedSchema`.
+- `scripts/fixtures/fixture_guard.py`: fail-closed validator. Authorized
+  capture classification is unconditionally gate-closed
+  (`AuthorizedCaptureGateClosed`); only the exact project-generated synthetic
+  format can pass. Payload scanning rejects capture magics, forbidden
+  suffixes, credentials, device identifiers, MACs, Luhn-verified IMEIs,
+  precise coordinates, TLS key material, and HTTP traces. Directory-relative
+  `O_NOFOLLOW` opens, duplicate-key and depth limits, exact inventory
+  structure, and size/hash bounds are enforced.
+- `scripts/fixtures/generate_synthetic.py`: offline, deterministic synthetic
+  fixture generator that never overwrites existing files.
+- `tests/fixtures/`: 20 tests (11 governance + 9 security review) covering
+  the original review findings: self-declared authorization, binary scanning,
+  and schema trust.
+
+## Files changed
+
+- `fixtures/README.md`, `fixtures/schema/manifest.schema.json`
+- `scripts/fixtures/fixture_guard.py`, `scripts/fixtures/generate_synthetic.py`
+- `tests/fixtures/__init__.py`, `tests/fixtures/test_fixture_governance.py`,
+  `tests/fixtures/test_fixture_security_review.py`
+- `.handoffs/issue-2.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `python3 -m pytest tests/fixtures/ -q` | Passed | 20 passed |
+| `python3 -m unittest discover -s tests -p 'test_*.py'` | Passed | 26 tests, OK |
+| `./scripts/ci/verify.sh` | Passed | agent handoff tools, secret scan, repository gates |
+| `git diff --check` | Passed | no whitespace errors |
+| differential review | Passed | all three original findings remediated: authorized capture is gate-closed, binary scan present, schema digest pinned |
+
+## Failed attempts
+
+- The remediation agent hit its API quota after completing the code; the
+  missing report was substituted by this checkpoint's differential review and
+  full verification.
+
+## Unresolved decisions and blockers
+
+- The two original independent reviewers (protocol + security) should confirm
+  the remediation; no P0/P1 are expected based on the differential review.
+- Merging this Issue closes the last Phase 0 gate and unblocks WLOC parser /
+  response-patch work under the clean-room synthetic fixture regime.
+
+## Next executable steps
+
+1. Open the Issue #2 PR with `Closes #2`, evidence, risks, rollback notes,
+   and this capsule path; verify the contract and repository gates pass.
+2. After merge, close the Phase 0 milestone and start Phase 3 (offline WLOC
+   patch core) with the synthetic fixture format as the only accepted input.
+
+## Capabilities required for the next Agent
+
+- protocol
+- security
+- test
+
+## Environment assumptions
+
+- Python 3, pytest, POSIX shell, and Git available.
+- No network access, device, or production fixture is required; everything is
+  offline and deterministic.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- The gate is default-deny: authorized captures cannot enter the repository
+  until a separately reviewed evidence pipeline exists.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,0 +1,97 @@
+# WLOC fixture governance contract
+
+This directory is an offline, fail-closed intake boundary. It is not a capture
+workspace and does not specify or implement Apple-private protocol fields.
+
+Only two classifications exist:
+
+- `synthetic`: deterministic project-authored generic bytes. These fixtures
+  contain no captured traffic and prove only that governance tooling works.
+- `authorized-sanitized-capture`: a future, independently approved laboratory
+  artifact description. **Phase 0 rejects this classification unconditionally
+  with `AuthorizedCaptureGateClosed`.** Self-declared manifest evidence never
+  unlocks intake and never counts as a GREEN test result.
+
+No authorized capture is included or approved by this change. The capture gate
+must remain closed until a dedicated protocol-aware sanitizer, an external
+trusted approval verifier, and independent protocol plus security approvals are
+implemented and reviewed. Raw captures remain outside Git at all times. Do not
+place PCAP/PCAPNG/HAR files, renamed HAR bodies, request or response dumps, TLS
+key logs, archives, PEM/key/profile material, secrets, device/network
+identifiers, or precise real coordinates in this repository.
+
+## Manifest and limits
+
+Every candidate uses `fixtures/schema/manifest.schema.json` and records:
+
+- provenance and authorization status/record;
+- iOS version (or `not-applicable-synthetic` for synthetic data);
+- exactly `gs-loc.apple.com` or `gs-loc-cn.apple.com`;
+- ALPN `h2`, classification, and redactions;
+- relative payload path, byte length, and lowercase SHA-256.
+
+The canonical schema bytes are pinned in the zero-dependency validator by
+SHA-256. A copied-but-modified or substitute schema is rejected. The validator
+manually enforces the synthetic constraints and rejects unknown/duplicate
+fields, Unicode/bidirectional filenames, unsafe paths, symlinks, schema depth
+over 12, manifests over 64 KiB, and payloads over 1 MiB. Reads use no-follow,
+directory-relative file descriptors and `fstat`; errors return stable codes and
+do not echo untrusted fields or content. It reads no credentials and performs no
+network requests.
+
+The future capture schema requires non-blank creator/date, protocol and security
+review attestations (`agent_id`, capabilities, `APPROVE` verdict), clean-room
+attestation, off-repository raw retention/deletion evidence, sanitizer
+ID/version/PASS result, and explicit `removed`, `verified-absent`, or
+`not-applicable` results for secrets, device IDs, network IDs, precise location,
+and raw body. These self-declared fields are documentation only in Phase 0.
+
+## Reproducible synthetic path
+
+Generate into a new or existing empty temporary directory, validate, then
+delete it. The generator refuses non-empty directories and creates both files
+exclusively without overwriting:
+
+```sh
+tmp_dir=$(mktemp -d)
+python3 scripts/fixtures/generate_synthetic.py \
+  --output-dir "$tmp_dir" \
+  --fixture-id synthetic-boundary-01 \
+  --seed offline-seed-01 \
+  --hostname gs-loc.apple.com
+python3 scripts/fixtures/fixture_guard.py "$tmp_dir/manifest.json"
+```
+
+The same seed and arguments produce byte-identical output and the manifest hash
+is checked against the payload. Passing this synthetic path does not authorize
+private-protocol parsing, response patching, CA creation, MITM, or real-device
+testing.
+
+The only accepted payload is the generator's fixed 61-byte governance format:
+the versioned project prefix followed by a SHA-256 seed digest. Unknown binary
+formats fail closed even when their manifest hash matches.
+
+## Repository inventory gate
+
+Scan the complete fixture tree before review or CI integration:
+
+```sh
+python3 scripts/fixtures/fixture_guard.py --inventory fixtures
+```
+
+At the root, only this README, the canonical schema directory, and fixture
+directories are allowed. Each fixture directory must contain exactly one
+`manifest.json` and its registered `fixture.bin`; only validated synthetic
+fixtures pass. Orphans, unknown files, symbolic links, capture extensions,
+renamed HAR content, and unregistered payloads fail closed.
+
+## Future authorized intake
+
+An authorized sample would require prior written owner consent for a dedicated
+test device, a time-bounded collection approval, legal/license review, a
+documented off-repository raw-data retention and deletion process, a separate
+protocol-aware sanitizer, external approval verification, and independent
+protocol plus security review. Until all of those mechanisms land and receive
+new review, the validator must still return `AuthorizedCaptureGateClosed`. If
+provenance, authorization, sanitization, or license status cannot be proved,
+reject the sample rather than weakening the gate.

--- a/fixtures/schema/manifest.schema.json
+++ b/fixtures/schema/manifest.schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wificalling-location-gateway.invalid/schema/fixture-manifest-v1.json",
+  "title": "Repository-safe WLOC fixture manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "fixture",
+    "provenance",
+    "authorization",
+    "ios_version",
+    "hostname",
+    "alpn",
+    "classification",
+    "redactions"
+  ],
+  "properties": {
+    "schema_version": { "const": "wloc-fixture/v1" },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "path", "media_type", "byte_length", "sha256"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$" },
+        "path": { "const": "fixture.bin" },
+        "media_type": { "const": "application/octet-stream" },
+        "byte_length": { "type": "integer", "minimum": 61, "maximum": 1048576 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "generator", "generator_version", "source_basis"],
+      "properties": {
+        "kind": { "enum": ["project-generated", "authorized-lab-capture"] },
+        "generator": { "$ref": "#/$defs/nonBlankAscii128" },
+        "generator_version": { "$ref": "#/$defs/nonBlankAscii32" },
+        "source_basis": { "$ref": "#/$defs/nonBlankAscii256" }
+      }
+    },
+    "authorization": {
+      "oneOf": [
+        { "$ref": "#/$defs/syntheticAuthorization" },
+        { "$ref": "#/$defs/captureAuthorization" }
+      ]
+    },
+    "ios_version": {
+      "type": "string",
+      "pattern": "^(not-applicable-synthetic|[0-9]{1,2}\\.[0-9]{1,2}(\\.[0-9]{1,2})?)$"
+    },
+    "hostname": { "enum": ["gs-loc.apple.com", "gs-loc-cn.apple.com"] },
+    "alpn": { "const": "h2" },
+    "classification": { "enum": ["synthetic", "authorized-sanitized-capture"] },
+    "redactions": {
+      "type": "array",
+      "maxItems": 32,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "credentials",
+          "device-identifiers",
+          "network-identifiers",
+          "precise-coordinates",
+          "request-metadata",
+          "unrelated-payload"
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "nonBlankAscii32": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32,
+      "pattern": "^(?=.*[!-~])[ -~]+$"
+    },
+    "nonBlankAscii64": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?=.*[!-~])[ -~]+$"
+    },
+    "nonBlankAscii128": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^(?=.*[!-~])[ -~]+$"
+    },
+    "nonBlankAscii256": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^(?=.*[!-~])[ -~]+$"
+    },
+    "reviewAttestation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent_id", "capabilities", "verdict"],
+      "properties": {
+        "agent_id": { "$ref": "#/$defs/nonBlankAscii64" },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/nonBlankAscii32" }
+        },
+        "verdict": { "const": "APPROVE" }
+      }
+    },
+    "rawRetention": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["storage_ref", "delete_by", "deletion_owner", "deletion_status"],
+      "properties": {
+        "storage_ref": { "$ref": "#/$defs/nonBlankAscii128" },
+        "delete_by": { "type": "string", "format": "date-time" },
+        "deletion_owner": { "$ref": "#/$defs/nonBlankAscii64" },
+        "deletion_status": { "enum": ["scheduled", "verified-deleted"] }
+      }
+    },
+    "sanitizerEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "result"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonBlankAscii64" },
+        "version": { "$ref": "#/$defs/nonBlankAscii32" },
+        "result": { "const": "PASS" }
+      }
+    },
+    "redactionEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["secrets", "device_ids", "network_ids", "precise_location", "raw_body"],
+      "properties": {
+        "secrets": { "$ref": "#/$defs/redactionResult" },
+        "device_ids": { "$ref": "#/$defs/redactionResult" },
+        "network_ids": { "$ref": "#/$defs/redactionResult" },
+        "precise_location": { "$ref": "#/$defs/redactionResult" },
+        "raw_body": { "$ref": "#/$defs/redactionResult" }
+      }
+    },
+    "redactionResult": {
+      "enum": ["removed", "verified-absent", "not-applicable"]
+    },
+    "syntheticAuthorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "record_id"],
+      "properties": {
+        "status": { "const": "not-required-synthetic" },
+        "record_id": { "const": "not-applicable" }
+      }
+    },
+    "captureAuthorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "record_id",
+        "creator",
+        "created_at",
+        "protocol_review",
+        "security_review",
+        "clean_room_attestation",
+        "raw_retention",
+        "sanitizer",
+        "redaction_evidence"
+      ],
+      "properties": {
+        "status": { "const": "approved" },
+        "record_id": { "$ref": "#/$defs/nonBlankAscii64" },
+        "creator": { "$ref": "#/$defs/nonBlankAscii64" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "protocol_review": { "$ref": "#/$defs/reviewAttestation" },
+        "security_review": { "$ref": "#/$defs/reviewAttestation" },
+        "clean_room_attestation": { "const": true },
+        "raw_retention": { "$ref": "#/$defs/rawRetention" },
+        "sanitizer": { "$ref": "#/$defs/sanitizerEvidence" },
+        "redaction_evidence": { "$ref": "#/$defs/redactionEvidence" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "classification": { "const": "synthetic" } } },
+      "then": {
+        "properties": {
+          "authorization": { "$ref": "#/$defs/syntheticAuthorization" },
+          "ios_version": { "const": "not-applicable-synthetic" },
+          "redactions": { "maxItems": 0 },
+          "provenance": { "properties": { "kind": { "const": "project-generated" } } }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "classification": { "const": "authorized-sanitized-capture" } }
+      },
+      "then": {
+        "properties": {
+          "authorization": { "$ref": "#/$defs/captureAuthorization" },
+          "provenance": {
+            "properties": { "kind": { "const": "authorized-lab-capture" } }
+          },
+          "redactions": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/fixture_guard.py
+++ b/scripts/fixtures/fixture_guard.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for repository fixture candidates.
+
+Only the project-generated synthetic governance format can pass. Authorized
+capture metadata is descriptive future schema surface and cannot open the gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+from pathlib import Path
+from typing import Any
+
+
+MAX_MANIFEST_BYTES = 64 * 1024
+MAX_SCHEMA_BYTES = 128 * 1024
+MAX_PAYLOAD_BYTES = 1024 * 1024
+MAX_JSON_DEPTH = 12
+ALLOWED_HOSTNAMES = ("gs-loc.apple.com", "gs-loc-cn.apple.com")
+TRUSTED_SCHEMA_SHA256 = "c034e535c47e00deb132678dabb9d8775274028eaf8f09cd49ff5ba8e738eaf0"
+SYNTHETIC_PREFIX = b"WLG-SYNTHETIC-GOVERNANCE-V1\x00"
+SYNTHETIC_PAYLOAD_BYTES = len(SYNTHETIC_PREFIX) + 32
+SYNTHETIC_GENERATOR = "scripts/fixtures/generate_synthetic.py"
+SYNTHETIC_GENERATOR_VERSION = "1"
+SYNTHETIC_SOURCE_BASIS = (
+    "project-authored generic bytes; no capture or private protocol source"
+)
+ALLOWED_REDACTIONS = {
+    "credentials",
+    "device-identifiers",
+    "network-identifiers",
+    "precise-coordinates",
+    "request-metadata",
+    "unrelated-payload",
+}
+FORBIDDEN_SUFFIXES = {
+    ".7z",
+    ".gz",
+    ".har",
+    ".key",
+    ".keys",
+    ".mobileconfig",
+    ".p12",
+    ".pcap",
+    ".pcapng",
+    ".pem",
+    ".pfx",
+    ".tar",
+    ".tgz",
+    ".zip",
+}
+CAPTURE_MAGICS = (
+    bytes.fromhex("a1b2c3d4"),
+    bytes.fromhex("d4c3b2a1"),
+    bytes.fromhex("a1b23c4d"),
+    bytes.fromhex("4d3cb2a1"),
+    bytes.fromhex("0a0d0d0a"),
+    bytes.fromhex("504b0304"),
+)
+SENSITIVE_PATTERNS = (
+    r"-----BEGIN [A-Z0-9 ]*(?:PRIVATE KEY|CERTIFICATE)-----",
+    r"(?i)\b(?:authorization\s*:\s*)?bearer\s+[A-Za-z0-9._~+/-]{8,}",
+    r"(?i)\b(?:api[_-]?key|secret|password|token)\s*[:=]\s*\S{4,}",
+    r"(?i)\b(?:device[_-]?id|serial(?:_number)?|idfv|idfa)\s*[:=]\s*\S+",
+    r"(?i)\bimei\s*[:=]\s*\d{14,16}\b",
+    r"(?i)\budid\s*[:=]\s*[0-9a-f-]{24,64}\b",
+    r"(?i)\b(?:device[_-]?)?mac\s*[:=]\s*(?:[0-9a-f]{2}:){5}[0-9a-f]{2}\b",
+    r"(?i)[\"']?(?:latitude|longitude|lat|lon)[\"']?\s*[:=]\s*-?\d{1,3}\.\d{3,}",
+    r"(?m)^(?:CLIENT_RANDOM|CLIENT_HANDSHAKE_TRAFFIC_SECRET|SERVER_HANDSHAKE_TRAFFIC_SECRET)\s",
+    r"(?m)^(?:GET|POST|PUT|PATCH|DELETE)\s+\S+\s+HTTP/1\.[01]\r?$",
+    r"(?m)^HTTP/1\.[01]\s+\d{3}\b",
+    r"\bgh[pousr]_[A-Za-z0-9]{20,255}\b",
+    r"\bgithub_pat_[A-Za-z0-9_]{20,255}\b",
+    r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,255}\b",
+    r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b",
+    r"\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b",
+    r"(?i)(?<![0-9a-f])(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}(?![0-9a-f])",
+    r"(?i)(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])",
+    r"(?i)(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{16}(?![0-9a-f])",
+    r"(?i)(?<![0-9a-f])[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}(?![0-9a-f])",
+    r"\[\s*-?\d{1,3}\.\d{3,}\s*,\s*-?\d{1,3}\.\d{3,}\s*\]",
+    r"(?is)[\"']log[\"']\s*:\s*\{.*[\"']entries[\"']\s*:\s*\[",
+)
+
+
+class FixtureRejected(ValueError):
+    """Stable-code rejection that never includes untrusted input."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+def _reject(code: str) -> None:
+    raise FixtureRejected(code)
+
+
+def _safe_ascii_name(name: str) -> bool:
+    return bool(name) and len(name) <= 128 and all(0x21 <= ord(char) <= 0x7E for char in name)
+
+
+def _read_regular(path: Path, maximum: int) -> bytes:
+    """Read a stable regular file using no-follow directory-relative opens."""
+    if not _safe_ascii_name(path.name):
+        _reject("UnsafePath")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    file_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    directory_fd = -1
+    file_fd = -1
+    try:
+        directory_fd = os.open(str(path.parent), directory_flags)
+        file_fd = os.open(path.name, file_flags, dir_fd=directory_fd)
+        details = os.fstat(file_fd)
+        if not stat.S_ISREG(details.st_mode):
+            _reject("UnsafeFile")
+        if not 1 <= details.st_size <= maximum:
+            _reject("SizeLimit")
+        chunks: list[bytes] = []
+        remaining = details.st_size
+        while remaining:
+            chunk = os.read(file_fd, min(remaining, 64 * 1024))
+            if not chunk:
+                _reject("UnsafeFile")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        if os.fstat(file_fd).st_size != details.st_size:
+            _reject("UnsafeFile")
+        return b"".join(chunks)
+    except FixtureRejected:
+        raise
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        _reject("UnsafeFile")
+    finally:
+        if file_fd >= 0:
+            os.close(file_fd)
+        if directory_fd >= 0:
+            os.close(directory_fd)
+    raise AssertionError("unreachable")
+
+
+def _no_duplicate_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _reject("InvalidJson")
+        result[key] = value
+    return result
+
+
+def _parse_json(raw: bytes) -> Any:
+    try:
+        return json.loads(raw.decode("utf-8"), object_pairs_hook=_no_duplicate_object)
+    except FixtureRejected:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        _reject("InvalidJson")
+
+
+def _check_depth(value: Any, current: int = 0) -> None:
+    if current > MAX_JSON_DEPTH:
+        _reject("SchemaLimit")
+    if isinstance(value, dict):
+        for child in value.values():
+            _check_depth(child, current + 1)
+    elif isinstance(value, list):
+        for child in value:
+            _check_depth(child, current + 1)
+
+
+def _exact_object(value: Any, keys: set[str], code: str) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        _reject(code)
+    return value
+
+
+def _bounded_ascii(value: Any, maximum: int, code: str) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= maximum:
+        _reject(code)
+    if not value.strip() or any(ord(character) < 0x20 or ord(character) > 0x7E for character in value):
+        _reject(code)
+    return value
+
+
+def _decoded_views(payload: bytes) -> list[str]:
+    views = [payload.decode("latin-1", errors="ignore")]
+    if b"\x00" in payload:
+        for encoding in ("utf-16-le", "utf-16-be"):
+            try:
+                views.append(payload.decode(encoding))
+            except UnicodeDecodeError:
+                continue
+    return views
+
+
+def _valid_imei(candidate: str) -> bool:
+    total = 0
+    for index, character in enumerate(candidate):
+        digit = int(character)
+        if index % 2:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0
+
+
+def inspect_payload(payload: bytes, filename: str) -> None:
+    """Reject high-confidence secret, identifier, location, and capture signals."""
+    if not isinstance(payload, bytes) or not 1 <= len(payload) <= MAX_PAYLOAD_BYTES:
+        _reject("SizeLimit")
+    if not _safe_ascii_name(filename):
+        _reject("UnsafePath")
+    if Path(filename).suffix.lower() in FORBIDDEN_SUFFIXES:
+        _reject("ForbiddenFileType")
+    if payload.startswith(CAPTURE_MAGICS):
+        _reject("SensitiveContent")
+    for text in _decoded_views(payload):
+        for pattern in SENSITIVE_PATTERNS:
+            if re.search(pattern, text):
+                _reject("SensitiveContent")
+        if any(_valid_imei(match.group(0)) for match in re.finditer(r"(?<!\d)\d{15}(?!\d)", text)):
+            _reject("SensitiveContent")
+
+
+def inspect_file(path: Path) -> bytes:
+    payload = _read_regular(path, MAX_PAYLOAD_BYTES)
+    inspect_payload(payload, path.name)
+    return payload
+
+
+def _validate_synthetic_manifest(manifest: Any) -> dict[str, Any]:
+    top = _exact_object(
+        manifest,
+        {
+            "schema_version",
+            "fixture",
+            "provenance",
+            "authorization",
+            "ios_version",
+            "hostname",
+            "alpn",
+            "classification",
+            "redactions",
+        },
+        "InvalidManifest",
+    )
+    if top["schema_version"] != "wloc-fixture/v1":
+        _reject("InvalidManifest")
+    if top["classification"] != "synthetic":
+        _reject("UnsupportedClassification")
+    if top["hostname"] not in ALLOWED_HOSTNAMES or top["alpn"] != "h2":
+        _reject("InvalidTransportMetadata")
+    if top["ios_version"] != "not-applicable-synthetic":
+        _reject("InvalidSyntheticMetadata")
+    redactions = top["redactions"]
+    if not isinstance(redactions, list) or any(not isinstance(item, str) for item in redactions):
+        _reject("InvalidRedactions")
+    if len(redactions) != len(set(redactions)) or not set(redactions).issubset(ALLOWED_REDACTIONS):
+        _reject("InvalidRedactions")
+    if redactions:
+        _reject("InvalidSyntheticMetadata")
+
+    fixture = _exact_object(
+        top["fixture"], {"id", "path", "media_type", "byte_length", "sha256"}, "InvalidFixture"
+    )
+    fixture_id = _bounded_ascii(fixture["id"], 64, "InvalidFixture")
+    if re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", fixture_id) is None:
+        _reject("InvalidFixture")
+    if fixture["path"] != "fixture.bin":
+        _reject("UnsafePath")
+    if fixture["media_type"] != "application/octet-stream":
+        _reject("InvalidFixture")
+    if (
+        not isinstance(fixture["byte_length"], int)
+        or isinstance(fixture["byte_length"], bool)
+        or fixture["byte_length"] != SYNTHETIC_PAYLOAD_BYTES
+    ):
+        _reject("UnsupportedSyntheticPayload")
+    if not isinstance(fixture["sha256"], str) or re.fullmatch(r"[0-9a-f]{64}", fixture["sha256"]) is None:
+        _reject("InvalidFixture")
+
+    provenance = _exact_object(
+        top["provenance"],
+        {"kind", "generator", "generator_version", "source_basis"},
+        "InvalidProvenance",
+    )
+    expected_provenance = {
+        "kind": "project-generated",
+        "generator": SYNTHETIC_GENERATOR,
+        "generator_version": SYNTHETIC_GENERATOR_VERSION,
+        "source_basis": SYNTHETIC_SOURCE_BASIS,
+    }
+    if provenance != expected_provenance:
+        _reject("InvalidProvenance")
+    authorization = _exact_object(
+        top["authorization"], {"status", "record_id"}, "InvalidAuthorization"
+    )
+    if authorization != {"status": "not-required-synthetic", "record_id": "not-applicable"}:
+        _reject("InvalidAuthorization")
+    return top
+
+
+def validate_fixture(manifest_path: Path, schema_path: Path) -> dict[str, Any]:
+    """Validate one fixed-format synthetic fixture with a pinned canonical schema."""
+    schema_bytes = _read_regular(schema_path, MAX_SCHEMA_BYTES)
+    if hashlib.sha256(schema_bytes).hexdigest() != TRUSTED_SCHEMA_SHA256:
+        _reject("UntrustedSchema")
+    schema = _parse_json(schema_bytes)
+    if not isinstance(schema, dict) or schema.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        _reject("UntrustedSchema")
+
+    if manifest_path.name != "manifest.json":
+        _reject("UnsafePath")
+    manifest_bytes = _read_regular(manifest_path, MAX_MANIFEST_BYTES)
+    manifest = _parse_json(manifest_bytes)
+    if isinstance(manifest, dict) and manifest.get("classification") == "authorized-sanitized-capture":
+        _reject("AuthorizedCaptureGateClosed")
+    inspect_payload(manifest_bytes, manifest_path.name)
+    _check_depth(manifest)
+    safe_manifest = _validate_synthetic_manifest(manifest)
+
+    payload_path = manifest_path.parent / "fixture.bin"
+    payload = inspect_file(payload_path)
+    if len(payload) != safe_manifest["fixture"]["byte_length"]:
+        _reject("HashMismatch")
+    if hashlib.sha256(payload).hexdigest() != safe_manifest["fixture"]["sha256"]:
+        _reject("HashMismatch")
+    if len(payload) != SYNTHETIC_PAYLOAD_BYTES or not payload.startswith(SYNTHETIC_PREFIX):
+        _reject("UnsupportedSyntheticPayload")
+    return safe_manifest
+
+
+def validate_inventory(fixtures_root: Path, schema_path: Path) -> None:
+    """Ensure the fixture tree contains only governance files and registered synthetics."""
+    try:
+        root_details = fixtures_root.lstat()
+    except OSError:
+        _reject("InventoryViolation")
+    if not stat.S_ISDIR(root_details.st_mode) or fixtures_root.is_symlink():
+        _reject("InventoryViolation")
+    try:
+        entries = list(os.scandir(fixtures_root))
+    except OSError:
+        _reject("InventoryViolation")
+
+    names = {entry.name for entry in entries}
+    if not {"README.md", "schema"}.issubset(names):
+        _reject("InventoryViolation")
+    for entry in entries:
+        if not _safe_ascii_name(entry.name) or entry.is_symlink():
+            _reject("InventoryViolation")
+        if entry.name == "README.md":
+            if not entry.is_file(follow_symlinks=False):
+                _reject("InventoryViolation")
+            continue
+        if entry.name == "schema":
+            if not entry.is_dir(follow_symlinks=False):
+                _reject("InventoryViolation")
+            schema_entries = list(os.scandir(entry.path))
+            if len(schema_entries) != 1 or schema_entries[0].name != "manifest.schema.json":
+                _reject("InventoryViolation")
+            continue
+        if not entry.is_dir(follow_symlinks=False):
+            _reject("InventoryViolation")
+        children = list(os.scandir(entry.path))
+        if {child.name for child in children} != {"manifest.json", "fixture.bin"}:
+            _reject("InventoryViolation")
+        if any(child.is_symlink() or not child.is_file(follow_symlinks=False) for child in children):
+            _reject("InventoryViolation")
+        validate_fixture(Path(entry.path) / "manifest.json", schema_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate repository-safe synthetic fixtures")
+    parser.add_argument("manifest", nargs="?", type=Path)
+    parser.add_argument("--inventory", type=Path)
+    parser.add_argument(
+        "--schema",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "fixtures" / "schema" / "manifest.schema.json",
+    )
+    arguments = parser.parse_args()
+    try:
+        if arguments.inventory is not None:
+            if arguments.manifest is not None:
+                parser.exit(2, "fixture rejected: InvalidCommand\n")
+            validate_inventory(arguments.inventory, arguments.schema)
+            print("fixture inventory accepted")
+        elif arguments.manifest is not None:
+            manifest = validate_fixture(arguments.manifest, arguments.schema)
+            print(f"fixture accepted: {manifest['fixture']['id']} {manifest['fixture']['sha256']}")
+        else:
+            parser.exit(2, "fixture rejected: InvalidCommand\n")
+    except FixtureRejected as error:
+        parser.exit(1, f"fixture rejected: {error.code}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fixtures/generate_synthetic.py
+++ b/scripts/fixtures/generate_synthetic.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Generate deterministic, generic fixture-governance bytes without networking."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+from pathlib import Path
+
+
+GENERATOR_VERSION = "1"
+HOSTNAMES = ("gs-loc.apple.com", "gs-loc-cn.apple.com")
+SYNTHETIC_PREFIX = b"WLG-SYNTHETIC-GOVERNANCE-V1\x00"
+
+
+def bounded_ascii(value: str, name: str, maximum: int) -> str:
+    if not value or len(value) > maximum or any(ord(char) < 0x20 or ord(char) > 0x7E for char in value):
+        raise ValueError(f"{name} must be 1..{maximum} printable ASCII characters")
+    return value
+
+
+def build_payload(seed: str) -> bytes:
+    """Return generic bytes that make no private-protocol compatibility claim."""
+    seed_digest = hashlib.sha256(seed.encode("ascii")).digest()
+    return SYNTHETIC_PREFIX + seed_digest
+
+
+def _exclusive_write(directory_fd: int, name: str, content: bytes) -> None:
+    flags = (
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = os.open(name, flags, 0o600, dir_fd=directory_fd)
+    try:
+        position = 0
+        while position < len(content):
+            written = os.write(descriptor, content[position:])
+            if written <= 0:
+                raise ValueError("exclusive output write failed")
+            position += written
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def generate(output_dir: Path, fixture_id: str, seed: str, hostname: str) -> dict:
+    bounded_ascii(seed, "seed", 128)
+    if re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", fixture_id) is None:
+        raise ValueError("fixture id has unsafe characters")
+    if hostname not in HOSTNAMES:
+        raise ValueError("hostname is outside the exact allowlist")
+    try:
+        details = output_dir.lstat()
+    except FileNotFoundError:
+        output_dir.mkdir(mode=0o700)
+    else:
+        if output_dir.is_symlink() or not stat.S_ISDIR(details.st_mode):
+            raise ValueError("output directory must be a real directory")
+
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        directory_fd = os.open(str(output_dir), directory_flags)
+    except OSError as error:
+        raise ValueError("output directory cannot be opened safely") from error
+    try:
+        if os.listdir(directory_fd):
+            raise ValueError("output directory must be empty")
+
+        payload = build_payload(seed)
+        payload_name = "fixture.bin"
+        manifest = {
+            "schema_version": "wloc-fixture/v1",
+            "fixture": {
+                "id": fixture_id,
+                "path": payload_name,
+                "media_type": "application/octet-stream",
+                "byte_length": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            },
+            "provenance": {
+                "kind": "project-generated",
+                "generator": "scripts/fixtures/generate_synthetic.py",
+                "generator_version": GENERATOR_VERSION,
+                "source_basis": "project-authored generic bytes; no capture or private protocol source",
+            },
+            "authorization": {
+                "status": "not-required-synthetic",
+                "record_id": "not-applicable",
+            },
+            "ios_version": "not-applicable-synthetic",
+            "hostname": hostname,
+            "alpn": "h2",
+            "classification": "synthetic",
+            "redactions": [],
+        }
+        manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        _exclusive_write(directory_fd, payload_name, payload)
+        _exclusive_write(directory_fd, "manifest.json", manifest_bytes)
+    finally:
+        os.close(directory_fd)
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--fixture-id", required=True)
+    parser.add_argument("--seed", required=True)
+    parser.add_argument("--hostname", required=True, choices=HOSTNAMES)
+    arguments = parser.parse_args()
+    try:
+        generate(arguments.output_dir, arguments.fixture_id, arguments.seed, arguments.hostname)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture governance tests included in repository unittest discovery."""

--- a/tests/fixtures/test_fixture_governance.py
+++ b/tests/fixtures/test_fixture_governance.py
@@ -1,0 +1,318 @@
+"""Executable contract for repository-safe WLOC fixtures.
+
+These tests intentionally exercise generic synthetic bytes only. They contain no
+Apple-private protocol knowledge and never access the network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "fixtures" / "schema" / "manifest.schema.json"
+GUARD_PATH = ROOT / "scripts" / "fixtures" / "fixture_guard.py"
+GENERATOR = ROOT / "scripts" / "fixtures" / "generate_synthetic.py"
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("fixture_guard", GUARD_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("fixture guard cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location("generate_synthetic", GENERATOR)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("synthetic generator cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FixtureGovernanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.guard = load_guard()
+        self.generator = load_generator()
+
+    def _generate(self, destination: Path, seed: str = "offline-seed-01") -> dict:
+        return self.generator.generate(
+            destination,
+            "synthetic-boundary-01",
+            seed,
+            "gs-loc.apple.com",
+        )
+
+    def test_manifest_schema_requires_security_and_provenance_fields(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        required = set(schema["required"])
+        self.assertTrue(
+            {
+                "schema_version",
+                "fixture",
+                "provenance",
+                "authorization",
+                "ios_version",
+                "hostname",
+                "alpn",
+                "classification",
+                "redactions",
+            }.issubset(required)
+        )
+        self.assertEqual(schema["additionalProperties"], False)
+        self.assertEqual(
+            schema["properties"]["hostname"]["enum"],
+            ["gs-loc.apple.com", "gs-loc-cn.apple.com"],
+        )
+        fixture_required = set(schema["properties"]["fixture"]["required"])
+        self.assertTrue({"path", "byte_length", "sha256"}.issubset(fixture_required))
+
+    def test_synthetic_generation_is_offline_deterministic_and_hash_verified(self) -> None:
+        with tempfile.TemporaryDirectory() as first, tempfile.TemporaryDirectory() as second:
+            first_dir, second_dir = Path(first), Path(second)
+            manifest_a = self._generate(first_dir)
+            manifest_b = self._generate(second_dir)
+            payload_a = (first_dir / manifest_a["fixture"]["path"]).read_bytes()
+            payload_b = (second_dir / manifest_b["fixture"]["path"]).read_bytes()
+
+            self.assertEqual(payload_a, payload_b)
+            self.assertEqual(manifest_a, manifest_b)
+            self.assertEqual(
+                manifest_a["fixture"]["sha256"], hashlib.sha256(payload_a).hexdigest()
+            )
+            self.assertEqual(manifest_a["classification"], "synthetic")
+            self.assertEqual(manifest_a["authorization"]["status"], "not-required-synthetic")
+            self.assertEqual(manifest_a["ios_version"], "not-applicable-synthetic")
+            self.guard.validate_fixture(first_dir / "manifest.json", SCHEMA)
+
+        self.assertEqual(
+            self.generator.build_payload("offline-seed-01"),
+            self.generator.build_payload("offline-seed-01"),
+        )
+
+    def test_authorized_classification_requires_consistent_approval_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            manifest["classification"] = "authorized-sanitized-capture"
+            manifest["provenance"]["kind"] = "authorized-lab-capture"
+            manifest["authorization"] = {"status": "approved", "record_id": "approval-17"}
+            manifest["ios_version"] = "17.6.1"
+            manifest["redactions"] = ["device-identifiers", "precise-coordinates"]
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected) as caught:
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+            self.assertEqual(caught.exception.code, "AuthorizedCaptureGateClosed")
+
+    def test_validator_rejects_non_exact_hostname_and_alpn(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            for field, bad_value in (("hostname", "example.invalid"), ("alpn", "http/1.1")):
+                broken = dict(manifest)
+                broken[field] = bad_value
+                (directory / "manifest.json").write_text(json.dumps(broken), encoding="utf-8")
+                with self.subTest(field=field), self.assertRaises(self.guard.FixtureRejected):
+                    self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+    def test_sanitizer_rejects_sensitive_identifiers_secrets_and_precise_coordinates(self) -> None:
+        prohibited = {
+            "bearer token": ("Bearer " + "eyJ" + ".fixture.token").encode(),
+            "private key": ("-----BEGIN " + "PRIVATE KEY-----\nnot-a-key").encode(),
+            "mac": ("device_mac=" + ":".join(["02", "11", "22", "33", "44", "55"])).encode(),
+            "imei": b"imei=" + b"123456789012345",
+            "udid": b"udid=" + (b"a" * 40),
+            "device id": b"device_id=dedicated-phone-01",
+            "precise coordinates": b'{"latitude":0.123456,"longitude":0.654321}',
+        }
+        for name, payload in prohibited.items():
+            with self.subTest(name=name), self.assertRaises(self.guard.FixtureRejected):
+                self.guard.inspect_payload(payload, filename="fixture.bin")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            manifest["provenance"]["source_basis"] = "token=" + "fixture-secret-value"
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+    def test_sanitizer_rejects_raw_capture_formats_and_magic(self) -> None:
+        for filename in (
+            "traffic.pcap",
+            "traffic.pcapng",
+            "traffic.har",
+            "session.keys",
+            "identity.pem",
+            "profile.mobileconfig",
+            "capture.zip",
+        ):
+            with self.subTest(filename=filename), self.assertRaises(self.guard.FixtureRejected):
+                self.guard.inspect_payload(b"generic", filename=filename)
+
+        with self.assertRaises(self.guard.FixtureRejected):
+            self.guard.inspect_payload(bytes.fromhex("d4c3b2a1") + b"generic", filename="fixture.bin")
+
+    def test_size_schema_path_and_hash_limits_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary) / "path-case"
+            manifest = self._generate(directory)
+
+            manifest["fixture"]["path"] = "../outside.bin"
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+            directory = Path(temporary) / "hash-case"
+            manifest = self._generate(directory)
+            manifest["fixture"]["sha256"] = "0" * 64
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+            directory = Path(temporary) / "unknown-case"
+            manifest = self._generate(directory)
+            manifest["unknown"] = "must fail closed"
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            oversized = Path(temporary) / "fixture.bin"
+            oversized.write_bytes(b"x" * (self.guard.MAX_PAYLOAD_BYTES + 1))
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.inspect_file(oversized)
+
+    def test_schema_size_and_duplicate_json_keys_are_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            self._generate(directory)
+            oversized_schema = directory / "oversized-schema.json"
+            oversized_schema.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "padding": "x" * (self.guard.MAX_SCHEMA_BYTES + 1),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", oversized_schema)
+
+            (directory / "manifest.json").write_text(
+                '{"schema_version":"wloc-fixture/v1","schema_version":"duplicate"}',
+                encoding="utf-8",
+            )
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+    def test_generator_refuses_symlink_output_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            external = directory / "external.bin"
+            external.write_bytes(b"must-remain-unchanged")
+            output = directory / "output"
+            output.mkdir()
+            (output / "fixture.bin").symlink_to(external)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(GENERATOR),
+                    "--output-dir",
+                    str(output),
+                    "--fixture-id",
+                    "synthetic-boundary-01",
+                    "--seed",
+                    "offline-seed-01",
+                    "--hostname",
+                    "gs-loc.apple.com",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(external.read_bytes(), b"must-remain-unchanged")
+
+    def test_validator_rejects_malformed_nested_and_mismatched_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary) / "invalid-utf8"
+            manifest = self._generate(directory)
+
+            (directory / "manifest.json").write_bytes(b"\xffnot-utf8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+            directory = Path(temporary) / "nested"
+            directory.mkdir()
+            nested: object = "too-deep"
+            for _ in range(self.guard.MAX_JSON_DEPTH + 2):
+                nested = [nested]
+            (directory / "manifest.json").write_text(json.dumps(nested), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+            directory = Path(temporary) / "length"
+            manifest = self._generate(directory)
+            manifest["fixture"]["byte_length"] += 1
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", SCHEMA)
+
+            invalid_schema = directory / "invalid-schema.json"
+            invalid_schema.write_text('{"$schema":"unexpected"}', encoding="utf-8")
+            with self.assertRaises(self.guard.FixtureRejected):
+                self.guard.validate_fixture(directory / "manifest.json", invalid_schema)
+
+    def test_generator_and_validator_cli_entrypoints_are_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            generator_args = [
+                str(GENERATOR),
+                "--output-dir",
+                str(directory),
+                "--fixture-id",
+                "synthetic-cli-01",
+                "--seed",
+                "cli-seed",
+                "--hostname",
+                "gs-loc-cn.apple.com",
+            ]
+            with patch.object(sys, "argv", generator_args):
+                self.assertEqual(self.generator.main(), 0)
+
+            guard_args = [
+                str(GUARD_PATH),
+                str(directory / "manifest.json"),
+                "--schema",
+                str(SCHEMA),
+            ]
+            output = io.StringIO()
+            with patch.object(sys, "argv", guard_args), redirect_stdout(output):
+                self.assertEqual(self.guard.main(), 0)
+            self.assertIn("fixture accepted: synthetic-cli-01", output.getvalue())
+
+            with self.assertRaises(ValueError):
+                self.generator.generate(directory, "BAD ID", "seed", "gs-loc.apple.com")
+            with self.assertRaises(ValueError):
+                self.generator.generate(directory, "safe-id", "", "gs-loc.apple.com")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/test_fixture_security_review.py
+++ b/tests/fixtures/test_fixture_security_review.py
@@ -1,0 +1,234 @@
+"""Regression tests for the Phase 0 protocol and security review findings."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "fixtures" / "schema" / "manifest.schema.json"
+GUARD_PATH = ROOT / "scripts" / "fixtures" / "fixture_guard.py"
+GENERATOR_PATH = ROOT / "scripts" / "fixtures" / "generate_synthetic.py"
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("test module cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FixtureSecurityReviewTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.guard = load_module("fixture_guard_security", GUARD_PATH)
+        self.generator = load_module("generate_synthetic_security", GENERATOR_PATH)
+
+    def _generate(self, directory: Path) -> dict:
+        return self.generator.generate(
+            directory,
+            "synthetic-security-01",
+            "review-seed",
+            "gs-loc.apple.com",
+        )
+
+    def _assert_rejected(self, expected_code: str, operation) -> None:
+        with self.assertRaises(self.guard.FixtureRejected) as caught:
+            operation()
+        self.assertEqual(caught.exception.code, expected_code)
+        self.assertEqual(str(caught.exception), expected_code)
+
+    def test_canonical_schema_digest_and_manual_constants_are_pinned(self) -> None:
+        schema_bytes = SCHEMA.read_bytes()
+        schema = json.loads(schema_bytes)
+        self.assertEqual(hashlib.sha256(schema_bytes).hexdigest(), self.guard.TRUSTED_SCHEMA_SHA256)
+        self.assertEqual(
+            tuple(schema["properties"]["hostname"]["enum"]), self.guard.ALLOWED_HOSTNAMES
+        )
+        self.assertEqual(
+            schema["properties"]["fixture"]["properties"]["byte_length"]["maximum"],
+            self.guard.MAX_PAYLOAD_BYTES,
+        )
+        self.assertEqual(
+            schema["properties"]["classification"]["enum"],
+            ["synthetic", "authorized-sanitized-capture"],
+        )
+
+    def test_authorized_capture_is_unconditionally_gate_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            manifest["classification"] = "authorized-sanitized-capture"
+            manifest["authorization"] = {"status": "approved", "record_id": "self-declared"}
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            self._assert_rejected(
+                "AuthorizedCaptureGateClosed",
+                lambda: self.guard.validate_fixture(directory / "manifest.json", SCHEMA),
+            )
+
+    def test_schema_describes_future_external_authorization_evidence(self) -> None:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        authorization = schema["$defs"]["captureAuthorization"]
+        self.assertTrue(
+            {
+                "creator",
+                "created_at",
+                "protocol_review",
+                "security_review",
+                "clean_room_attestation",
+                "raw_retention",
+                "sanitizer",
+                "redaction_evidence",
+            }.issubset(set(authorization["required"]))
+        )
+        reviewer_required = set(schema["$defs"]["reviewAttestation"]["required"])
+        self.assertEqual(reviewer_required, {"agent_id", "capabilities", "verdict"})
+        evidence_required = set(schema["$defs"]["redactionEvidence"]["required"])
+        self.assertEqual(
+            evidence_required,
+            {"secrets", "device_ids", "network_ids", "precise_location", "raw_body"},
+        )
+
+    def test_high_confidence_sensitive_encodings_are_rejected(self) -> None:
+        candidates = {
+            "github pat": ("gh" + "p_" + "A" * 40).encode(),
+            "github fine-grained pat": ("github" + "_pat_" + "A" * 40).encode(),
+            "openai": ("s" + "k-proj-" + "A" * 32).encode(),
+            "aws": ("AK" + "IA" + "A" * 16).encode(),
+            "jwt": ("eyJ" + "hbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature123").encode(),
+            "bare mac": ":".join(["02", "11", "22", "33", "44", "55"]).encode(),
+            "bare hyphen mac": "-".join(["02", "11", "22", "33", "44", "55"]).encode(),
+            "bare imei": b"0" * 15,
+            "bare udid": b"a" * 40,
+            "bare modern udid": ("00008101-" + "a" * 16).encode(),
+            "coordinate array": b"[0.123456,0.654321]",
+            "renamed har": b'{"log":{"version":"1.2","entries":[]}}',
+        }
+        for name, payload in candidates.items():
+            with self.subTest(name=name):
+                self._assert_rejected(
+                    "SensitiveContent",
+                    lambda payload=payload: self.guard.inspect_payload(payload, "fixture.bin"),
+                )
+
+        utf16_secret = ("token=" + "encoded-secret-value").encode("utf-16-le")
+        self._assert_rejected(
+            "SensitiveContent",
+            lambda: self.guard.inspect_payload(utf16_secret, "fixture.bin"),
+        )
+
+    def test_only_fixed_synthetic_payload_format_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            payload = directory / "fixture.bin"
+            payload.write_bytes(b"unknown-binary-format\x00\x01")
+            changed = payload.read_bytes()
+            manifest["fixture"]["byte_length"] = len(changed)
+            manifest["fixture"]["sha256"] = hashlib.sha256(changed).hexdigest()
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            self._assert_rejected(
+                "UnsupportedSyntheticPayload",
+                lambda: self.guard.validate_fixture(directory / "manifest.json", SCHEMA),
+            )
+
+    def test_fake_or_modified_schema_and_bidi_paths_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            fake_schema = directory / "schema.json"
+            fake_schema.write_text(SCHEMA.read_text(encoding="utf-8") + " ", encoding="utf-8")
+            self._assert_rejected(
+                "UntrustedSchema",
+                lambda: self.guard.validate_fixture(directory / "manifest.json", fake_schema),
+            )
+
+            manifest["fixture"]["path"] = "safe\u202egnp.exe"
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            self._assert_rejected(
+                "UnsafePath",
+                lambda: self.guard.validate_fixture(directory / "manifest.json", SCHEMA),
+            )
+
+    def test_redactions_non_string_is_a_controlled_rejection(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            manifest = self._generate(directory)
+            manifest["redactions"] = [{}]
+            (directory / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            self._assert_rejected(
+                "InvalidRedactions",
+                lambda: self.guard.validate_fixture(directory / "manifest.json", SCHEMA),
+            )
+
+    def test_repository_inventory_rejects_orphans_and_renamed_captures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            inventory = Path(temporary)
+            (inventory / "schema").mkdir()
+            (inventory / "README.md").write_text("fixture inventory\n", encoding="utf-8")
+            shutil.copyfile(SCHEMA, inventory / "schema" / "manifest.schema.json")
+            self._generate(inventory / "synthetic-security-01")
+            self.guard.validate_inventory(inventory, inventory / "schema" / "manifest.schema.json")
+
+            for name, content in (
+                ("orphan.bin", b"orphan"),
+                ("renamed.bin", b'{"log":{"version":"1.2","entries":[]}}'),
+                ("capture.pcap", bytes.fromhex("d4c3b2a1") + b"capture"),
+            ):
+                candidate = inventory / name
+                candidate.write_bytes(content)
+                with self.subTest(name=name):
+                    self._assert_rejected(
+                        "InventoryViolation",
+                        lambda: self.guard.validate_inventory(
+                            inventory, inventory / "schema" / "manifest.schema.json"
+                        ),
+                    )
+                candidate.unlink()
+
+    def test_safe_open_rejects_symlink_and_generator_never_overwrites(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            external = root / "external"
+            external.write_bytes(b"unchanged")
+            output = root / "output"
+            output.mkdir()
+            (output / "existing.txt").write_text("occupied", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                self._generate(output)
+            self.assertEqual((output / "existing.txt").read_text(encoding="utf-8"), "occupied")
+
+            empty = root / "empty"
+            empty.mkdir()
+            (empty / "fixture.bin").symlink_to(external)
+            with self.assertRaises(ValueError):
+                self._generate(empty)
+            self.assertEqual(external.read_bytes(), b"unchanged")
+
+            broken = root / "broken-output"
+            broken.symlink_to(root / "missing-target", target_is_directory=True)
+            with self.assertRaises(ValueError):
+                self._generate(broken)
+
+            generated = root / "generated"
+            self._generate(generated)
+            replacement = root / "replacement"
+            replacement.write_bytes((generated / "fixture.bin").read_bytes())
+            (generated / "fixture.bin").unlink()
+            (generated / "fixture.bin").symlink_to(replacement)
+            self._assert_rejected(
+                "UnsafeFile",
+                lambda: self.guard.validate_fixture(generated / "manifest.json", SCHEMA),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2

## Objective

Close the Phase 0 fixture governance gate. The remediation agent completed the
code but hit its API quota before reporting; this PR records the completed
differential review and full repository verification.

## Changes

- `fixtures/schema/manifest.schema.json` — canonical manifest schema, pinned
  by `TRUSTED_SCHEMA_SHA256`.
- `scripts/fixtures/fixture_guard.py` — fail-closed validator: authorized
  capture classification is unconditionally gate-closed; only the exact
  project-generated synthetic format passes. Payload scanning rejects capture
  magics, credentials, device identifiers, MACs, Luhn-verified IMEIs,
  coordinates, TLS key material, and HTTP traces. `O_NOFOLLOW` opens,
  duplicate-key/depth limits, exact inventory structure, size/hash bounds.
- `scripts/fixtures/generate_synthetic.py` — offline deterministic generator.
- `tests/fixtures/` — 20 tests (11 governance + 9 security review).

## Evidence

- `python3 -m pytest tests/fixtures/ -q`: 20 passed
- `python3 -m unittest discover -s tests -p 'test_*.py'`: 26 tests OK
- `./scripts/ci/verify.sh`: repository gates passed
- `git diff --check`: clean

Differential review confirms all three original findings are remediated:
self-declared authorization (gate-closed), binary scanning (magics + patterns),
and schema trust (pinned digest).

## Risks and rollback

- Parser/protocol work stays blocked on this gate until merged; merge only
  unblocks future synthetic-fixture-based development.
- Rollback: revert the commit; the previous fixture governance state is
  restored (only READMEs).

## Handoff capsule: `.handoffs/issue-2.md`