### PR TITLE
docs: define isolated dual-stack WLOC traffic model

### DIFF
--- a/.handoffs/issue-6.md
+++ b/.handoffs/issue-6.md
@@ -1,0 +1,74 @@
+# Agent handoff: Issue 6
+
+## Identity and scope
+
+- Source agent ID: codex-network-adr
+- Capabilities used: openwrt,security,network
+- Branch: codex/issue-6-traffic-isolation-codex-network-adr-20260811114252-b17aaab4
+- Checkpoint parent: a68bc55693309629510a4f8c873b0cf80587740c
+- Updated at (UTC): 2026-08-13T05:18:00Z
+- Credentials included: no
+
+## Objective
+
+Freeze and test the isolated OpenWrt dual-stack traffic model before any live redirect implementation is accepted.
+
+## Completed
+
+- Selected a unified IPv4/IPv6 lifecycle; scoped AAAA suppression remains a superseding-ADR fallback only.
+- Defined exact one-device, two-hostname, TCP 443 matching in a dedicated `wificalling_location` table.
+- Prohibited Gateway table changes, global flushes, ordinary HTTPS capture, and UDP 500/4500 interception.
+- Modeled short-lived kernel leases, health-gated renewal, startup/reboot without leases, and ordered idempotent teardown.
+- Added deterministic DNS A/AAAA rotation, lifecycle, rendered-plan, and semantic-delta tests.
+
+## Files changed
+
+- `docs/openwrt/traffic-isolation.md`
+- `openwrt/tests/TRAFFIC_ISOLATION_TEST_PLAN.md`
+- `tests/network/README.md`
+- `tests/network/__init__.py`
+- `tests/network/test_traffic_isolation.py`
+- `tests/network/traffic_isolation_model.py`
+- `.handoffs/issue-6.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `python3 -m unittest discover -s tests/network -p 'test_*.py' -v` | Passed | 21/21 network tests |
+| `./scripts/ci/verify.sh` | Passed | 27/27 tests plus secret scan |
+| `git diff --check` | Passed | No whitespace errors |
+
+## Failed attempts
+
+- The first RED run failed because the traffic-isolation model did not exist.
+- The second RED run exposed missing DNS record reconciliation before the minimum model was implemented.
+
+## Unresolved decisions and blockers
+
+- Independent OpenWrt/network/security review is still required; this checkpoint is intentionally opened as a draft PR.
+- The 15-second lease, 5-second renewal, and 20-second recovery gate are design targets until measured on AX6S.
+- No real nftables, dnsmasq, procd, root, router, or device mutation is included.
+
+## Next executable steps
+
+1. Perform independent network/security review and close all P0/P1/P2 findings.
+2. Rebase onto current main and reconcile this model with the Issue 17 implementation.
+3. Measure failure recovery and semantic isolation on AX6S before enabling a live redirect.
+
+## Capabilities required for the next Agent
+
+- openwrt
+- network
+- security
+- test
+
+## Environment assumptions
+
+- Python 3 and POSIX shell are sufficient for this offline model.
+- Router access and credentials are not required for review.
+
+## Security and privacy notes
+
+- No secrets, keys, raw captures, device identifiers, precise locations, or production traffic are included.
+- Passing the model tests does not prove a live router implementation.

--- a/docs/openwrt/traffic-isolation.md
+++ b/docs/openwrt/traffic-isolation.md
@@ -1,0 +1,176 @@
+# ADR: isolated OpenWrt traffic and IPv6 lifecycle
+
+Status: proposed for independent network and security review. This ADR and its
+tests are offline design evidence only. They do not authorize or contain live
+`nft`, `dnsmasq`, `procd`, router, CA, MITM, or device operations.
+
+## Decision
+
+Use one complete dual-stack lifecycle. IPv4 and IPv6 each have an assigned
+device set, an exact-WLOC destination set, a kernel-expiring live-lease set,
+and a redirect predicate. Both address families must be healthy before either
+can intercept. There is no IPv4-only degraded interception mode.
+
+The alternative—suppressing AAAA only for the assigned device and the two WLOC
+names—is rejected for this design. The known AX6S constraints (memory, storage,
+and existing IPv4-only Gateway policy) do not establish that two small IPv6
+sets and a symmetric rule are infeasible. Full dual stack also avoids a special
+DNS answer path and preserves ordinary IPv6 semantics. A later AX6S capability
+test must still prove timeout elements and IPv6 redirect behavior. If that test
+fails, interception stays disabled; switching to scoped AAAA suppression
+requires a superseding reviewed ADR and new negative-isolation tests.
+
+## Scope and ownership
+
+The future implementation may own only the fully named `inet`
+`wificalling_location` table and objects within it. It must never reuse,
+modify, flush, rename, or depend on `wificalling_gateway`, the global ruleset,
+another table, or the running sing-box configuration.
+
+A connection is eligible only when every predicate is true:
+
+1. its source is the currently assigned single test device in the matching
+   IPv4 or IPv6 source set;
+2. its destination is a current, unexpired A or AAAA address learned from
+   exactly `gs-loc.apple.com` or `gs-loc-cn.apple.com`;
+3. it is TCP destination port 443;
+4. the matching assigned-device key has a live kernel timeout element; and
+5. TLS ingress independently confirms one exact approved hostname before any
+   leaf signing or proxying.
+
+An IP set is routing containment, not hostname authentication. Shared or
+poisoned destination addresses therefore cannot bypass the independent TLS
+hostname check. Other devices, ordinary HTTPS, router management, sing-box
+management/health traffic, and every UDP flow—including IPsec ports 500 and
+4500—bypass the component.
+
+## Declarative object plan
+
+Issue #6 deliberately freezes semantics rather than executable syntax. The
+machine-readable renderer in `tests/network/traffic_isolation_model.py` emits
+`offline-review-manifest/v1` dictionaries with `executable: false`. Future
+OpenWrt code must be derived in a separate implementation Issue and reviewed
+against these manifests.
+
+The table has symmetric logical objects:
+
+| Purpose | IPv4 | IPv6 | Required behavior |
+|---|---|---|---|
+| assigned source | one address | one address | drift disables both families |
+| WLOC destination | current A set | current AAAA set | exact-name observations, TTL expiry |
+| live lease | assigned-device key | assigned-device key | kernel timeout element |
+| redirect | scoped predicate | scoped predicate | requires the live lease |
+
+No object has a wildcard source, wildcard hostname, default route prefix, UDP
+match, or broad HTTPS match. Rule handles are implementation details; teardown
+resolves only objects carrying the project-owned names and refuses ambiguous
+ownership.
+
+## DNS rotation and reload
+
+Only answers originating from the two complete names may enter a generation.
+Only syntactically valid A and AAAA records are accepted. Each element expires
+at its authoritative record TTL; expired addresses cannot be copied into a new
+generation. An update builds both family sets off-path and atomically replaces
+the owned generation, so address rotation cannot mix old A records with new
+AAAA records.
+
+A dnsmasq reload rebuilds the owned generation from fresh exact-name answers.
+Until both family paths are ready, the live lease is absent. Empty A or AAAA is
+not silently treated as complete dual-stack readiness; an explicitly proven
+IPv6-only or IPv4-only upstream condition must be represented by the later
+implementation state machine and independently tested before it can enable.
+No global IPv6 setting or answer is changed.
+
+Device IPv4 or IPv6 address/lease drift is a scope fault: stop renewal, remove
+both live leases and the redirect, then repopulate both source sets from the
+validated binding. An address learned for a second LAN device never enters the
+sets.
+
+## Kernel lease and recovery bound
+
+The design freezes a 15-second kernel element TTL and a 5-second healthy
+renewal cadence. Startup and reboot create no live lease. The external
+supervisor renews only while the engine, exact scope, DNS A and AAAA
+generations, both address-family paths, and watchdog ownership are healthy.
+A PID or procd respawn state is not health.
+
+If the engine fails while the supervisor runs, the supervisor stops renewal,
+removes both lease elements, then removes and verifies absence of the owned
+redirect before any engine restart. If the supervisor is killed, OOM-terminated,
+wedged, or unscheduled, renewal stops; the kernel expires the element and any
+residual rule becomes inert without userspace help.
+
+The offline model proves ordering, not AX6S timing. Before real-device testing,
+kernel tests must measure engine kill, supervisor kill, OOM, scheduler delay,
+and crash-loop cases. Acceptance is expiry no later than 20 seconds after the
+last successful renewal, with the raw maximum recorded. Any miss leaves the
+feature disabled and requires a reviewed bound change; it cannot be waived by
+calling reboot the rollback mechanism.
+
+## Ordered lifecycle
+
+Enable is fail-closed until its final two operations:
+
+1. validate one device, two exact names, TCP 443, object ownership, and bounds;
+2. build and validate current A and AAAA generations;
+3. prove the unified IPv4/IPv6 path and device binding;
+4. start the engine in pass-through mode and prove engine health;
+5. arm the external watchdog while the lease is absent;
+6. install the owned redirect last, with mandatory live-lease membership;
+7. create or renew the lease only while every earlier gate remains healthy.
+
+Disable and active fault handling prioritize recovery and are idempotent:
+
+1. stop renewal and delete both live-lease elements;
+2. block new installs;
+3. remove only the owned redirect and verify semantic absence;
+4. disarm watchdog ownership;
+5. drain or terminate the engine;
+6. remove owned destination/source sets and temporary state as requested.
+
+Repeated disable with every owned object absent succeeds without changing any
+unrelated state. Failure to verify absence reports hard degraded state and does
+not claim recovery.
+
+## procd boundary
+
+The future procd service starts pass-through only and uses bounded respawn. An
+external health owner, not the engine and not the PID file, controls renewal.
+Respawn cannot recreate a lease, inherit a lease, or install redirect. The
+service's start/reload/restart/reboot paths all begin with lease absence and
+must re-run every gate. Its stop path follows the disable order above.
+
+## Semantic before/after proof
+
+Every privileged integration test must capture normalized semantic state
+before enable, after enable, after fault, after disable, and after reboot.
+Normalization includes table/chain/set names, families, hooks, priorities,
+predicates, ownership, timeout semantics, and DNS generations while excluding
+volatile counters and handles.
+
+The proof passes only when:
+
+- enable adds or changes `wificalling_location` objects and nothing else;
+- the normalized `wificalling_gateway` and unrelated-state hashes are equal
+  before and after every operation;
+- packet tests show redirects only for both approved IPv4/IPv6 cases;
+- other devices, ordinary HTTPS, router/sing-box management, and UDP 500/4500
+  have zero WLOC redirect hits; and
+- stop, kill/OOM recovery, lease expiry, dnsmasq reload, and reboot return to
+  the original unrelated-state snapshot.
+
+Text diffs alone are insufficient because handles and counters can obscure a
+semantic change. The offline `semantic_delta` test models this allowlist; a
+later privileged harness must inspect actual kernel state without global flush.
+
+## Test gates and non-goals
+
+The offline suite verifies renderer safety, exact flow classification, DNS
+TTL/rotation, lifecycle order, kill/OOM behavior, watchdog lease expiry, reboot,
+idempotent disable, and before/after isolation. The later OpenWrt harness must
+repeat these cases in a namespace/QEMU environment before AX6S measurement.
+
+This ADR does not implement rules, edit configuration, require root, generate
+certificates, use production traffic, connect a device, or authorize live
+router mutation. Gateway 1.7 remains a read-only external dependency.

--- a/openwrt/tests/TRAFFIC_ISOLATION_TEST_PLAN.md
+++ b/openwrt/tests/TRAFFIC_ISOLATION_TEST_PLAN.md
@@ -1,0 +1,30 @@
+# OpenWrt traffic-isolation test plan
+
+This is a staged test plan, not a deployment script. Issue #6 runs only Stage
+0. Stages 1–3 require later Issues and their explicit authorization.
+
+| Stage | Environment | Evidence | Gate |
+|---|---|---|---|
+| 0 | unprivileged Python | declarative render, flow/state model, semantic diff | required for ADR review |
+| 1 | isolated network namespace | actual nft/dns behavior; no host rules | required before QEMU |
+| 2 | OpenWrt QEMU | procd, dnsmasq reload, reboot, kill/OOM | required before AX6S |
+| 3 | authorized AX6S window | timeout measurements and semantic snapshots | required before device |
+
+## Common matrix
+
+- exact assigned IPv4 + each exact hostname + TCP 443 + live lease;
+- exact assigned IPv6 + each exact hostname + TCP 443 + live lease;
+- second device, source-binding drift, suffix/wildcard name, ordinary HTTPS;
+- UDP 500/4500, router management, sing-box management and health traffic;
+- A/AAAA addition, expiry, rotation, empty family, and dnsmasq reload;
+- engine kill, engine OOM, supervisor kill/OOM, scheduler delay, crash loop;
+- enable failure at every gate, repeated disable, rollback, and reboot;
+- normalized before/enable/fault/disable/reboot semantic snapshots.
+
+Stage 3 freezes the observed maximum from last successful lease renewal to
+kernel expiry. With the 15-second TTL, the gate is at most 20 seconds. The test
+must fail if a residual redirect remains active, any unrelated semantic hash
+changes, or either Gateway/IPsec path records a WLOC redirect hit.
+
+No stage may run on a real router or device merely because the offline tests
+pass. Each stage needs its own Issue, rollback owner, and approval.

--- a/tests/network/README.md
+++ b/tests/network/README.md
@@ -1,0 +1,25 @@
+# Issue #6 TDD evidence
+
+Journeys were derived from Issue #6, `DEVELOPMENT_TEST_PLAN.md`, and the
+reviewed Issue #3 threat/fail-open candidates.
+
+| Guarantee | Test | Type |
+|---|---|---|
+| only the dedicated table is represented; Gateway/global/IPsec are absent | `RenderedPlanTests` | contract |
+| IPv4 and IPv6 use the same exact source/destination/TCP/lease scope | `RenderedPlanTests`, `FlowIsolationTests` | unit |
+| exact A/AAAA generations rotate atomically and TTL-expired entries disappear | `DnsRotationTests` | unit |
+| startup/reboot have no lease; redirect is installed last | `LifecycleTests` | state model |
+| disable is idempotent and network recovery precedes process stop | `LifecycleTests` | state model |
+| engine kill/OOM removes redirect; supervisor loss becomes inert on expiry | `LifecycleTests` | failure model |
+| before/after proof permits changes only to owned objects | `SemanticProofTests` | contract |
+
+RED evidence:
+
+- initial run failed importing the absent `traffic_isolation_model`;
+- DNS rotation extension failed importing absent `Record` and
+  `reconcile_dns_generation`.
+
+GREEN command: `python3 -m unittest tests.network.test_traffic_isolation`.
+The suite is offline and unprivileged. It does not claim kernel, QEMU, AX6S, or
+real-device coverage; those gaps are explicit staged gates in
+`openwrt/tests/TRAFFIC_ISOLATION_TEST_PLAN.md`.

--- a/tests/network/__init__.py
+++ b/tests/network/__init__.py
@@ -1,0 +1,1 @@
+"""Offline network-contract tests."""

--- a/tests/network/test_traffic_isolation.py
+++ b/tests/network/test_traffic_isolation.py
@@ -1,0 +1,230 @@
+import json
+import unittest
+
+from tests.network.traffic_isolation_model import (
+    APPROVED_HOSTS,
+    Event,
+    Flow,
+    Lifecycle,
+    Record,
+    build_dns_plan,
+    build_nft_plan,
+    build_procd_plan,
+    classify_flow,
+    reconcile_dns_generation,
+    semantic_delta,
+)
+
+
+class RenderedPlanTests(unittest.TestCase):
+    def setUp(self):
+        self.nft = build_nft_plan(lease_ttl_seconds=15)
+        self.dns = build_dns_plan(record_ttl_seconds=60)
+        self.procd = build_procd_plan()
+        self.rendered = json.dumps(
+            {"nft": self.nft, "dns": self.dns, "procd": self.procd},
+            sort_keys=True,
+        )
+
+    def test_plan_owns_one_dedicated_table_and_never_gateway_or_global_state(self):
+        self.assertEqual(self.nft["table"], "wificalling_location")
+        self.assertEqual(self.nft["family"], "inet")
+        self.assertEqual(self.nft["ownership"], "project-only")
+        forbidden = (
+            "wificalling_gateway",
+            "flush ruleset",
+            '"table": "filter"',
+            '"table": "nat"',
+        )
+        for token in forbidden:
+            self.assertNotIn(token, self.rendered)
+
+    def test_nft_plan_has_symmetric_ipv4_ipv6_scope_and_kernel_leases(self):
+        self.assertEqual(self.nft["ipv6_mode"], "full-dual-stack")
+        for family in ("ipv4", "ipv6"):
+            scope = self.nft["scope"][family]
+            self.assertEqual(scope["source_cardinality"], 1)
+            self.assertEqual(scope["destination_source"], "exact-dns-allowlist")
+            self.assertEqual(scope["transport"], "tcp")
+            self.assertEqual(scope["destination_port"], 443)
+            self.assertEqual(scope["lease"]["kind"], "kernel-timeout-element")
+            self.assertEqual(scope["lease"]["ttl_seconds"], 15)
+            self.assertTrue(scope["redirect_requires_live_lease"])
+
+    def test_dns_plan_tracks_only_exact_a_and_aaaa_records_with_ttl_rotation(self):
+        self.assertEqual(tuple(self.dns["hostnames"]), APPROVED_HOSTS)
+        self.assertEqual(self.dns["record_types"], ["A", "AAAA"])
+        self.assertEqual(self.dns["update"], "atomic-generation-replace")
+        self.assertEqual(self.dns["expiry"], "authoritative-record-ttl")
+        self.assertEqual(self.dns["record_ttl_seconds"], 60)
+        self.assertFalse(self.dns["global_ipv6_disable"])
+        self.assertFalse(self.dns["aaaa_suppression"])
+
+    def test_procd_plan_cannot_create_or_renew_lease_without_all_health_gates(self):
+        self.assertEqual(self.procd["startup_lease"], "absent")
+        self.assertEqual(self.procd["reboot_lease"], "absent")
+        self.assertEqual(
+            self.procd["renew_only_when"],
+            ["engine", "scope", "dns-a", "dns-aaaa", "ipv4", "ipv6", "watchdog"],
+        )
+        self.assertEqual(self.procd["fault_action"], "stop-renewal-then-remove-owned-redirect")
+
+    def test_rendered_plans_contain_no_ipsec_or_broad_redirect(self):
+        for token in ("udp", "500", "4500", "0.0.0.0/0", "::/0", "all-https"):
+            self.assertNotIn(token, self.rendered.lower())
+
+    def test_lease_ttl_is_short_and_bounded(self):
+        for invalid_ttl in (0, 4, 61, 3600):
+            with self.assertRaises(ValueError):
+                build_nft_plan(lease_ttl_seconds=invalid_ttl)
+
+
+class FlowIsolationTests(unittest.TestCase):
+    def test_only_assigned_ipv4_wloc_tcp443_with_live_lease_redirects(self):
+        flow = Flow("ipv4", True, "gs-loc.apple.com", "tcp", 443, True)
+        self.assertEqual(classify_flow(flow), "redirect")
+
+    def test_only_assigned_ipv6_wloc_tcp443_with_live_lease_redirects(self):
+        flow = Flow("ipv6", True, "gs-loc-cn.apple.com", "tcp", 443, True)
+        self.assertEqual(classify_flow(flow), "redirect")
+
+    def test_other_devices_and_ordinary_https_bypass(self):
+        cases = (
+            Flow("ipv4", False, "gs-loc.apple.com", "tcp", 443, True),
+            Flow("ipv6", False, "gs-loc-cn.apple.com", "tcp", 443, True),
+            Flow("ipv4", True, "example.com", "tcp", 443, True),
+            Flow("ipv6", True, "apple.com", "tcp", 443, True),
+            Flow("ipv4", True, "evil.gs-loc.apple.com", "tcp", 443, True),
+        )
+        self.assertTrue(all(classify_flow(case) == "bypass" for case in cases))
+
+
+class DnsRotationTests(unittest.TestCase):
+    def test_a_and_aaaa_rotation_replaces_generation_and_drops_expired_records(self):
+        records = (
+            Record("gs-loc.apple.com", "A", "192.0.2.10", 1060),
+            Record("gs-loc.apple.com", "AAAA", "2001:db8::10", 1060),
+            Record("gs-loc-cn.apple.com", "A", "192.0.2.20", 999),
+            Record("gs-loc-cn.apple.com", "AAAA", "2001:db8::20", 1060),
+        )
+        generation = reconcile_dns_generation(records, now=1000, generation=8)
+        self.assertEqual(generation["generation"], 9)
+        self.assertEqual(generation["ipv4"], ["192.0.2.10"])
+        self.assertEqual(generation["ipv6"], ["2001:db8::10", "2001:db8::20"])
+        self.assertEqual(generation["replace"], "atomic")
+
+    def test_dns_rotation_rejects_nonexact_host_or_record_type(self):
+        invalid = (
+            Record("evil.gs-loc.apple.com", "A", "192.0.2.10", 1060),
+            Record("gs-loc.apple.com", "CNAME", "alias.example", 1060),
+        )
+        for record in invalid:
+            with self.assertRaises(ValueError):
+                reconcile_dns_generation((record,), now=1000, generation=1)
+
+    def test_dns_rotation_rejects_record_type_address_family_mismatch(self):
+        with self.assertRaises(ValueError):
+            reconcile_dns_generation(
+                (Record("gs-loc.apple.com", "A", "2001:db8::10", 1060),),
+                now=1000,
+                generation=1,
+            )
+
+    def test_ipsec_and_missing_lease_always_bypass(self):
+        cases = (
+            Flow("ipv4", True, "gs-loc.apple.com", "udp", 500, True),
+            Flow("ipv6", True, "gs-loc.apple.com", "udp", 4500, True),
+            Flow("ipv4", True, "gs-loc.apple.com", "tcp", 443, False),
+            Flow("ipv6", True, "gs-loc-cn.apple.com", "tcp", 443, False),
+        )
+        self.assertTrue(all(classify_flow(case) == "bypass" for case in cases))
+
+
+class LifecycleTests(unittest.TestCase):
+    def test_redirect_cannot_install_before_scope_dual_stack_engine_and_watchdog(self):
+        with self.assertRaises(ValueError):
+            Lifecycle.startup().apply(Event.INSTALL_REDIRECT)
+
+    def test_enable_installs_redirect_last_and_renews_lease_after_it(self):
+        lifecycle = Lifecycle.startup()
+        for event in (
+            Event.VALIDATE_SCOPE,
+            Event.VERIFY_DUAL_STACK,
+            Event.START_PASSTHROUGH,
+            Event.PROVE_ENGINE_HEALTH,
+            Event.ARM_WATCHDOG,
+            Event.INSTALL_REDIRECT,
+            Event.RENEW_LEASE,
+        ):
+            lifecycle = lifecycle.apply(event)
+        self.assertEqual(lifecycle.state, "intercepting")
+        self.assertEqual(lifecycle.history[-2:], ("install-redirect", "renew-lease"))
+        self.assertTrue(lifecycle.redirect_present)
+        self.assertTrue(lifecycle.live_lease)
+
+    def test_startup_and_reboot_never_restore_a_lease(self):
+        self.assertFalse(Lifecycle.startup().live_lease)
+        running = Lifecycle.startup().with_test_state(redirect_present=True, live_lease=True)
+        rebooted = running.apply(Event.REBOOT)
+        self.assertFalse(rebooted.redirect_present)
+        self.assertFalse(rebooted.live_lease)
+        self.assertEqual(rebooted.state, "disabled")
+
+    def test_disable_removes_lease_and_redirect_before_process_stop_and_is_idempotent(self):
+        lifecycle = Lifecycle.startup().with_test_state(
+            state="intercepting", redirect_present=True, live_lease=True, engine_running=True
+        )
+        disabled = lifecycle.apply(Event.DISABLE)
+        self.assertEqual(
+            disabled.history[-4:],
+            ("remove-lease", "remove-redirect", "verify-absence", "stop-engine"),
+        )
+        self.assertEqual(disabled.apply(Event.DISABLE), disabled)
+
+    def test_engine_kill_and_oom_remove_owned_redirect_immediately(self):
+        for event in (Event.ENGINE_KILL, Event.ENGINE_OOM):
+            lifecycle = Lifecycle.startup().with_test_state(
+                state="intercepting", redirect_present=True, live_lease=True, engine_running=True
+            )
+            failed = lifecycle.apply(event)
+            self.assertFalse(failed.redirect_present)
+            self.assertFalse(failed.live_lease)
+            self.assertEqual(failed.state, "degraded-pass-through")
+
+    def test_watchdog_loss_stops_renewal_and_kernel_expiry_makes_residual_rule_inert(self):
+        lifecycle = Lifecycle.startup().with_test_state(
+            state="intercepting", redirect_present=True, live_lease=True, engine_running=True
+        )
+        lost = lifecycle.apply(Event.WATCHDOG_LOST)
+        self.assertTrue(lost.redirect_present)
+        self.assertTrue(lost.live_lease)
+        expired = lost.apply(Event.LEASE_EXPIRED)
+        self.assertTrue(expired.redirect_present)
+        self.assertFalse(expired.live_lease)
+        self.assertEqual(expired.state, "degraded-pass-through")
+
+
+class SemanticProofTests(unittest.TestCase):
+    def test_before_after_delta_is_limited_to_owned_objects(self):
+        before = {
+            "wificalling_gateway": "gateway-semantic-hash",
+            "unrelated_filter": "filter-semantic-hash",
+        }
+        after = {
+            **before,
+            "wificalling_location": "location-semantic-hash",
+        }
+        delta = semantic_delta(before, after)
+        self.assertEqual(delta["added"], ["wificalling_location"])
+        self.assertEqual(delta["removed"], [])
+        self.assertEqual(delta["changed"], [])
+        self.assertTrue(delta["safe"])
+
+    def test_semantic_proof_rejects_gateway_or_unrelated_changes(self):
+        before = {"wificalling_gateway": "a", "unrelated_filter": "x"}
+        after = {"wificalling_gateway": "b", "unrelated_filter": "x"}
+        self.assertFalse(semantic_delta(before, after)["safe"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/network/traffic_isolation_model.py
+++ b/tests/network/traffic_isolation_model.py
@@ -1,0 +1,281 @@
+"""Pure, non-deployable model for the Issue #6 traffic-isolation contract.
+
+The returned dictionaries are review manifests, not nftables, dnsmasq, or procd
+configuration.  They intentionally contain no command execution facility.
+"""
+
+from dataclasses import dataclass, replace
+from enum import Enum
+import ipaddress
+from typing import Dict, Mapping, Tuple
+
+
+APPROVED_HOSTS = ("gs-loc.apple.com", "gs-loc-cn.apple.com")
+
+
+def build_nft_plan(lease_ttl_seconds: int) -> Dict[str, object]:
+    if not 5 <= lease_ttl_seconds <= 60:
+        raise ValueError("offline lease TTL must be between 5 and 60 seconds")
+
+    def family_scope() -> Dict[str, object]:
+        return {
+            "source_cardinality": 1,
+            "destination_source": "exact-dns-allowlist",
+            "transport": "tcp",
+            "destination_port": 443,
+            "lease": {
+                "kind": "kernel-timeout-element",
+                "ttl_seconds": lease_ttl_seconds,
+            },
+            "redirect_requires_live_lease": True,
+        }
+
+    return {
+        "format": "offline-review-manifest/v1",
+        "executable": False,
+        "family": "inet",
+        "table": "wificalling_location",
+        "ownership": "project-only",
+        "ipv6_mode": "full-dual-stack",
+        "scope": {"ipv4": family_scope(), "ipv6": family_scope()},
+        "teardown": [
+            "remove-live-lease",
+            "remove-owned-redirect",
+            "verify-owned-redirect-absent",
+            "remove-owned-table",
+        ],
+    }
+
+
+def build_dns_plan(record_ttl_seconds: int) -> Dict[str, object]:
+    if not 1 <= record_ttl_seconds <= 86400:
+        raise ValueError("record TTL must be positive and bounded")
+    return {
+        "format": "offline-review-manifest/v1",
+        "executable": False,
+        "hostnames": list(APPROVED_HOSTS),
+        "record_types": ["A", "AAAA"],
+        "record_ttl_seconds": record_ttl_seconds,
+        "update": "atomic-generation-replace",
+        "expiry": "authoritative-record-ttl",
+        "global_ipv6_disable": False,
+        "aaaa_suppression": False,
+        "reload_behavior": "rebuild-owned-destination-generations",
+    }
+
+
+def build_procd_plan() -> Dict[str, object]:
+    return {
+        "format": "offline-review-manifest/v1",
+        "executable": False,
+        "service": "wificalling-location",
+        "supervision": "external-health-owner",
+        "startup_lease": "absent",
+        "reboot_lease": "absent",
+        "renew_only_when": [
+            "engine",
+            "scope",
+            "dns-a",
+            "dns-aaaa",
+            "ipv4",
+            "ipv6",
+            "watchdog",
+        ],
+        "fault_action": "stop-renewal-then-remove-owned-redirect",
+        "respawn": "bounded-and-never-authoritative-for-health",
+    }
+
+
+@dataclass(frozen=True)
+class Record:
+    hostname: str
+    record_type: str
+    address: str
+    expires_at: int
+
+
+def reconcile_dns_generation(
+    records: Tuple[Record, ...], now: int, generation: int
+) -> Dict[str, object]:
+    ipv4 = []
+    ipv6 = []
+    for record in records:
+        if record.hostname not in APPROVED_HOSTS:
+            raise ValueError("DNS record hostname is not exactly approved")
+        if record.record_type not in ("A", "AAAA"):
+            raise ValueError("only A and AAAA observations are accepted")
+        address = ipaddress.ip_address(record.address)
+        if (record.record_type == "A") != (address.version == 4):
+            raise ValueError("DNS record type and address family disagree")
+        if record.expires_at <= now:
+            continue
+        (ipv4 if address.version == 4 else ipv6).append(str(address))
+    return {
+        "generation": generation + 1,
+        "replace": "atomic",
+        "ipv4": sorted(set(ipv4)),
+        "ipv6": sorted(set(ipv6)),
+    }
+
+
+@dataclass(frozen=True)
+class Flow:
+    address_family: str
+    assigned_device: bool
+    hostname: str
+    transport: str
+    destination_port: int
+    live_lease: bool
+
+
+def classify_flow(flow: Flow) -> str:
+    exact_scope = (
+        flow.address_family in ("ipv4", "ipv6")
+        and flow.assigned_device
+        and flow.hostname in APPROVED_HOSTS
+        and flow.transport == "tcp"
+        and flow.destination_port == 443
+        and flow.live_lease
+    )
+    return "redirect" if exact_scope else "bypass"
+
+
+class Event(Enum):
+    VALIDATE_SCOPE = "validate-scope"
+    VERIFY_DUAL_STACK = "verify-dual-stack"
+    START_PASSTHROUGH = "start-pass-through"
+    PROVE_ENGINE_HEALTH = "prove-engine-health"
+    ARM_WATCHDOG = "arm-watchdog"
+    INSTALL_REDIRECT = "install-redirect"
+    RENEW_LEASE = "renew-lease"
+    DISABLE = "disable"
+    ENGINE_KILL = "engine-kill"
+    ENGINE_OOM = "engine-oom"
+    WATCHDOG_LOST = "watchdog-lost"
+    LEASE_EXPIRED = "lease-expired"
+    REBOOT = "reboot"
+
+
+@dataclass(frozen=True)
+class Lifecycle:
+    state: str = "disabled"
+    redirect_present: bool = False
+    live_lease: bool = False
+    engine_running: bool = False
+    scope_valid: bool = False
+    dual_stack_ready: bool = False
+    engine_healthy: bool = False
+    watchdog_armed: bool = False
+    history: Tuple[str, ...] = ()
+
+    @classmethod
+    def startup(cls) -> "Lifecycle":
+        return cls(history=("startup-no-lease",))
+
+    def with_test_state(self, **changes: object) -> "Lifecycle":
+        """Build synthetic failure states without exposing mutable production state."""
+        return replace(self, **changes)
+
+    def apply(self, event: Event) -> "Lifecycle":
+        if event == Event.DISABLE:
+            if self.state == "disabled" and not self.redirect_present and not self.live_lease:
+                return self
+            return replace(
+                self,
+                state="disabled",
+                redirect_present=False,
+                live_lease=False,
+                engine_running=False,
+                engine_healthy=False,
+                watchdog_armed=False,
+                history=self.history
+                + ("remove-lease", "remove-redirect", "verify-absence", "stop-engine"),
+            )
+        if event == Event.REBOOT:
+            return Lifecycle(history=self.history + ("reboot-no-lease",))
+        if event in (Event.ENGINE_KILL, Event.ENGINE_OOM):
+            return replace(
+                self,
+                state="degraded-pass-through",
+                redirect_present=False,
+                live_lease=False,
+                engine_running=False,
+                engine_healthy=False,
+                history=self.history
+                + ("stop-renewal", "remove-lease", "remove-redirect", "verify-absence"),
+            )
+        if event == Event.WATCHDOG_LOST:
+            return replace(
+                self,
+                watchdog_armed=False,
+                history=self.history + ("stop-renewal",),
+            )
+        if event == Event.LEASE_EXPIRED:
+            return replace(
+                self,
+                state="degraded-pass-through",
+                live_lease=False,
+                history=self.history + ("kernel-lease-expired",),
+            )
+
+        transitions = {
+            Event.VALIDATE_SCOPE: (
+                not self.scope_valid,
+                {"scope_valid": True, "state": "starting"},
+            ),
+            Event.VERIFY_DUAL_STACK: (
+                self.scope_valid and not self.dual_stack_ready,
+                {"dual_stack_ready": True},
+            ),
+            Event.START_PASSTHROUGH: (
+                self.scope_valid and self.dual_stack_ready and not self.engine_running,
+                {"engine_running": True, "state": "ready-pass-through"},
+            ),
+            Event.PROVE_ENGINE_HEALTH: (
+                self.engine_running and not self.engine_healthy,
+                {"engine_healthy": True},
+            ),
+            Event.ARM_WATCHDOG: (
+                self.engine_healthy and not self.watchdog_armed and not self.live_lease,
+                {"watchdog_armed": True},
+            ),
+            Event.INSTALL_REDIRECT: (
+                self.scope_valid
+                and self.dual_stack_ready
+                and self.engine_healthy
+                and self.watchdog_armed
+                and not self.redirect_present
+                and not self.live_lease,
+                {"redirect_present": True},
+            ),
+            Event.RENEW_LEASE: (
+                self.redirect_present
+                and self.scope_valid
+                and self.dual_stack_ready
+                and self.engine_healthy
+                and self.watchdog_armed,
+                {"live_lease": True, "state": "intercepting"},
+            ),
+        }
+        allowed, changes = transitions[event]
+        if not allowed:
+            raise ValueError("unsafe lifecycle transition: " + event.value)
+        return replace(self, **changes, history=self.history + (event.value,))
+
+
+def semantic_delta(
+    before: Mapping[str, str], after: Mapping[str, str]
+) -> Dict[str, object]:
+    before_keys = set(before)
+    after_keys = set(after)
+    added = sorted(after_keys - before_keys)
+    removed = sorted(before_keys - after_keys)
+    changed = sorted(
+        key for key in before_keys & after_keys if before[key] != after[key]
+    )
+    safe = (
+        set(added) <= {"wificalling_location"}
+        and set(removed) <= {"wificalling_location"}
+        and set(changed) <= {"wificalling_location"}
+    )
+    return {"added": added, "removed": removed, "changed": changed, "safe": safe}


### PR DESCRIPTION
Closes #6

## Summary
- freezes a dedicated dual-stack WLOC traffic-isolation model
- proves exact device/hostname/TCP 443 scope and Gateway/IPsec exclusion
- models expiring kernel leases, DNS rotation, ordered teardown, and reboot recovery

## Verification
- `python3 -m unittest discover -s tests/network -p "test_*.py" -v` (21/21)
- `./scripts/ci/verify.sh` (27/27 plus secret scan)
- `git diff --check`

## Review status
Draft: independent OpenWrt/network/security review remains required. Numeric lease and recovery targets are design gates until measured on AX6S. No live router rules are included.

## Rollback
Remove only the Issue #6 documentation/model/tests; no runtime state is changed.

Handoff capsule: `.handoffs/issue-6.md`
