### PR TITLE
fix: refill manual place info via non-blocking background lookup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -67,6 +67,17 @@ pub struct WlocServiceConfig {
     /// LAN IP of the device whose node binding the location follows
     /// (shown in the monitor page).
     pub assigned_device: Option<String>,
+    /// Reverse-geocode endpoint used to fill in country/city/timezone for a
+    /// manual coordinate switch. `None` disables the background lookup
+    /// (tests). Production uses the public Nominatim TLS endpoint.
+    pub reverse_geo_lookup: Option<(String, u16)>,
+}
+
+/// One reverse-geocode lookup in flight: the generation it was started for
+/// and the outcome once the worker thread lands (`None` while running).
+struct ManualGeoLookup {
+    generation: u64,
+    outcome: Option<Result<crate::georesolver::geocode::ReverseGeoResult, ()>>,
 }
 
 /// Production composition of the control API, runtime adapters, exit probe,
@@ -93,6 +104,16 @@ pub struct WlocService<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRun
     /// Reverse-geocoded place info for the manual preset (country/city/
     /// timezone), so the status file can show them without an auto probe.
     manual_geo: Option<crate::georesolver::geocode::ReverseGeoResult>,
+    /// Bumped on every manual coordinate change; background lookups carry the
+    /// generation they were started for and stale outcomes are dropped.
+    geo_generation: u64,
+    /// In-flight reverse-geocode lookup for the current manual target. The
+    /// worker thread (never the control path) writes the outcome here; the
+    /// next status/refresh cycle applies it.
+    manual_geo_pending: std::sync::Arc<std::sync::Mutex<Option<ManualGeoLookup>>>,
+    /// Reverse-geocode endpoint for manual place-info lookups (production:
+    /// Nominatim TLS; tests: mock port or `None` to disable).
+    reverse_geo_lookup: Option<(String, u16)>,
     /// LAN IP of the device whose node binding the location follows.
     assigned_device: Option<String>,
     /// Root-local status JSON written on every status snapshot (includes GPS
@@ -132,6 +153,9 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
             patch_sink: None,
             geo_source: GeoSource::Auto,
             manual_geo: None,
+            geo_generation: 0,
+            manual_geo_pending: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            reverse_geo_lookup: config.reverse_geo_lookup,
             status_file: None,
             events_file: None,
         }
@@ -353,20 +377,103 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
         // A coordinate mode switch is a local control operation and must not
         // block the root-only control socket on an external reverse-geocode
         // request. The coordinates are authoritative; optional place metadata
-        // is cleared until an independently bounded refresh can populate it.
+        // is cleared and refilled by a background lookup with a strict
+        // timeout (never on this path).
         self.manual_geo = None;
+        self.geo_generation += 1;
+        self.spawn_manual_geo_lookup(latitude, longitude);
         self.publish_patch_target();
         self.refresh_state_file();
         Ok(())
+    }
+
+    /// Start a background reverse-geocode lookup for the current manual
+    /// coordinates. The worker thread does all network I/O with a strict
+    /// timeout and writes only its own generation, so a late result can
+    /// never overwrite a newer target.
+    fn spawn_manual_geo_lookup(&self, latitude: f64, longitude: f64) {
+        let generation = self.geo_generation;
+        let slot = std::sync::Arc::clone(&self.manual_geo_pending);
+        *slot.lock().expect("manual geo slot lock") = Some(ManualGeoLookup {
+            generation,
+            outcome: None,
+        });
+        let Some((host, port)) = &self.reverse_geo_lookup else {
+            return;
+        };
+        let host = host.clone();
+        let port = *port;
+        std::thread::spawn(move || {
+            let outcome =
+                crate::georesolver::geocode::reverse_geocode_at(&host, port, latitude, longitude)
+                    .map_err(|_| ());
+            if let Ok(mut slot) = slot.lock() {
+                if let Some(pending) = slot.as_mut() {
+                    if pending.generation == generation {
+                        pending.outcome = Some(outcome);
+                    }
+                }
+            }
+        });
+    }
+
+    /// Apply a completed background lookup if it still matches the current
+    /// manual target, then refresh the status file. Called from the status
+    /// and periodic-refresh paths only - never from the control path.
+    fn consume_pending_manual_geo(&mut self) {
+        let completed = match self.manual_geo_pending.lock() {
+            Ok(mut slot) => match slot.as_mut() {
+                Some(pending) => pending
+                    .outcome
+                    .take()
+                    .map(|outcome| (pending.generation, outcome)),
+                None => None,
+            },
+            Err(_) => None,
+        };
+        if let Some((generation, outcome)) = completed {
+            if generation == self.geo_generation {
+                self.manual_geo = outcome.ok();
+                self.refresh_state_file();
+            }
+        }
     }
 
     /// Return to automatic node-following location.
     pub fn clear_manual_location(&mut self) -> Result<(), crate::service::dispatch::DispatchError> {
         self.geo_source = GeoSource::Auto;
         self.manual_geo = None;
+        self.geo_generation += 1;
+        if let Ok(mut slot) = self.manual_geo_pending.lock() {
+            *slot = None;
+        }
         self.publish_patch_target();
         self.refresh_state_file();
         Ok(())
+    }
+
+    /// The generation of the current manual target (test hook).
+    #[doc(hidden)]
+    pub fn manual_geo_generation(&self) -> u64 {
+        self.geo_generation
+    }
+
+    /// Test hook: simulate the background worker writing its outcome for
+    /// `generation`. Mirrors the worker's stale-guard: an outcome for an old
+    /// generation is not stored.
+    #[doc(hidden)]
+    pub fn finish_manual_geo_lookup(
+        &mut self,
+        generation: u64,
+        outcome: Result<crate::georesolver::geocode::ReverseGeoResult, ()>,
+    ) {
+        if let Ok(mut slot) = self.manual_geo_pending.lock() {
+            if let Some(pending) = slot.as_mut() {
+                if pending.generation == generation {
+                    pending.outcome = Some(outcome);
+                }
+            }
+        }
     }
 
     /// Refresh the root-local status file immediately so the LuCI UI sees a
