### PR TITLE
fix: make OpenWrt packaging scripts ShellCheck clean

### DIFF
--- a/.handoffs/issue-23.md
+++ b/.handoffs/issue-23.md
@@ -1,0 +1,57 @@
+# Agent handoff: Issue 23
+
+## Identity and scope
+
+- Source agent ID: codex-shellcheck-fix
+- Capabilities used: shell,ci,openwrt,test
+- Branch: codex/issue-23-shellcheck-portability
+- Checkpoint parent: f032f7be6c0f44211bf94705fc78e80641304449
+- Updated at (UTC): 2026-08-13T09:09:35Z
+- Credentials included: no
+
+## Objective
+
+Restore the repository gate after GitHub ShellCheck exposed portability warnings in the OpenWrt packaging scripts merged by PR 22.
+
+## Completed
+
+- Made the repository-root lookup an explicit empty-`CDPATH` assignment.
+- Replaced intentionally split tar option strings with a portable archive helper that emits discrete GNU tar or bsdtar ownership arguments.
+- Marked both bounded retry counters as intentionally unused.
+- Verified all repository shell scripts with ShellCheck v0.10.0 in its official container.
+
+## Files changed
+
+- `scripts/build-luci-ipk.sh`
+- `scripts/openwrt/verify-docker-matrix.sh`
+- `.handoffs/issue-23.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| ShellCheck v0.10.0 over every `scripts/**/*.sh` file | Passed | No diagnostics |
+| `./tests/scripts/test-openwrt-release-packaging.sh` | Passed | Release packaging tests passed |
+| `./scripts/build-luci-ipk.sh 0.1.0-3 production` plus archive listing | Passed | Non-empty readable IPK archive |
+| `./scripts/ci/verify.sh` | Passed | 67 Python/network tests, 80.32% Rust line coverage, audits and secret scan |
+
+## Failed attempts
+
+- GitHub run 31684241690 provided the RED result: ShellCheck reported SC1007, SC2086, and SC2034.
+- The first local GREEN attempt changed only the first of two retry loops; ShellCheck correctly retained one SC2034 failure, which was then fixed.
+
+## Next executable steps
+
+1. Merge the focused CI repair after all repository gates pass.
+2. Confirm the subsequent `main` push workflow is green.
+
+## Capabilities required for the next Agent
+
+- ci
+- shell
+- openwrt
+
+## Security and privacy notes
+
+- No runtime protocol, interception scope, credentials, device data, certificate material, or precise location changed.
+- The archive helper preserves the existing root ownership metadata on GNU tar and bsdtar hosts.

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 version=${1:-0.1.0-2}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
@@ -12,10 +12,22 @@ stage=$(mktemp -d "${TMPDIR:-/tmp}/wloc-luci-ipk.XXXXXX")
 trap 'rm -rf "$stage"' EXIT HUP INT TERM
 
 tar_format=gnutar
-tar_owner_options='--uid 0 --gid 0 --uname root --gname root'
 case "$(tar --version 2>/dev/null | head -n 1)" in
-	*GNU*) tar_format=gnu; tar_owner_options='--owner=0 --group=0' ;;
+	*GNU*) tar_format=gnu ;;
 esac
+
+make_archive() {
+	archive_dir=$1
+	archive_path=$2
+	shift 2
+	if [ "$tar_format" = gnu ]; then
+		(cd "$archive_dir" && COPYFILE_DISABLE=1 tar --format "$tar_format" \
+			--owner=0 --group=0 -czf "$archive_path" "$@")
+	else
+		(cd "$archive_dir" && COPYFILE_DISABLE=1 tar --format "$tar_format" \
+			--uid 0 --gid 0 --uname root --gname root -czf "$archive_path" "$@")
+	fi
+}
 
 mkdir -p "$stage/control" "$stage/data" "$out_dir"
 cp -R "$source_dir/." "$stage/data/"
@@ -95,9 +107,9 @@ printf '%s\n' \
 	> "$stage/control/control"
 printf '2.0\n' > "$stage/debian-binary"
 
-(cd "$stage/control" && COPYFILE_DISABLE=1 tar --format "$tar_format" $tar_owner_options -czf "$stage/control.tar.gz" .)
-(cd "$stage/data" && COPYFILE_DISABLE=1 tar --format "$tar_format" $tar_owner_options -czf "$stage/data.tar.gz" .)
+make_archive "$stage/control" "$stage/control.tar.gz" .
+make_archive "$stage/data" "$stage/data.tar.gz" .
 rm -f "$out"
-(cd "$stage" && COPYFILE_DISABLE=1 tar --format "$tar_format" $tar_owner_options -czf "$out" debian-binary data.tar.gz control.tar.gz)
+make_archive "$stage" "$out" debian-binary data.tar.gz control.tar.gz
 
 echo "$out"

--- a/scripts/openwrt/verify-docker-matrix.sh
+++ b/scripts/openwrt/verify-docker-matrix.sh
@@ -79,7 +79,7 @@ run_case() {
 		--entrypoint /sbin/init "$image" >/dev/null
 
 	ready=0
-	for attempt in 1 2 3 4 5 6 7 8 9 10; do
+	for _attempt in 1 2 3 4 5 6 7 8 9 10; do
 		if docker exec "$container" /bin/sh -c 'ubus list system >/dev/null 2>&1'; then
 			ready=1
 			break
@@ -110,7 +110,7 @@ run_case() {
 	docker exec "$container" /etc/init.d/wloc-service enable
 	docker exec "$container" /etc/init.d/wloc-service restart
 	socket_ready=0
-	for attempt in 1 2 3 4 5 6 7 8 9 10; do
+	for _attempt in 1 2 3 4 5 6 7 8 9 10; do
 		if docker exec "$container" test -S /var/run/wloc-service/control.sock; then
 			socket_ready=1
 			break


### PR DESCRIPTION
## Task

Closes #23

Role: `role:test`

Handoff capsule: `.handoffs/issue-23.md`

## Outcome

Restores the repository gate after the integrated packaging scripts exposed SC1007, SC2086, and SC2034 on the GitHub Linux runner. Archive ownership behavior is preserved across GNU tar and bsdtar.

## Owned paths

- `scripts/build-luci-ipk.sh`
- `scripts/openwrt/verify-docker-matrix.sh`
- `.handoffs/issue-23.md`

## Verification evidence

```text
ShellCheck v0.10.0: all scripts PASS
OpenWrt release packaging tests: PASS
IPK archive smoke: PASS
./scripts/ci/verify.sh: PASS
67 Python/network tests; Rust line coverage 80.32%
```

## Security and privacy

- [x] No secrets, keys, raw production captures, device identifiers, or precise user location.
- [x] No network-input behavior changed.
- [x] Existing controlled-failure behavior remains tested.
- [x] No CA, proxy, OpenWrt runtime policy, or workflow file changed.

## Rollback

Revert the two commits in this PR. The change affects build/lint portability only and does not alter the installed Gateway 1.7 or WLOC runtime.

## Handoff

No follow-up implementation is required. Confirm the post-merge `main` workflow is green.