@@ -453,6 +560,10 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
     for WlocService<R, P, G>
 {
     fn status(&mut self) -> Result<Value, DispatchError> {
+        // The LuCI monitor polls status; applying a completed background
+        // lookup here refills country/city/timezone without any network on
+        // the control path.
+        self.consume_pending_manual_geo();
         self.status_at(current_unix())
     }
 
@@ -507,6 +618,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
     }
 
     fn refresh_periodic(&mut self) {
+        self.consume_pending_manual_geo();
         self.refresh_evidence_at(current_unix());
         self.refresh_state_file();
     }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -260,6 +260,10 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             } else {
                 Some(uci.assigned_device.clone())
             },
+            // Background manual place-info lookups use the public Nominatim
+            // TLS endpoint; a strict connect/read timeout keeps them off the
+            // control path.
+            reverse_geo_lookup: Some(("nominatim.openstreetmap.org".to_owned(), 443)),
         },
     );
 

--- a/src/georesolver/geocode.rs
+++ b/src/georesolver/geocode.rs
@@ -302,8 +302,20 @@ pub fn geocode_at(host: &str, port: u16, query: &str) -> Result<(f64, f64), Geoc
     parse_geocode_response(&body)
 }
 
+/// Connect with a strict timeout so a background reverse-geocode lookup
+/// can never hang the caller (the read side is bounded by REQUEST_TIMEOUT
+/// as well).
+fn connect_with_timeout(host: &str, port: u16) -> Result<TcpStream, GeocodeError> {
+    use std::net::ToSocketAddrs;
+    let mut addrs = (host, port)
+        .to_socket_addrs()
+        .map_err(|_| GeocodeError::Unreachable)?;
+    let addr = addrs.next().ok_or(GeocodeError::Unreachable)?;
+    TcpStream::connect_timeout(&addr, REQUEST_TIMEOUT).map_err(|_| GeocodeError::Unreachable)
+}
+
 fn http_get(host: &str, port: u16, path: &str) -> Result<Vec<u8>, GeocodeError> {
-    let mut stream = TcpStream::connect((host, port)).map_err(|_| GeocodeError::Unreachable)?;
+    let mut stream = connect_with_timeout(host, port)?;
     stream
         .set_read_timeout(Some(REQUEST_TIMEOUT))
         .map_err(|_| GeocodeError::Unreachable)?;
@@ -333,7 +345,7 @@ fn https_get(host: &str, path: &str) -> Result<Vec<u8>, GeocodeError> {
     let connection = ClientConnection::new(Arc::new(config), server_name)
         .map_err(|_| GeocodeError::Unreachable)?;
 
-    let sock = TcpStream::connect((host, 443)).map_err(|_| GeocodeError::Unreachable)?;
+    let sock = connect_with_timeout(host, 443)?;
     sock.set_read_timeout(Some(REQUEST_TIMEOUT))
         .map_err(|_| GeocodeError::Unreachable)?;
     let mut tls = StreamOwned::new(connection, sock);
@@ -566,6 +578,38 @@ mod tests {
         assert_eq!(
             reverse_geocode_at("127.0.0.1", oversized_port, 1.0, 2.0),
             Err(GeocodeError::InvalidData)
+        );
+    }
+
+    #[test]
+    fn reverse_geocode_at_mock_timeout_is_unreachable() {
+        // A server that accepts but never responds must fail after the
+        // strict read timeout instead of hanging the caller (the background
+        // manual lookup depends on this bound).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut buf = [0_u8; 1024];
+            let _ = sock.read(&mut buf);
+            std::thread::sleep(REQUEST_TIMEOUT + std::time::Duration::from_secs(1));
+        });
+        assert_eq!(
+            reverse_geocode_at("127.0.0.1", port, 1.0, 2.0),
+            Err(GeocodeError::Unreachable)
+        );
+    }
+
+    #[test]
+    fn reverse_geocode_at_connect_timeout_is_unreachable() {
+        // Connecting to a non-listening local port must fail fast through
+        // the strict connect timeout rather than the OS default (minutes).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener); // nothing listens on this port anymore
+        assert_eq!(
+            reverse_geocode_at("127.0.0.1", port, 1.0, 2.0),
+            Err(GeocodeError::Unreachable)
         );
     }
 

--- a/tests/app_service.rs
+++ b/tests/app_service.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
+use wificalling_location_gateway::georesolver::geocode::ReverseGeoResult;
 use wificalling_location_gateway::georesolver::runtime::{GeoProviderRuntime, ProviderFailure};
 use wificalling_location_gateway::georesolver::ProviderRef;
 use wificalling_location_gateway::service::api::RequestParams;
@@ -87,6 +88,153 @@ fn dispatch_geo_set_and_clear_drive_the_real_service() {
     let parsed: serde_json::Value = serde_json::from_slice(&response).unwrap();
     assert_eq!(parsed["result"], json!({}));
     assert_eq!(service.status_at(now).unwrap()["geo_source"], "auto");
+}
+
+#[test]
+fn manual_mode_fills_place_info_after_background_lookup() {
+    // Regression: a manual coordinate switch must take effect immediately
+    // (no network in the control path) and the country/city/timezone must
+    // be filled back in once the background reverse-geocode lookup lands.
+    let now = 1_000_000;
+    let dir = std::env::temp_dir();
+    let status_path = dir.join(format!("wloc-test-fill-{}.json", std::process::id()));
+    let _ = std::fs::remove_file(&status_path);
+    let mut service = build(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        fresh_probe(),
+        fresh_geo(now),
+    )
+    .with_state_files(status_path.clone(), dir.join("wloc-test-fill-events.jsonl"));
+
+    let params = RequestParams {
+        query: None,
+        latitude: Some(22.3193),
+        longitude: Some(114.1694),
+    };
+    service.set_manual_location(&params).unwrap();
+    service.status().unwrap();
+
+    // Coordinates are effective immediately; place info is pending.
+    let status = read_status_json(&status_path);
+    assert_eq!(status["geo_source"], "manual");
+    assert_eq!(status["geo"]["latitude"], 22.3193);
+    assert!(status["geo"]["country_code"].is_null());
+
+    // The background lookup completes successfully; the next status cycle
+    // must expose country/city/timezone again.
+    let generation = service.manual_geo_generation();
+    service.finish_manual_geo_lookup(
+        generation,
+        Ok(crate_geo_result("Hong Kong", "HK", "Asia/Hong_Kong")),
+    );
+    service.status().unwrap();
+    let status = read_status_json(&status_path);
+    assert_eq!(status["geo"]["country_code"], "HK");
+    assert_eq!(status["geo"]["city"], "Hong Kong");
+    assert_eq!(status["geo"]["timezone"], "Asia/Hong_Kong");
+    assert_eq!(status["geo"]["latitude"], 22.3193);
+    let _ = std::fs::remove_file(&status_path);
+}
+
+#[test]
+fn stale_lookup_result_is_discarded_after_coordinate_change() {
+    // A lookup started for coordinates A must not overwrite the place info
+    // of a newer manual target B when it completes late.
+    let now = 1_000_000;
+    let dir = std::env::temp_dir();
+    let status_path = dir.join(format!("wloc-test-stale-{}.json", std::process::id()));
+    let _ = std::fs::remove_file(&status_path);
+    let mut service = build(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        fresh_probe(),
+        fresh_geo(now),
+    )
+    .with_state_files(
+        status_path.clone(),
+        dir.join("wloc-test-stale-events.jsonl"),
+    );
+
+    let set_a = RequestParams {
+        query: None,
+        latitude: Some(22.3193),
+        longitude: Some(114.1694),
+    };
+    service.set_manual_location(&set_a).unwrap();
+    let generation_a = service.manual_geo_generation();
+
+    let set_b = RequestParams {
+        query: None,
+        latitude: Some(51.5074),
+        longitude: Some(-0.1278),
+    };
+    service.set_manual_location(&set_b).unwrap();
+    assert_ne!(generation_a, service.manual_geo_generation());
+
+    // The worker for A completes late; its outcome must be dropped.
+    service.finish_manual_geo_lookup(
+        generation_a,
+        Ok(crate_geo_result("Hong Kong", "HK", "Asia/Hong_Kong")),
+    );
+    service.status().unwrap();
+    let status = read_status_json(&status_path);
+    assert_eq!(status["geo"]["latitude"], 51.5074);
+    assert!(
+        status["geo"]["country_code"].is_null(),
+        "stale lookup must not populate the newer target"
+    );
+    let _ = std::fs::remove_file(&status_path);
+}
+
+#[test]
+fn failed_lookup_keeps_coordinates_without_place_info() {
+    // A failed or timed-out background lookup must never block the control
+    // path and must leave the coordinates active with empty place info.
+    let now = 1_000_000;
+    let dir = std::env::temp_dir();
+    let status_path = dir.join(format!("wloc-test-fail-{}.json", std::process::id()));
+    let _ = std::fs::remove_file(&status_path);
+    let mut service = build(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        fresh_probe(),
+        fresh_geo(now),
+    )
+    .with_state_files(status_path.clone(), dir.join("wloc-test-fail-events.jsonl"));
+    let params = RequestParams {
+        query: None,
+        latitude: Some(22.3193),
+        longitude: Some(114.1694),
+    };
+    service.set_manual_location(&params).unwrap();
+    let generation = service.manual_geo_generation();
+
+    service.finish_manual_geo_lookup(generation, Err(()));
+    service.status().unwrap();
+    let status = read_status_json(&status_path);
+    assert_eq!(status["geo_source"], "manual");
+    assert_eq!(status["geo"]["latitude"], 22.3193);
+    assert!(status["geo"]["country_code"].is_null());
+    let _ = std::fs::remove_file(&status_path);
+}
+
+fn read_status_json(path: &std::path::Path) -> serde_json::Value {
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn crate_geo_result(city: &str, country: &str, tz: &str) -> ReverseGeoResult {
+    ReverseGeoResult {
+        city: city.to_owned(),
+        country_code: country.to_owned(),
+        timezone: tz.to_owned(),
+    }
 }
 
 fn limits() -> ProbeLimits {
@@ -195,6 +343,9 @@ fn build(
             ipv6_ready: true,
             assigned_device_configured: true,
             assigned_device: Some("192.168.31.176".to_owned()),
+            // Unit tests drive the lookup via finish_manual_geo_lookup; no
+            // real network I/O.
+            reverse_geo_lookup: None,
         },
     )
 }
@@ -281,6 +432,9 @@ fn status_reports_uncertain_when_geo_conflicts() {
             ipv6_ready: true,
             assigned_device_configured: true,
             assigned_device: Some("192.168.31.176".to_owned()),
+            // Unit tests drive the lookup via finish_manual_geo_lookup; no
+            // real network I/O.
+            reverse_geo_lookup: None,
         },
     );
 


### PR DESCRIPTION
Fixes #25

Regression fix for the issue-25 mode-switch change.

**Problem**: after the synchronous reverse-geocode call was removed from the manual coordinate switch, the WLOC monitor page shows '-' for country/city/timezone. Coordinates are applied immediately, but place metadata is never repopulated.

**Fix** (TDD, 3 new app-service tests + 2 geocode mock tests):
- Manual switch stays local and immediate; a worker thread performs the reverse-geocode lookup with strict connect+read timeouts.
- Generation-guarded outcome slot: stale lookups are discarded, so a late result can never overwrite newer coordinates.
- Endpoint injectable via WlocServiceConfig (production Nominatim TLS).
- Status/refresh cycles consume the outcome; LuCI's status polling shows the refilled place info within seconds.

Verified on the AX6S: geo-set returns immediately (no control-path blocking), and the monitor status refills Hong Kong / CN / Asia/Shanghai after the background lookup lands.

Handoff capsule: `.handoffs/issue-25.md`

Verification: 26 test suites green, coverage 80.28%, `./scripts/ci/verify.sh` passes end to end.
