### PR TITLE
feat: add bounded v2 device profile model

### DIFF
--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -1,0 +1,70 @@
+# Agent handoff: Issue 31
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,test
+- Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
+- Checkpoint parent: 601097f
+- Updated at (UTC): 2026-08-21T05:05:00Z
+- Credentials included: no
+
+## Objective
+
+Implement the bounded v2 device-profile model, legacy singleton projection,
+explicit UCI profile parsing, and additive v2 profile API decoding without
+changing the current runtime interception path.
+
+## Completed
+
+- Added `DeviceProfile`, `ProfileModel`, node selection and location mode
+  fields, validation, AX6S-oriented resource ceilings, redacted status, and
+  transactional replacement.
+- Added deterministic v1-to-singleton migration and explicit `config device`
+  UCI sections with duplicate, address, mode, coordinate, and required-device
+  validation.
+- Added v2 profile request decoding and bounded v2 result envelopes while
+  preserving the frozen v1 API.
+- Added profile tests, API tests, UCI example documentation, and the v2 profile
+  contract document.
+
+## Verification
+
+- `cargo test --all-targets`: passed.
+- `cargo clippy --all-targets -- -D warnings`: passed.
+- `./scripts/ci/verify.sh`: passed.
+- Python suite: 69 passed.
+- Rust coverage: 80.54% total.
+- Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
+  release gates: passed.
+- Relevant commits: `7542dd9`, `f38def9`.
+
+## Failed attempts
+
+- No product-code verification failure occurred. The repository commit hook
+  reports that `lefthook` is unavailable in the local PATH; the required CI
+  verification script passed independently.
+
+## Next executable steps
+
+1. Perform an independent review of the two implementation commits.
+2. Merge the branch through the Issue #31 pull request after review.
+3. Start V2-02 for the unified procd supervisor and runtime lifecycle.
+
+## Capabilities required for the next Agent
+
+- rust
+- openwrt
+- test
+- security
+
+## Security and privacy notes
+
+- No credentials, private keys, raw production traffic, device identifiers, or
+  precise location data are included.
+- Explicit v2 profiles require an assigned local IPv4/IPv6 or MAC address, but
+  redacted status exposes only configured/not-configured booleans.
+- Legacy singleton migration remains compatible with an empty assigned device;
+  it does not create a multi-device routing policy.
+- Runtime dispatch, nftables routing, procd supervision, LuCI, logs, and update
+  operations remain out of scope for this Issue.

--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -5,8 +5,8 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
-- Checkpoint parent: 601097f
-- Updated at (UTC): 2026-08-21T05:05:00Z
+- Checkpoint parent: 6b0a744
+- Updated at (UTC): 2026-08-21T05:50:00Z
 - Credentials included: no
 
 ## Objective
@@ -27,17 +27,22 @@ changing the current runtime interception path.
   preserving the frozen v1 API.
 - Added profile tests, API tests, UCI example documentation, and the v2 profile
   contract document.
+- Runtime now consumes an explicit single profile, rejects unsupported MAC and
+  multiple-profile runtime selection, and fail-closes invalid existing UCI.
+- Profile-bound probes require a matching Gateway UCI device policy and reject
+  route-only or stale sing-box rule fallback.
 
 ## Verification
 
-- `cargo test --all-targets`: passed.
+- `cargo test --all-targets`: passed (64 unit tests plus all integration suites).
 - `cargo clippy --all-targets -- -D warnings`: passed.
 - `./scripts/ci/verify.sh`: passed.
 - Python suite: 69 passed.
-- Rust coverage: 80.54% total.
+- Rust coverage: 80.96% total.
 - Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
   release gates: passed.
-- Relevant commits: `7542dd9`, `f38def9`.
+- Relevant commits: `7542dd9`, `f38def9`, `a9ad40a`, `4663edb`, `05d1b42`,
+  `6b0a744`, `0061686`.
 
 ## Failed attempts
 
@@ -47,7 +52,7 @@ changing the current runtime interception path.
 
 ## Next executable steps
 
-1. Perform an independent review of the two implementation commits.
+1. Complete independent review of the implementation and binding fallback fix.
 2. Merge the branch through the Issue #31 pull request after review.
 3. Start V2-02 for the unified procd supervisor and runtime lifecycle.
 
@@ -68,3 +73,5 @@ changing the current runtime interception path.
   it does not create a multi-device routing policy.
 - Runtime dispatch, nftables routing, procd supervision, LuCI, logs, and update
   operations remain out of scope for this Issue.
+- The route-only binding regression is covered by
+  `required_device_binding_rejects_route_only_match`.

--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -5,8 +5,8 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
-- Checkpoint parent: 6b0a744
-- Updated at (UTC): 2026-08-21T05:50:00Z
+- Checkpoint parent: 05002bf
+- Updated at (UTC): 2026-08-21T05:58:00Z
 - Credentials included: no
 
 ## Objective
@@ -31,6 +31,8 @@ changing the current runtime interception path.
   multiple-profile runtime selection, and fail-closes invalid existing UCI.
 - Profile-bound probes require a matching Gateway UCI device policy and reject
   route-only or stale sing-box rule fallback.
+- Invalid or unsupported profile scope now blocks status/periodic/forced
+  background probes and withdraws any stale patch target.
 
 ## Verification
 
@@ -38,11 +40,11 @@ changing the current runtime interception path.
 - `cargo clippy --all-targets -- -D warnings`: passed.
 - `./scripts/ci/verify.sh`: passed.
 - Python suite: 69 passed.
-- Rust coverage: 80.96% total.
+- Rust coverage: 81.00% total.
 - Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
   release gates: passed.
 - Relevant commits: `7542dd9`, `f38def9`, `a9ad40a`, `4663edb`, `05d1b42`,
-  `6b0a744`, `0061686`.
+  `6b0a744`, `0061686`, `05002bf`.
 
 ## Failed attempts
 
@@ -75,3 +77,5 @@ changing the current runtime interception path.
   operations remain out of scope for this Issue.
 - The route-only binding regression is covered by
   `required_device_binding_rejects_route_only_match`.
+- The invalid-scope background-probe regression is covered by
+  `invalid_scope_never_runs_an_unbound_probe_or_publishes_target`.

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -52,7 +52,13 @@ rejected. MAC addresses are accepted in the profile schema for the future
 multi-device resolver, but the current single-runtime daemon accepts only IP
 bindings and stays disabled for a MAC-only profile. The legacy singleton
 projection may still have no address so an existing installation can continue
-its current Gateway-policy discovery path.
+its current Gateway-policy discovery path. Explicit IP bindings are limited to
+RFC1918 IPv4 or ULA IPv6 and the sing-box probe requires a matching Gateway
+device policy; it never falls back to an unrelated outbound for a profile.
+
+A missing UCI file retains the v1 unconfigured-default behavior. An existing
+but malformed or oversized UCI file is fail-closed and cannot be re-enabled by
+the v1 control socket until the file is corrected.
 
 ## v2 request envelope
 

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -1,0 +1,70 @@
+# WLOC service v2 profile slice
+
+This document records the V2-01 profile-management slice. It is additive to
+the existing `wloc.service/v1` API; no v1 request is interpreted as a profile
+request.
+
+## Bounded profile model
+
+One `device` profile is the unit of configuration for a LAN device. The model
+contains:
+
+- a stable lower-case `id`;
+- a display `label`;
+- an assigned IPv4/IPv6 address or six-octet MAC address for explicit v2
+  device sections;
+- a node reference and `node_mode` (`fixed` or `gateway_default`);
+- a WLOC source (`auto` or `manual`), optional manual coordinates, and an
+  optional manual location reference;
+- an `enabled` flag.
+
+The model is deliberately bounded for small OpenWrt gateways:
+
+- at most 8 profiles;
+- profile IDs up to 32 bytes;
+- labels up to 48 bytes;
+- node references up to 96 bytes;
+- manual location references up to 64 bytes;
+- serialized profile configuration up to 8 KiB;
+- redacted status output up to 4 KiB.
+
+Validation is performed before a model replacement. A failed replacement
+leaves the previous model unchanged.
+
+## Legacy migration
+
+If no `config device` sections exist, the v1 singleton fields are projected
+into a deterministic profile with ID `default`. The projection preserves the
+assigned device, node reference, enabled state, WLOC source, and manual
+coordinates. Repeating the projection is idempotent.
+
+When explicit device sections exist, they take precedence over the legacy
+singleton fields. Invalid IDs, addresses, node modes, location pairs, or
+duplicate IDs reject the UCI parse before any runtime operation.
+
+## v2 request envelope
+
+Profile methods use the existing control-frame bound and the version string
+`wloc.service/v2`:
+
+```json
+{
+  "api_version": "wloc.service/v2",
+  "request_id": "req-1",
+  "method": "profile.get",
+  "params": { "profile_id": "phone" }
+}
+```
+
+The V2-01 decoder accepts `profile.list`, `profile.get`, `profile.create`,
+`profile.update`, and `profile.delete`. Unknown top-level or parameter fields,
+invalid profile IDs, invalid modes, invalid addresses, and out-of-range
+coordinates fail before dispatch. `get`, `update`, and `delete` require a
+profile ID.
+
+Profile status is redacted: it reports whether an assigned device or manual
+location is configured, but never returns the device address, node reference,
+coordinates, credentials, or private key material.
+
+Runtime dispatch, multi-device nftables routing, the unified procd supervisor,
+LuCI pages, and component updates are subsequent v2 issues.

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -27,6 +27,7 @@ The model is deliberately bounded for small OpenWrt gateways:
 - manual location references up to 64 bytes;
 - serialized profile configuration up to 8 KiB;
 - redacted status output up to 4 KiB.
+- complete UCI input up to 32 KiB before section accumulation.
 
 Validation is performed before a model replacement. A failed replacement
 leaves the previous model unchanged.
@@ -41,6 +42,14 @@ coordinates. Repeating the projection is idempotent.
 When explicit device sections exist, they take precedence over the legacy
 singleton fields. Invalid IDs, addresses, node modes, location pairs, or
 duplicate IDs reject the UCI parse before any runtime operation.
+
+The current daemon consumes exactly one explicit profile. If more than one
+profile is configured before the unified multi-device runtime lands, it stays
+disabled rather than selecting a profile implicitly. Explicit addresses must
+be usable unicast LAN bindings: unspecified, loopback, multicast, broadcast,
+IPv4 link-local, IPv6 link-local, zero MAC, and multicast MAC values are
+rejected. The legacy singleton projection may still have no address so an
+existing installation can continue its current Gateway-policy discovery path.
 
 ## v2 request envelope
 
@@ -60,7 +69,9 @@ The V2-01 decoder accepts `profile.list`, `profile.get`, `profile.create`,
 `profile.update`, and `profile.delete`. Unknown top-level or parameter fields,
 invalid profile IDs, invalid modes, invalid addresses, and out-of-range
 coordinates fail before dispatch. `get`, `update`, and `delete` require a
-profile ID.
+profile ID. `create` requires the complete profile identity, label, assigned
+device, node, node mode, location source, and enabled fields; manual creates
+also require both coordinates.
 
 Profile status is redacted: it reports whether an assigned device or manual
 location is configured, but never returns the device address, node reference,

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -48,8 +48,11 @@ profile is configured before the unified multi-device runtime lands, it stays
 disabled rather than selecting a profile implicitly. Explicit addresses must
 be usable unicast LAN bindings: unspecified, loopback, multicast, broadcast,
 IPv4 link-local, IPv6 link-local, zero MAC, and multicast MAC values are
-rejected. The legacy singleton projection may still have no address so an
-existing installation can continue its current Gateway-policy discovery path.
+rejected. MAC addresses are accepted in the profile schema for the future
+multi-device resolver, but the current single-runtime daemon accepts only IP
+bindings and stays disabled for a MAC-only profile. The legacy singleton
+projection may still have no address so an existing installation can continue
+its current Gateway-policy discovery path.
 
 ## v2 request envelope
 

--- a/openwrt/files/etc/config/wloc-service
+++ b/openwrt/files/etc/config/wloc-service
@@ -36,3 +36,17 @@ config preset 'hong_kong'
 	option label 'Hong Kong'
 	option latitude '22.3193'
 	option longitude '114.1694'
+
+# v2 migration example (disabled by default): one config device section is
+# the future unit for node binding, WLOC mode, service enablement, logs, and
+# monitoring. If any device sections are present, they take precedence over
+# the legacy singleton fields above. Keep addresses and locations local to
+# the router; they are never returned by the redacted status API.
+#
+# config device 'phone'
+# 	option label 'Living room phone'
+# 	option assigned_device '192.168.1.100'
+# 	option node_ref 'default'
+# 	option node_mode 'fixed'
+# 	option geo_source 'auto'
+# 	option enabled '1'

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,6 +190,19 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     /// Probe and resolve evidence when the cached observation is missing,
     /// stale, or the last probe failed.
     fn refresh_evidence_at(&mut self, now_unix: u64) {
+        // An invalid or unsupported profile is disabled at startup, but
+        // status and periodic refreshes still run independently of the
+        // enable path. Do not let those paths create an unbound legacy probe
+        // that silently selects the first outbound, and withdraw any stale
+        // evidence/patch target already held by the service.
+        if !self.scope_valid {
+            self.exit_evidence = ExitEvidence::Unavailable;
+            self.geo_resolution = GeoResolution::Unavailable;
+            self.last_probe_fingerprint = None;
+            self.last_probe_error = Some("invalid service scope".to_owned());
+            self.publish_patch_target();
+            return;
+        }
         // Manual mode pins the location to the preset coordinates; exit
         // probing exists only to drive auto-follow, so it is skipped
         // entirely in manual mode (no reverse probe, no misleading IP).
@@ -240,6 +253,14 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     /// Publish the current patch target: a manual preset when set, otherwise
     /// the freshest Geo record (in Auto mode).
     fn publish_patch_target(&self) {
+        if !self.scope_valid {
+            if let Some(sink) = &self.patch_sink {
+                if let Ok(mut guard) = sink.lock() {
+                    *guard = None;
+                }
+            }
+            return;
+        }
         let target = match self.geo_source {
             GeoSource::Manual {
                 latitude,

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
-use wificalling_location_gateway::config::{LocationMode, WlocUciConfig};
+use wificalling_location_gateway::config::{LocationMode, RuntimeProfile, WlocUciConfig};
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
 use wificalling_location_gateway::georesolver::http::GeoHttpClient;
@@ -43,6 +43,31 @@ fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs())
         .unwrap_or(0)
+}
+
+fn disabled_runtime_profile() -> RuntimeProfile {
+    RuntimeProfile {
+        id: "invalid".to_owned(),
+        enabled: false,
+        assigned_device: None,
+        node_ref: "default".to_owned(),
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+    }
+}
+
+fn runtime_profile_from_uci(uci: &WlocUciConfig) -> RuntimeProfile {
+    match uci
+        .profile_model()
+        .and_then(|model| model.single_runtime_profile())
+    {
+        Ok(profile) => profile,
+        Err(error) => {
+            eprintln!("wloc-service: profile is not runnable yet: {error}; staying disabled");
+            disabled_runtime_profile()
+        }
+    }
 }
 
 /// No-op runtime control: every adapter step succeeds and the engine is
@@ -213,24 +238,35 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let uci = match WlocUciConfig::load(Path::new(&uci_path)) {
         Ok(config) => config,
         Err(error) => {
-            eprintln!("wloc-service: {error}; using defaults");
-            WlocUciConfig::default()
+            eprintln!("wloc-service: {error}; using disabled defaults");
+            WlocUciConfig {
+                enabled: false,
+                ..WlocUciConfig::default()
+            }
         }
     };
+    let runtime_profile = runtime_profile_from_uci(&uci);
     // The device whose node binding the location follows. It is normally
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
     // instead of a fixed example address.
-    let assigned_device = if uci.assigned_device.trim().is_empty() {
+    let assigned_device = if runtime_profile
+        .assigned_device
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
         gateway_first_device_ip().unwrap_or_default()
     } else {
-        uci.assigned_device.clone()
+        runtime_profile.assigned_device.clone().unwrap_or_default()
     };
     eprintln!(
-        "wloc-service: uci enabled={} geo_source={:?} node={} device={}",
-        uci.enabled,
-        uci.location_mode,
-        uci.node_ref,
+        "wloc-service: profile={} enabled={} geo_source={:?} node={} device={}",
+        runtime_profile.id,
+        runtime_profile.enabled,
+        runtime_profile.location_mode,
+        runtime_profile.node_ref,
         if assigned_device.is_empty() {
             "(none)".to_owned()
         } else {
@@ -257,7 +293,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         build_probe(&assigned_device, uci.probe_port),
         geo,
         WlocServiceConfig {
-            node_ref: NodeRef::new(&uci.node_ref)
+            node_ref: NodeRef::new(&runtime_profile.node_ref)
                 .unwrap_or_else(|_| NodeRef::new("default").expect("static node ref is valid")),
             providers: vec![ProviderRef::new("http").expect("static provider ref is valid")],
             probe_limits: ProbeLimits {
@@ -385,8 +421,11 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // manual location preset first (so a manual target is already fresh), then
     // the desired enabled state. Failures are logged, not fatal: the daemon
     // still serves status and can be steered through the control API.
-    if uci.location_mode == LocationMode::Manual {
-        if let (Some(latitude), Some(longitude)) = (uci.manual_latitude, uci.manual_longitude) {
+    if runtime_profile.location_mode == LocationMode::Manual {
+        if let (Some(latitude), Some(longitude)) = (
+            runtime_profile.manual_latitude,
+            runtime_profile.manual_longitude,
+        ) {
             let params = RequestParams {
                 query: None,
                 latitude: Some(latitude),
@@ -401,7 +440,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             );
         }
     }
-    if uci.enabled {
+    if runtime_profile.enabled {
         if let Err(error) = service.enable() {
             eprintln!("wloc-service: enable failed: {error:?}");
         }
@@ -607,5 +646,29 @@ mod tests {
     fn ignores_non_ip_tokens() {
         let output = "elements = { 59.82.17.33, hostname, 10.0.0.1/8 }\n";
         assert_eq!(parse_apple_ips(output), vec!["59.82.17.33"]);
+    }
+
+    #[test]
+    fn explicit_profile_is_the_single_runtime_source() {
+        let config = WlocUciConfig::parse(
+            "config wloc-service 'main'\n\toption enabled '0'\n\toption node_ref 'legacy'\n\toption assigned_device '192.168.1.200'\nconfig device 'phone'\n\toption label 'Phone'\n\toption assigned_device '192.168.1.100'\n\toption node_ref 'profile-node'\n\toption geo_source 'auto'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert_eq!(profile.id, "phone");
+        assert!(profile.enabled);
+        assert_eq!(profile.assigned_device.as_deref(), Some("192.168.1.100"));
+        assert_eq!(profile.node_ref, "profile-node");
+    }
+
+    #[test]
+    fn multiple_profiles_never_select_one_implicitly() {
+        let config = WlocUciConfig::parse(
+            "config device 'phone'\n\toption assigned_device '192.168.1.100'\nconfig device 'tablet'\n\toption assigned_device '192.168.1.101'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert!(!profile.enabled);
+        assert_eq!(profile.id, "invalid");
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -49,6 +49,7 @@ fn disabled_runtime_profile() -> RuntimeProfile {
     RuntimeProfile {
         id: "invalid".to_owned(),
         enabled: false,
+        runtime_supported: false,
         assigned_device: None,
         node_ref: "default".to_owned(),
         location_mode: LocationMode::Auto,
@@ -62,12 +63,25 @@ fn runtime_profile_from_uci(uci: &WlocUciConfig) -> RuntimeProfile {
         .profile_model()
         .and_then(|model| model.single_runtime_profile())
     {
-        Ok(profile) => profile,
+        Ok(mut profile) => {
+            if !profile.runtime_supported {
+                eprintln!(
+                    "wloc-service: profile {} has no IP runtime binding; staying disabled",
+                    profile.id
+                );
+                profile.enabled = false;
+            }
+            profile
+        }
         Err(error) => {
             eprintln!("wloc-service: profile is not runnable yet: {error}; staying disabled");
             disabled_runtime_profile()
         }
     }
+}
+
+fn runtime_scope_valid(config_valid: bool, profile: &RuntimeProfile) -> bool {
+    config_valid && profile.runtime_supported
 }
 
 /// No-op runtime control: every adapter step succeeds and the engine is
@@ -235,14 +249,17 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // file falls back to the defaults so the daemon still runs unconfigured.
     let uci_path = std::env::var("WLOC_UCI_CONFIG")
         .unwrap_or_else(|_| wificalling_location_gateway::config::uci::DEFAULT_UCI_PATH.into());
-    let uci = match WlocUciConfig::load(Path::new(&uci_path)) {
-        Ok(config) => config,
+    let (uci, config_valid) = match WlocUciConfig::load(Path::new(&uci_path)) {
+        Ok(config) => (config, true),
         Err(error) => {
             eprintln!("wloc-service: {error}; using disabled defaults");
-            WlocUciConfig {
-                enabled: false,
-                ..WlocUciConfig::default()
-            }
+            (
+                WlocUciConfig {
+                    enabled: false,
+                    ..WlocUciConfig::default()
+                },
+                false,
+            )
         }
     };
     let runtime_profile = runtime_profile_from_uci(&uci);
@@ -250,7 +267,9 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
     // instead of a fixed example address.
-    let assigned_device = if runtime_profile
+    let assigned_device = if !runtime_profile.runtime_supported {
+        String::new()
+    } else if runtime_profile
         .assigned_device
         .as_deref()
         .unwrap_or_default()
@@ -299,7 +318,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             probe_limits: ProbeLimits {
                 max_observation_age: Duration::from_secs(uci.probe_interval_secs),
             },
-            scope_valid: true,
+            scope_valid: runtime_scope_valid(config_valid, &runtime_profile),
             ipv6_ready: true,
             assigned_device_configured: !assigned_device.is_empty(),
             assigned_device: if assigned_device.is_empty() {
@@ -670,5 +689,22 @@ mod tests {
         let profile = runtime_profile_from_uci(&config);
         assert!(!profile.enabled);
         assert_eq!(profile.id, "invalid");
+    }
+
+    #[test]
+    fn mac_profile_is_not_enabled_until_runtime_resolution_exists() {
+        let config = WlocUciConfig::parse(
+            "config device 'phone'\n\toption assigned_device 'aa:bb:cc:dd:ee:ff'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert!(!profile.enabled);
+        assert!(!profile.runtime_supported);
+    }
+
+    #[test]
+    fn invalid_uci_cannot_be_enabled_from_the_control_socket() {
+        let profile = disabled_runtime_profile();
+        assert!(!runtime_scope_valid(false, &profile));
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -153,17 +153,20 @@ fn build_probe(assigned_device: &str, probe_port: u16) -> Box<dyn ExitProbeRunti
             .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
     );
     let probe_port: u16 = env_or("WLOC_PROBE_PORT", probe_port);
-    Box::new(
-        wificalling_location_gateway::exitprobe::singbox::SingBoxProbe::new(
-            std::path::PathBuf::from(
-                std::env::var("WLOC_SINGBOX_CONFIG")
-                    .unwrap_or_else(|_| "/var/run/wificalling-gateway/sing-box.json".into()),
-            ),
-            device_ip,
-            probe_port,
-            std::path::PathBuf::from("/tmp/wloc-probe"),
+    let probe = wificalling_location_gateway::exitprobe::singbox::SingBoxProbe::new(
+        std::path::PathBuf::from(
+            std::env::var("WLOC_SINGBOX_CONFIG")
+                .unwrap_or_else(|_| "/var/run/wificalling-gateway/sing-box.json".into()),
         ),
-    )
+        device_ip,
+        probe_port,
+        std::path::PathBuf::from("/tmp/wloc-probe"),
+    );
+    if assigned_device.trim().is_empty() {
+        Box::new(probe)
+    } else {
+        Box::new(probe.with_required_device_binding())
+    }
 }
 
 /// Stub Geo provider: returns a fixed, valid record for the queried exit.
@@ -246,11 +249,16 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .unwrap_or_else(|_| "/var/run/wloc-service/control.sock".into());
 
     // Persisted configuration from /etc/config/wloc-service (UCI). A missing
-    // file falls back to the defaults so the daemon still runs unconfigured.
+    // file preserves the v1 unconfigured-default behavior; an existing but
+    // invalid file is fail-closed and cannot later be enabled over the socket.
     let uci_path = std::env::var("WLOC_UCI_CONFIG")
         .unwrap_or_else(|_| wificalling_location_gateway::config::uci::DEFAULT_UCI_PATH.into());
     let (uci, config_valid) = match WlocUciConfig::load(Path::new(&uci_path)) {
         Ok(config) => (config, true),
+        Err(error) if !Path::new(&uci_path).exists() => {
+            eprintln!("wloc-service: {error}; using unconfigured defaults");
+            (WlocUciConfig::default(), true)
+        }
         Err(error) => {
             eprintln!("wloc-service: {error}; using disabled defaults");
             (

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,5 +12,6 @@ pub mod uci;
 pub use profile::{
     validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
     validate_profile_label, DeviceProfile, NodeSelectionMode, ProfileError, ProfileModel,
+    RuntimeProfile,
 };
 pub use uci::{LocationMode, Preset, UciError, WlocUciConfig};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,11 @@
 //! only writer; keeping the parser inside the daemon means the root-only
 //! control API stays the single runtime write path.
 
+pub mod profile;
 pub mod uci;
 
+pub use profile::{
+    validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
+    validate_profile_label, DeviceProfile, NodeSelectionMode, ProfileError, ProfileModel,
+};
 pub use uci::{LocationMode, Preset, UciError, WlocUciConfig};

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -320,6 +320,9 @@ fn is_valid_device_address(value: &str) -> bool {
                     || ip.is_multicast()
                     || ip == std::net::Ipv4Addr::BROADCAST
                     || (octets[0] == 169 && octets[1] == 254))
+                    && (octets[0] == 10
+                        || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                        || (octets[0] == 192 && octets[1] == 168))
             }
             IpAddr::V6(ip) => {
                 let first = ip.segments()[0];
@@ -327,6 +330,7 @@ fn is_valid_device_address(value: &str) -> bool {
                     && !ip.is_loopback()
                     && !ip.is_multicast()
                     && (first & 0xffc0) != 0xfe80
+                    && (first & 0xfe00) == 0xfc00
             }
         };
     }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,282 @@
+//! Bounded v2 device profiles.
+//!
+//! A profile is the unit that will eventually connect one LAN device to one
+//! node, one WLOC location policy, and one service lifecycle.  This module is
+//! deliberately independent from runtime control: validation happens before
+//! any UCI write, nftables operation, or child-process change.
+
+use std::fmt;
+use std::net::IpAddr;
+
+use serde::Serialize;
+
+use super::uci::{LocationMode, WlocUciConfig};
+
+pub const MAX_PROFILES: usize = 8;
+pub const MAX_PROFILE_ID_BYTES: usize = 32;
+pub const MAX_PROFILE_LABEL_BYTES: usize = 48;
+pub const MAX_NODE_REF_BYTES: usize = 96;
+pub const MAX_LOCATION_REF_BYTES: usize = 64;
+pub const MAX_SERIALIZED_PROFILES_BYTES: usize = 8 * 1024;
+pub const MAX_REDACTED_STATUS_BYTES: usize = 4 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeSelectionMode {
+    Fixed,
+    GatewayDefault,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DeviceProfile {
+    pub id: String,
+    pub label: String,
+    pub assigned_device: Option<String>,
+    pub node_ref: String,
+    pub node_mode: NodeSelectionMode,
+    pub location_mode: LocationMode,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
+    pub manual_location_ref: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProfileError {
+    TooManyProfiles,
+    DuplicateId(String),
+    MissingAssignedDevice,
+    EmptyField(&'static str),
+    FieldTooLong { field: &'static str, max: usize },
+    InvalidProfileId(String),
+    InvalidDeviceAddress(String),
+    InvalidNodeRef,
+    IncompleteLocation,
+    InvalidLocation,
+    SerializedTooLarge,
+}
+
+impl fmt::Display for ProfileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooManyProfiles => write!(formatter, "too many device profiles"),
+            Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
+            Self::MissingAssignedDevice => {
+                formatter.write_str("assigned device address is required")
+            }
+            Self::EmptyField(field) => write!(formatter, "profile field is empty: {field}"),
+            Self::FieldTooLong { field, max } => {
+                write!(
+                    formatter,
+                    "profile field is too long: {field} (max {max} bytes)"
+                )
+            }
+            Self::InvalidProfileId(id) => write!(formatter, "invalid device profile id: {id}"),
+            Self::InvalidDeviceAddress(address) => {
+                write!(formatter, "invalid assigned device address: {address}")
+            }
+            Self::InvalidNodeRef => formatter.write_str("invalid node reference"),
+            Self::IncompleteLocation => formatter.write_str("manual location is incomplete"),
+            Self::InvalidLocation => formatter.write_str("manual location is invalid"),
+            Self::SerializedTooLarge => formatter.write_str("device profiles exceed storage bound"),
+        }
+    }
+}
+
+impl std::error::Error for ProfileError {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProfileModel {
+    profiles: Vec<DeviceProfile>,
+}
+
+#[derive(Serialize)]
+struct RedactedProfileStatus<'a> {
+    profile_id: &'a str,
+    label: &'a str,
+    enabled: bool,
+    node_mode: NodeSelectionMode,
+    location_mode: LocationMode,
+    assigned_device_configured: bool,
+    manual_location_configured: bool,
+}
+
+impl ProfileModel {
+    pub fn new(profiles: Vec<DeviceProfile>) -> Result<Self, ProfileError> {
+        let model = Self { profiles };
+        model.validate()?;
+        Ok(model)
+    }
+
+    /// Convert the v1 singleton configuration without changing its effective
+    /// behavior. Re-running this function produces the same model.
+    pub fn from_legacy(config: &WlocUciConfig) -> Result<Self, ProfileError> {
+        let has_manual_coordinates =
+            config.manual_latitude.is_some() || config.manual_longitude.is_some();
+        Self::new(vec![DeviceProfile {
+            id: "default".to_owned(),
+            label: "Default device".to_owned(),
+            assigned_device: (!config.assigned_device.trim().is_empty())
+                .then(|| config.assigned_device.clone()),
+            node_ref: config.node_ref.clone(),
+            node_mode: NodeSelectionMode::Fixed,
+            location_mode: config.location_mode,
+            manual_latitude: config.manual_latitude,
+            manual_longitude: config.manual_longitude,
+            manual_location_ref: has_manual_coordinates.then(|| "legacy-manual".to_owned()),
+            enabled: config.enabled,
+        }])
+    }
+
+    pub fn profiles(&self) -> &[DeviceProfile] {
+        &self.profiles
+    }
+
+    /// Validate a candidate before replacing the current model. The existing
+    /// value is left untouched on every error.
+    pub fn replace(&mut self, profiles: Vec<DeviceProfile>) -> Result<(), ProfileError> {
+        let candidate = Self::new(profiles)?;
+        self.profiles = candidate.profiles;
+        Ok(())
+    }
+
+    pub fn redacted_status(&self) -> Result<Vec<serde_json::Value>, ProfileError> {
+        let status: Vec<_> = self
+            .profiles
+            .iter()
+            .map(|profile| {
+                serde_json::to_value(RedactedProfileStatus {
+                    profile_id: &profile.id,
+                    label: &profile.label,
+                    enabled: profile.enabled,
+                    node_mode: profile.node_mode,
+                    location_mode: profile.location_mode,
+                    assigned_device_configured: profile.assigned_device.is_some(),
+                    manual_location_configured: profile.manual_latitude.is_some()
+                        && profile.manual_longitude.is_some(),
+                })
+                .map_err(|_| ProfileError::SerializedTooLarge)
+            })
+            .collect::<Result<_, _>>()?;
+        let encoded = serde_json::to_vec(&status).map_err(|_| ProfileError::SerializedTooLarge)?;
+        if encoded.len() > MAX_REDACTED_STATUS_BYTES {
+            return Err(ProfileError::SerializedTooLarge);
+        }
+        Ok(status)
+    }
+
+    fn validate(&self) -> Result<(), ProfileError> {
+        if self.profiles.len() > MAX_PROFILES {
+            return Err(ProfileError::TooManyProfiles);
+        }
+        let mut ids = Vec::with_capacity(self.profiles.len());
+        for profile in &self.profiles {
+            validate_profile_id(&profile.id)?;
+            if !ids.iter().any(|id: &String| id == &profile.id) {
+                ids.push(profile.id.clone());
+            } else {
+                return Err(ProfileError::DuplicateId(profile.id.clone()));
+            }
+            validate_bounded_text("label", &profile.label, MAX_PROFILE_LABEL_BYTES)?;
+            if let Some(address) = profile.assigned_device.as_deref() {
+                validate_device_address(address)?;
+            }
+            validate_node_ref(&profile.node_ref)?;
+            if let Some(reference) = profile.manual_location_ref.as_deref() {
+                validate_location_ref(reference)?;
+            }
+            let has_latitude = profile.manual_latitude.is_some();
+            let has_longitude = profile.manual_longitude.is_some();
+            if has_latitude != has_longitude {
+                return Err(ProfileError::IncompleteLocation);
+            }
+            if let (Some(latitude), Some(longitude)) =
+                (profile.manual_latitude, profile.manual_longitude)
+            {
+                if !latitude.is_finite()
+                    || !longitude.is_finite()
+                    || !(-90.0..=90.0).contains(&latitude)
+                    || !(-180.0..=180.0).contains(&longitude)
+                {
+                    return Err(ProfileError::InvalidLocation);
+                }
+            }
+            if profile.location_mode == LocationMode::Manual && !(has_latitude && has_longitude) {
+                return Err(ProfileError::IncompleteLocation);
+            }
+        }
+        let encoded =
+            serde_json::to_vec(&self.profiles).map_err(|_| ProfileError::SerializedTooLarge)?;
+        if encoded.len() > MAX_SERIALIZED_PROFILES_BYTES {
+            return Err(ProfileError::SerializedTooLarge);
+        }
+        Ok(())
+    }
+}
+
+pub fn validate_profile_id(value: &str) -> Result<(), ProfileError> {
+    if value.is_empty() {
+        return Err(ProfileError::EmptyField("id"));
+    }
+    if value.len() > MAX_PROFILE_ID_BYTES
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
+    {
+        return Err(ProfileError::InvalidProfileId(value.to_owned()));
+    }
+    Ok(())
+}
+
+pub fn validate_device_address(value: &str) -> Result<(), ProfileError> {
+    if !is_valid_device_address(value) {
+        return Err(ProfileError::InvalidDeviceAddress(value.to_owned()));
+    }
+    Ok(())
+}
+
+pub fn validate_node_ref(value: &str) -> Result<(), ProfileError> {
+    if value.is_empty()
+        || value.len() > MAX_NODE_REF_BYTES
+        || value.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || character == '/'
+                || character == '\\'
+        })
+    {
+        return Err(ProfileError::InvalidNodeRef);
+    }
+    Ok(())
+}
+
+pub fn validate_profile_label(value: &str) -> Result<(), ProfileError> {
+    validate_bounded_text("label", value, MAX_PROFILE_LABEL_BYTES)
+}
+
+pub fn validate_location_ref(value: &str) -> Result<(), ProfileError> {
+    validate_bounded_text("manual_location_ref", value, MAX_LOCATION_REF_BYTES)
+}
+
+fn validate_bounded_text(field: &'static str, value: &str, max: usize) -> Result<(), ProfileError> {
+    if value.is_empty() {
+        return Err(ProfileError::EmptyField(field));
+    }
+    if value.len() > max {
+        return Err(ProfileError::FieldTooLong { field, max });
+    }
+    Ok(())
+}
+
+fn is_valid_device_address(value: &str) -> bool {
+    value.parse::<IpAddr>().is_ok() || is_valid_mac(value)
+}
+
+fn is_valid_mac(value: &str) -> bool {
+    let separator = if value.contains(':') { ':' } else { '-' };
+    let parts: Vec<_> = value.split(separator).collect();
+    parts.len() == 6
+        && parts
+            .iter()
+            .all(|part| part.len() == 2 && part.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -19,6 +19,7 @@ pub const MAX_NODE_REF_BYTES: usize = 96;
 pub const MAX_LOCATION_REF_BYTES: usize = 64;
 pub const MAX_SERIALIZED_PROFILES_BYTES: usize = 8 * 1024;
 pub const MAX_REDACTED_STATUS_BYTES: usize = 4 * 1024;
+pub const MAX_UCI_TEXT_BYTES: usize = 32 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +47,7 @@ pub enum ProfileError {
     TooManyProfiles,
     DuplicateId(String),
     MissingAssignedDevice,
+    MultipleProfilesRequireUnifiedRuntime,
     EmptyField(&'static str),
     FieldTooLong { field: &'static str, max: usize },
     InvalidProfileId(String),
@@ -63,6 +65,9 @@ impl fmt::Display for ProfileError {
             Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
             Self::MissingAssignedDevice => {
                 formatter.write_str("assigned device address is required")
+            }
+            Self::MultipleProfilesRequireUnifiedRuntime => {
+                formatter.write_str("multiple profiles require the unified runtime")
             }
             Self::EmptyField(field) => write!(formatter, "profile field is empty: {field}"),
             Self::FieldTooLong { field, max } => {
@@ -88,6 +93,17 @@ impl std::error::Error for ProfileError {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProfileModel {
     profiles: Vec<DeviceProfile>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RuntimeProfile {
+    pub id: String,
+    pub enabled: bool,
+    pub assigned_device: Option<String>,
+    pub node_ref: String,
+    pub location_mode: LocationMode,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -130,6 +146,26 @@ impl ProfileModel {
 
     pub fn profiles(&self) -> &[DeviceProfile] {
         &self.profiles
+    }
+
+    /// The current daemon is still a single-runtime process. It may consume
+    /// exactly one profile, but must refuse to guess when multiple profiles
+    /// are configured before unified multi-device routing lands.
+    pub fn single_runtime_profile(&self) -> Result<RuntimeProfile, ProfileError> {
+        let profile = self
+            .profiles
+            .first()
+            .filter(|_| self.profiles.len() == 1)
+            .ok_or(ProfileError::MultipleProfilesRequireUnifiedRuntime)?;
+        Ok(RuntimeProfile {
+            id: profile.id.clone(),
+            enabled: profile.enabled,
+            assigned_device: profile.assigned_device.clone(),
+            node_ref: profile.node_ref.clone(),
+            location_mode: profile.location_mode,
+            manual_latitude: profile.manual_latitude,
+            manual_longitude: profile.manual_longitude,
+        })
     }
 
     /// Validate a candidate before replacing the current model. The existing
@@ -269,14 +305,40 @@ fn validate_bounded_text(field: &'static str, value: &str, max: usize) -> Result
 }
 
 fn is_valid_device_address(value: &str) -> bool {
-    value.parse::<IpAddr>().is_ok() || is_valid_mac(value)
+    if let Ok(address) = value.parse::<IpAddr>() {
+        return match address {
+            IpAddr::V4(ip) => {
+                let octets = ip.octets();
+                !ip.is_unspecified()
+                    && !ip.is_loopback()
+                    && !ip.is_multicast()
+                    && ip != std::net::Ipv4Addr::BROADCAST
+                    && !(octets[0] == 169 && octets[1] == 254)
+            }
+            IpAddr::V6(ip) => {
+                let first = ip.segments()[0];
+                !ip.is_unspecified()
+                    && !ip.is_loopback()
+                    && !ip.is_multicast()
+                    && (first & 0xffc0) != 0xfe80
+            }
+        };
+    }
+    is_valid_mac(value)
 }
 
 fn is_valid_mac(value: &str) -> bool {
     let separator = if value.contains(':') { ':' } else { '-' };
     let parts: Vec<_> = value.split(separator).collect();
+    let first = parts
+        .first()
+        .and_then(|part| u8::from_str_radix(part, 16).ok());
     parts.len() == 6
         && parts
             .iter()
             .all(|part| part.len() == 2 && part.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        && parts
+            .iter()
+            .any(|part| part.bytes().any(|byte| byte != b'0'))
+        && first.is_some_and(|byte| byte & 1 == 0)
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -99,6 +99,7 @@ pub struct ProfileModel {
 pub struct RuntimeProfile {
     pub id: String,
     pub enabled: bool,
+    pub runtime_supported: bool,
     pub assigned_device: Option<String>,
     pub node_ref: String,
     pub location_mode: LocationMode,
@@ -160,6 +161,11 @@ impl ProfileModel {
         Ok(RuntimeProfile {
             id: profile.id.clone(),
             enabled: profile.enabled,
+            runtime_supported: profile
+                .assigned_device
+                .as_deref()
+                .map(|address| address.parse::<IpAddr>().is_ok())
+                .unwrap_or(true),
             assigned_device: profile.assigned_device.clone(),
             node_ref: profile.node_ref.clone(),
             location_mode: profile.location_mode,

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -309,11 +309,11 @@ fn is_valid_device_address(value: &str) -> bool {
         return match address {
             IpAddr::V4(ip) => {
                 let octets = ip.octets();
-                !ip.is_unspecified()
-                    && !ip.is_loopback()
-                    && !ip.is_multicast()
-                    && ip != std::net::Ipv4Addr::BROADCAST
-                    && !(octets[0] == 169 && octets[1] == 254)
+                !(ip.is_unspecified()
+                    || ip.is_loopback()
+                    || ip.is_multicast()
+                    || ip == std::net::Ipv4Addr::BROADCAST
+                    || (octets[0] == 169 && octets[1] == 254))
             }
             IpAddr::V6(ip) => {
                 let first = ip.segments()[0];

--- a/src/config/uci.rs
+++ b/src/config/uci.rs
@@ -81,6 +81,8 @@ pub enum UciError {
     Coordinate { option: String, value: String },
     /// A device profile section failed v2 validation.
     Profile(String),
+    /// The complete UCI input exceeds the small-gateway parser bound.
+    ConfigTooLarge,
 }
 
 impl fmt::Display for UciError {
@@ -94,6 +96,7 @@ impl fmt::Display for UciError {
                 write!(f, "invalid {option} coordinate: {value}")
             }
             UciError::Profile(message) => write!(f, "invalid device profile: {message}"),
+            UciError::ConfigTooLarge => write!(f, "UCI configuration exceeds the size limit"),
         }
     }
 }
@@ -123,6 +126,11 @@ impl PresetBuilder {
 impl WlocUciConfig {
     /// Read and parse the daemon configuration file.
     pub fn load(path: &Path) -> Result<Self, UciError> {
+        let metadata =
+            std::fs::metadata(path).map_err(|_| UciError::Io(path.display().to_string()))?;
+        if metadata.len() > super::profile::MAX_UCI_TEXT_BYTES as u64 {
+            return Err(UciError::ConfigTooLarge);
+        }
         let text =
             std::fs::read_to_string(path).map_err(|_| UciError::Io(path.display().to_string()))?;
         Self::parse(&text)
@@ -142,6 +150,9 @@ impl WlocUciConfig {
 
     /// Parse UCI text. A missing `main` section yields the defaults.
     pub fn parse(text: &str) -> Result<Self, UciError> {
+        if text.len() > super::profile::MAX_UCI_TEXT_BYTES {
+            return Err(UciError::ConfigTooLarge);
+        }
         let mut config = Self::default();
         let mut section_type: Option<String> = None;
         let mut section_name: Option<String> = None;

--- a/src/config/uci.rs
+++ b/src/config/uci.rs
@@ -10,6 +10,8 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
+use serde::Serialize;
+
 pub const DEFAULT_UCI_PATH: &str = "/etc/config/wloc-service";
 pub const DEFAULT_PROBE_PORT: u16 = 18080;
 pub const DEFAULT_PROBE_INTERVAL_SECS: u64 = 300;
@@ -17,7 +19,8 @@ const DEFAULT_NODE_REF: &str = "default";
 
 /// Where the location target comes from: follow the bound node's exit, or
 /// use the manually configured coordinates.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LocationMode {
     Auto,
     Manual,
@@ -45,6 +48,9 @@ pub struct WlocUciConfig {
     pub geo_provider: String,
     pub probe_port: u16,
     pub presets: Vec<Preset>,
+    /// Explicit v2 device sections. An empty list means the legacy singleton
+    /// fields above are still the source and can be migrated by `profile_model`.
+    pub profiles: Vec<super::profile::DeviceProfile>,
 }
 
 impl Default for WlocUciConfig {
@@ -60,6 +66,7 @@ impl Default for WlocUciConfig {
             geo_provider: "http".to_owned(),
             probe_port: DEFAULT_PROBE_PORT,
             presets: Vec::new(),
+            profiles: Vec::new(),
         }
     }
 }
@@ -72,6 +79,8 @@ pub enum UciError {
     Syntax { line: usize, text: String },
     /// A coordinate value is not a valid f64.
     Coordinate { option: String, value: String },
+    /// A device profile section failed v2 validation.
+    Profile(String),
 }
 
 impl fmt::Display for UciError {
@@ -84,6 +93,7 @@ impl fmt::Display for UciError {
             UciError::Coordinate { option, value } => {
                 write!(f, "invalid {option} coordinate: {value}")
             }
+            UciError::Profile(message) => write!(f, "invalid device profile: {message}"),
         }
     }
 }
@@ -118,12 +128,25 @@ impl WlocUciConfig {
         Self::parse(&text)
     }
 
+    /// Return the explicit v2 profiles, or a deterministic singleton model
+    /// synthesized from the v1 fields when no device sections exist.
+    pub fn profile_model(
+        &self,
+    ) -> Result<super::profile::ProfileModel, super::profile::ProfileError> {
+        if self.profiles.is_empty() {
+            super::profile::ProfileModel::from_legacy(self)
+        } else {
+            super::profile::ProfileModel::new(self.profiles.clone())
+        }
+    }
+
     /// Parse UCI text. A missing `main` section yields the defaults.
     pub fn parse(text: &str) -> Result<Self, UciError> {
         let mut config = Self::default();
         let mut section_type: Option<String> = None;
         let mut section_name: Option<String> = None;
         let mut preset: Option<PresetBuilder> = None;
+        let mut device: Option<DeviceBuilder> = None;
 
         for (index, raw_line) in text.lines().enumerate() {
             let line = raw_line.trim();
@@ -139,14 +162,25 @@ impl WlocUciConfig {
                     if let Some(builder) = preset.take() {
                         config.presets.push(builder.finish());
                     }
+                    if let Some(builder) = device.take() {
+                        config
+                            .profiles
+                            .push(builder.finish().map_err(profile_error)?);
+                    }
                     match tokens.as_slice() {
                         [_keyword, type_name, name, ..] => {
                             section_type = Some(type_name.clone());
                             section_name = Some(name.clone());
+                            if type_name == "device" {
+                                device = Some(DeviceBuilder::new(name.clone()));
+                            }
                         }
                         [_keyword, type_name] => {
                             section_type = Some(type_name.clone());
                             section_name = None;
+                            if type_name == "device" {
+                                device = Some(DeviceBuilder::new("default".to_owned()));
+                            }
                         }
                         _ => {
                             return Err(UciError::Syntax {
@@ -169,6 +203,7 @@ impl WlocUciConfig {
                     apply_option(
                         &mut config,
                         &mut preset,
+                        &mut device,
                         section_type.as_deref(),
                         section_name.as_deref(),
                         name,
@@ -186,6 +221,14 @@ impl WlocUciConfig {
         }
         if let Some(builder) = preset.take() {
             config.presets.push(builder.finish());
+        }
+        if let Some(builder) = device.take() {
+            config
+                .profiles
+                .push(builder.finish().map_err(profile_error)?);
+        }
+        if !config.profiles.is_empty() {
+            super::profile::ProfileModel::new(config.profiles.clone()).map_err(profile_error)?;
         }
         Ok(config)
     }
@@ -224,6 +267,7 @@ fn split_uci_tokens(line: &str) -> Option<Vec<String>> {
 fn apply_option(
     config: &mut WlocUciConfig,
     preset: &mut Option<PresetBuilder>,
+    device: &mut Option<DeviceBuilder>,
     section_type: Option<&str>,
     section_name: Option<&str>,
     name: &str,
@@ -239,6 +283,35 @@ fn apply_option(
                 "label" => builder.label = value.to_owned(),
                 "latitude" => builder.latitude = parse_coord(name, value)?,
                 "longitude" => builder.longitude = parse_coord(name, value)?,
+                _ => {}
+            }
+        }
+        Some("device") => {
+            let builder = device.as_mut().ok_or_else(|| {
+                UciError::Profile("device option outside a device section".to_owned())
+            })?;
+            match name {
+                "label" | "name" => builder.label = value.to_owned(),
+                "assigned_device" => builder.assigned_device = Some(value.to_owned()),
+                "node_ref" => builder.node_ref = value.to_owned(),
+                "node_mode" => {
+                    builder.node_mode = match value {
+                        "fixed" => super::profile::NodeSelectionMode::Fixed,
+                        "gateway_default" => super::profile::NodeSelectionMode::GatewayDefault,
+                        _ => return Err(UciError::Profile("unknown node_mode".to_owned())),
+                    }
+                }
+                "geo_source" => {
+                    builder.location_mode = match value {
+                        "auto" => LocationMode::Auto,
+                        "manual" => LocationMode::Manual,
+                        _ => return Err(UciError::Profile("unknown geo_source".to_owned())),
+                    }
+                }
+                "manual_lat" => builder.manual_latitude = Some(parse_coord(name, value)?),
+                "manual_lon" => builder.manual_longitude = Some(parse_coord(name, value)?),
+                "manual_location_ref" => builder.manual_location_ref = Some(value.to_owned()),
+                "enabled" => builder.enabled = matches!(value, "1" | "true" | "on"),
                 _ => {}
             }
         }
@@ -266,6 +339,59 @@ fn apply_option(
         _ => {}
     }
     Ok(())
+}
+
+fn profile_error(error: super::profile::ProfileError) -> UciError {
+    UciError::Profile(error.to_string())
+}
+
+struct DeviceBuilder {
+    id: String,
+    label: String,
+    assigned_device: Option<String>,
+    node_ref: String,
+    node_mode: super::profile::NodeSelectionMode,
+    location_mode: LocationMode,
+    manual_latitude: Option<f64>,
+    manual_longitude: Option<f64>,
+    manual_location_ref: Option<String>,
+    enabled: bool,
+}
+
+impl DeviceBuilder {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            label: "Default device".to_owned(),
+            assigned_device: None,
+            node_ref: DEFAULT_NODE_REF.to_owned(),
+            node_mode: super::profile::NodeSelectionMode::Fixed,
+            location_mode: LocationMode::Auto,
+            manual_latitude: None,
+            manual_longitude: None,
+            manual_location_ref: None,
+            enabled: true,
+        }
+    }
+
+    fn finish(self) -> Result<super::profile::DeviceProfile, super::profile::ProfileError> {
+        if self.assigned_device.is_none() {
+            return Err(super::profile::ProfileError::MissingAssignedDevice);
+        }
+        let profile = super::profile::DeviceProfile {
+            id: self.id,
+            label: self.label,
+            assigned_device: self.assigned_device,
+            node_ref: self.node_ref,
+            node_mode: self.node_mode,
+            location_mode: self.location_mode,
+            manual_latitude: self.manual_latitude,
+            manual_longitude: self.manual_longitude,
+            manual_location_ref: self.manual_location_ref,
+            enabled: self.enabled,
+        };
+        super::profile::ProfileModel::new(vec![profile.clone()]).map(|_| profile)
+    }
 }
 
 fn parse_coord(option: &str, value: &str) -> Result<f64, UciError> {

--- a/src/exitprobe/singbox.rs
+++ b/src/exitprobe/singbox.rs
@@ -289,6 +289,9 @@ pub struct SingBoxProbe {
     /// the bound node for devices that have no route rule (e.g. disabled
     /// Wi-Fi Calling policies), so follow-device still probes their node.
     uci_config_path: PathBuf,
+    /// When true, an explicit device binding is required. A missing binding
+    /// must not silently fall back to an unrelated outbound.
+    require_device_binding: bool,
 }
 
 impl SingBoxProbe {
@@ -306,7 +309,16 @@ impl SingBoxProbe {
             timeout: Duration::from_secs(15),
             singbox_bin: "/usr/bin/sing-box".to_owned(),
             uci_config_path: PathBuf::from("/etc/config/wificalling-gateway"),
+            require_device_binding: false,
         }
+    }
+
+    /// Require a matching Gateway policy for this probe target. This is used
+    /// by the profile-driven daemon; legacy callers may retain the historical
+    /// fallback behavior unless they opt in.
+    pub fn with_required_device_binding(mut self) -> Self {
+        self.require_device_binding = true;
+        self
     }
 
     /// Read the Gateway config and select the outbound for the test device.
@@ -336,6 +348,9 @@ impl SingBoxProbe {
             if config.endpoints.iter().any(|e| e.tag == tag) {
                 return Ok(tag);
             }
+        }
+        if self.require_device_binding {
+            return Err(ProbeFailure::Unreachable);
         }
         // 2. Fall back to the first non-direct outbound, then the first
         //    wireguard endpoint (a gateway with only wg nodes has no usable
@@ -646,6 +661,35 @@ mod tests {
         let _ = probe.probe_exit_ip();
         std::fs::remove_file(&config_path).unwrap();
         let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-fallback-work"));
+    }
+
+    #[test]
+    fn required_device_binding_never_falls_back_to_another_outbound() {
+        let doc = json!({"outbounds": [
+            {"type": "hysteria2", "tag": "node-a"},
+            {"type": "direct", "tag": "direct"}
+        ]});
+        let dir = std::env::temp_dir();
+        let config_path = dir.join("wloc-singbox-required-binding.json");
+        let uci_path = dir.join("wloc-singbox-required-binding-uci");
+        std::fs::write(&config_path, doc.to_string()).unwrap();
+        std::fs::write(
+            &uci_path,
+            "config device\n\tlist source_ip '192.168.31.177'\n",
+        )
+        .unwrap();
+        let mut probe = SingBoxProbe::new(
+            config_path.clone(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 31, 176)),
+            18080,
+            dir.join("wloc-singbox-required-binding-work"),
+        )
+        .with_required_device_binding();
+        probe.uci_config_path = uci_path.clone();
+        assert_eq!(probe.load_outbound_tag(), Err(ProbeFailure::Unreachable));
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::remove_file(&uci_path).unwrap();
+        let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-binding-work"));
     }
 
     #[test]

--- a/src/exitprobe/singbox.rs
+++ b/src/exitprobe/singbox.rs
@@ -335,7 +335,19 @@ impl SingBoxProbe {
         //    which the Gateway compiler names `wg-<section>` (sing-box
         //    1.11+), while the UCI binding resolves to `node-<section>`.
         let uci_text = std::fs::read_to_string(&self.uci_config_path).ok();
-        if let Some(tag) = select_node_tag(&document, uci_text.as_deref(), self.device_ip) {
+        let selected_tag = if self.require_device_binding {
+            // A profile-bound probe must never trust a generated route rule
+            // as a substitute for the Gateway's device policy. Route rules
+            // can be stale or orphaned after a node switch; accepting one
+            // here would let the probe follow a different device/node than
+            // the profile explicitly selected.
+            uci_text
+                .as_deref()
+                .and_then(|text| device_bound_node_tag(text, self.device_ip))
+        } else {
+            select_node_tag(&document, uci_text.as_deref(), self.device_ip)
+        };
+        if let Some(tag) = selected_tag {
             if config.outbounds.iter().any(|o| o.tag == tag) {
                 return Ok(tag);
             }
@@ -690,6 +702,43 @@ mod tests {
         std::fs::remove_file(&config_path).unwrap();
         std::fs::remove_file(&uci_path).unwrap();
         let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-binding-work"));
+    }
+
+    #[test]
+    fn required_device_binding_rejects_route_only_match() {
+        // A stale generated route rule can still point this device at an
+        // outbound even when Gateway UCI has no matching device policy. A
+        // profile-bound probe must reject that route-only match.
+        let doc = json!({
+            "outbounds": [
+                {"type": "hysteria2", "tag": "node-a"},
+                {"type": "direct", "tag": "direct"}
+            ],
+            "route": {"rules": [
+                {"source_ip_cidr": ["192.168.31.176/32"], "action": "route", "outbound": "node-a"}
+            ]}
+        });
+        let dir = std::env::temp_dir();
+        let config_path = dir.join("wloc-singbox-required-route-only.json");
+        let uci_path = dir.join("wloc-singbox-required-route-only-uci");
+        std::fs::write(&config_path, doc.to_string()).unwrap();
+        std::fs::write(
+            &uci_path,
+            "config device\n\tlist source_ip '192.168.31.177'\n",
+        )
+        .unwrap();
+        let mut probe = SingBoxProbe::new(
+            config_path.clone(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 31, 176)),
+            18080,
+            dir.join("wloc-singbox-required-route-only-work"),
+        )
+        .with_required_device_binding();
+        probe.uci_config_path = uci_path.clone();
+        assert_eq!(probe.load_outbound_tag(), Err(ProbeFailure::Unreachable));
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::remove_file(&uci_path).unwrap();
+        let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-route-only-work"));
     }
 
     #[test]

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -7,11 +7,224 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::{
+    validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
+    validate_profile_label,
+};
+
 pub const SERVICE_API_ID: &str = "wloc.service/v1";
+pub const SERVICE_API_V2_ID: &str = "wloc.service/v2";
 /// Single source of truth for the control-frame size bound. Re-exported from
 /// the transport codec so the API decoder and the frame layer cannot drift.
 pub use crate::runtime::uds::MAX_CONTROL_FRAME_BYTES;
 const MAX_REQUEST_ID_BYTES: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileApiMethod {
+    List,
+    Get,
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApiV2ErrorCode {
+    FrameTooLarge,
+    MalformedRequest,
+    IncompatibleVersion,
+    InvalidRequestId,
+    UnknownMethod,
+    InvalidParams,
+}
+
+impl ApiV2ErrorCode {
+    pub const fn wire_code(self) -> &'static str {
+        match self {
+            Self::FrameTooLarge => "frame_too_large",
+            Self::MalformedRequest => "malformed_request",
+            Self::IncompatibleVersion => "incompatible_version",
+            Self::InvalidRequestId => "invalid_request_id",
+            Self::UnknownMethod => "unknown_method",
+            Self::InvalidParams => "invalid_params",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfileRequestParams {
+    pub profile_id: Option<String>,
+    pub label: Option<String>,
+    pub assigned_device: Option<String>,
+    pub node_ref: Option<String>,
+    pub node_mode: Option<String>,
+    pub geo_source: Option<String>,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
+    pub manual_location_ref: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApiV2ProfileRequest {
+    api_version: String,
+    request_id: String,
+    method: ProfileApiMethod,
+    params: ProfileRequestParams,
+}
+
+impl ApiV2ProfileRequest {
+    pub fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub const fn method(&self) -> ProfileApiMethod {
+        self.method
+    }
+
+    pub fn params(&self) -> &ProfileRequestParams {
+        &self.params
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireV2ProfileRequest {
+    api_version: String,
+    request_id: String,
+    method: String,
+    #[serde(default)]
+    params: WireV2ProfileParams,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct WireV2ProfileParams {
+    #[serde(default)]
+    profile_id: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    assigned_device: Option<String>,
+    #[serde(default)]
+    node_ref: Option<String>,
+    #[serde(default)]
+    node_mode: Option<String>,
+    #[serde(default)]
+    geo_source: Option<String>,
+    #[serde(default)]
+    manual_lat: Option<f64>,
+    #[serde(default)]
+    manual_lon: Option<f64>,
+    #[serde(default)]
+    manual_location_ref: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+impl From<WireV2ProfileParams> for ProfileRequestParams {
+    fn from(params: WireV2ProfileParams) -> Self {
+        Self {
+            profile_id: params.profile_id,
+            label: params.label,
+            assigned_device: params.assigned_device,
+            node_ref: params.node_ref,
+            node_mode: params.node_mode,
+            geo_source: params.geo_source,
+            manual_latitude: params.manual_lat,
+            manual_longitude: params.manual_lon,
+            manual_location_ref: params.manual_location_ref,
+            enabled: params.enabled,
+        }
+    }
+}
+
+/// Decode profile-management requests for the additive v2 API. Runtime
+/// dispatch is intentionally a later issue; decoding and validation are
+/// complete before any handler can receive the request.
+pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, ApiV2ErrorCode> {
+    if frame.is_empty() {
+        return Err(ApiV2ErrorCode::MalformedRequest);
+    }
+    if frame.len() > MAX_CONTROL_FRAME_BYTES {
+        return Err(ApiV2ErrorCode::FrameTooLarge);
+    }
+    let wire: WireV2ProfileRequest =
+        serde_json::from_slice(frame).map_err(|_| ApiV2ErrorCode::MalformedRequest)?;
+    if wire.api_version != SERVICE_API_V2_ID {
+        return Err(ApiV2ErrorCode::IncompatibleVersion);
+    }
+    if !valid_request_id(&wire.request_id) {
+        return Err(ApiV2ErrorCode::InvalidRequestId);
+    }
+    let method = match wire.method.as_str() {
+        "profile.list" => ProfileApiMethod::List,
+        "profile.get" => ProfileApiMethod::Get,
+        "profile.create" => ProfileApiMethod::Create,
+        "profile.update" => ProfileApiMethod::Update,
+        "profile.delete" => ProfileApiMethod::Delete,
+        _ => return Err(ApiV2ErrorCode::UnknownMethod),
+    };
+    if let Some(profile_id) = wire.params.profile_id.as_deref() {
+        validate_profile_id(profile_id).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if matches!(
+        method,
+        ProfileApiMethod::Get | ProfileApiMethod::Update | ProfileApiMethod::Delete
+    ) && wire.params.profile_id.is_none()
+    {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
+    validate_v2_profile_params(&wire.params)?;
+    Ok(ApiV2ProfileRequest {
+        api_version: wire.api_version,
+        request_id: wire.request_id,
+        method,
+        params: wire.params.into(),
+    })
+}
+
+fn validate_v2_profile_params(params: &WireV2ProfileParams) -> Result<(), ApiV2ErrorCode> {
+    if let Some(label) = params.label.as_deref() {
+        validate_profile_label(label).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(address) = params.assigned_device.as_deref() {
+        validate_device_address(address).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(node_ref) = params.node_ref.as_deref() {
+        validate_node_ref(node_ref).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(node_mode) = params.node_mode.as_deref() {
+        if !matches!(node_mode, "fixed" | "gateway_default") {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    if let Some(geo_source) = params.geo_source.as_deref() {
+        if !matches!(geo_source, "auto" | "manual") {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    if let Some(reference) = params.manual_location_ref.as_deref() {
+        validate_location_ref(reference).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if params.manual_lat.is_some() != params.manual_lon.is_some() {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
+    if let (Some(latitude), Some(longitude)) = (params.manual_lat, params.manual_lon) {
+        if !latitude.is_finite()
+            || !longitude.is_finite()
+            || !(-90.0..=90.0).contains(&latitude)
+            || !(-180.0..=180.0).contains(&longitude)
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    Ok(())
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ApiMethod {
@@ -204,8 +417,8 @@ struct ErrorResponse<'a> {
 }
 
 #[derive(Serialize)]
-struct ResultResponse {
-    api_version: &'static str,
+struct VersionedResultResponse<'a> {
+    api_version: &'a str,
     request_id: String,
     result: serde_json::Value,
 }
@@ -257,8 +470,25 @@ pub fn encode_result_response(
     request_id: &str,
     result: &serde_json::Value,
 ) -> Result<Vec<u8>, ResponseEncodeError> {
-    let response = ResultResponse {
-        api_version: SERVICE_API_ID,
+    encode_versioned_result_response(SERVICE_API_ID, request_id, result)
+}
+
+/// Encode a bounded v2 profile response. Runtime dispatch remains a later
+/// issue, but UI clients can share the reviewed v1/v2 envelope shape.
+pub fn encode_v2_result_response(
+    request_id: &str,
+    result: &serde_json::Value,
+) -> Result<Vec<u8>, ResponseEncodeError> {
+    encode_versioned_result_response(SERVICE_API_V2_ID, request_id, result)
+}
+
+fn encode_versioned_result_response(
+    api_version: &str,
+    request_id: &str,
+    result: &serde_json::Value,
+) -> Result<Vec<u8>, ResponseEncodeError> {
+    let response = VersionedResultResponse {
+        api_version,
         request_id: request_id.to_owned(),
         result: result.clone(),
     };

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -186,6 +186,23 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
     {
         return Err(ApiV2ErrorCode::InvalidParams);
     }
+    if method == ProfileApiMethod::Create {
+        if wire.params.profile_id.is_none()
+            || wire.params.label.is_none()
+            || wire.params.assigned_device.is_none()
+            || wire.params.node_ref.is_none()
+            || wire.params.node_mode.is_none()
+            || wire.params.geo_source.is_none()
+            || wire.params.enabled.is_none()
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+        if wire.params.geo_source.as_deref() == Some("manual")
+            && (wire.params.manual_lat.is_none() || wire.params.manual_lon.is_none())
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
     validate_v2_profile_params(&wire.params)?;
     Ok(ApiV2ProfileRequest {
         api_version: wire.api_version,

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -179,6 +179,13 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
     {
         return Err(ApiV2ErrorCode::InvalidParams);
     }
+    if matches!(
+        method,
+        ProfileApiMethod::List | ProfileApiMethod::Get | ProfileApiMethod::Delete
+    ) && has_non_identity_profile_params(&wire.params)
+    {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
     validate_v2_profile_params(&wire.params)?;
     Ok(ApiV2ProfileRequest {
         api_version: wire.api_version,
@@ -186,6 +193,18 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
         method,
         params: wire.params.into(),
     })
+}
+
+fn has_non_identity_profile_params(params: &WireV2ProfileParams) -> bool {
+    params.label.is_some()
+        || params.assigned_device.is_some()
+        || params.node_ref.is_some()
+        || params.node_mode.is_some()
+        || params.geo_source.is_some()
+        || params.manual_lat.is_some()
+        || params.manual_lon.is_some()
+        || params.manual_location_ref.is_some()
+        || params.enabled.is_some()
 }
 
 fn validate_v2_profile_params(params: &WireV2ProfileParams) -> Result<(), ApiV2ErrorCode> {

--- a/tests/app_service.rs
+++ b/tests/app_service.rs
@@ -438,6 +438,44 @@ fn status_reports_unavailable_when_probe_fails() {
 }
 
 #[test]
+fn invalid_scope_never_runs_an_unbound_probe_or_publishes_target() {
+    // An unsupported/malformed profile must fail closed in status and
+    // periodic refresh too, not only in control_enable. An empty probe
+    // sequence makes any accidental fallback probe panic this test.
+    let sink = Arc::new(Mutex::new(None));
+    let mut service = WlocService::new(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        SequenceProbe {
+            results: vec![],
+            index: 0,
+        },
+        SequenceGeo {
+            results: vec![],
+            index: 0,
+        },
+        WlocServiceConfig {
+            node_ref: NodeRef::new("node-1").unwrap(),
+            providers: vec![ProviderRef::new("geo-a").unwrap()],
+            probe_limits: limits(),
+            scope_valid: false,
+            ipv6_ready: true,
+            assigned_device_configured: false,
+            assigned_device: None,
+            reverse_geo_lookup: None,
+        },
+    )
+    .with_patch_sink(Arc::clone(&sink));
+
+    let status = service.status_at(1_000_000).unwrap();
+    assert_eq!(status["exit"]["state"], "unavailable");
+    assert_eq!(status["geo"]["state"], "unavailable");
+    assert!(sink.lock().unwrap().is_none());
+}
+
+#[test]
 fn status_reports_uncertain_when_geo_conflicts() {
     let now = 1_000_000;
     let mut service = WlocService::new(

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -1,0 +1,191 @@
+use std::net::IpAddr;
+
+use wificalling_location_gateway::config::{
+    DeviceProfile, LocationMode, NodeSelectionMode, ProfileError, ProfileModel, WlocUciConfig,
+};
+
+fn profile(id: &str, address: &str) -> DeviceProfile {
+    DeviceProfile {
+        id: id.to_owned(),
+        label: "Living room phone".to_owned(),
+        assigned_device: Some(address.to_owned()),
+        node_ref: "node-a".to_owned(),
+        node_mode: NodeSelectionMode::Fixed,
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+        manual_location_ref: None,
+        enabled: true,
+    }
+}
+
+#[test]
+fn legacy_single_device_configuration_migrates_idempotently() {
+    let config = WlocUciConfig {
+        enabled: true,
+        location_mode: LocationMode::Manual,
+        manual_latitude: Some(22.3193),
+        manual_longitude: Some(114.1694),
+        node_ref: "node-a".to_owned(),
+        assigned_device: "192.168.1.100".to_owned(),
+        ..WlocUciConfig::default()
+    };
+
+    let first = ProfileModel::from_legacy(&config).expect("legacy config is valid");
+    let second = ProfileModel::from_legacy(&config).expect("legacy config is valid");
+    assert_eq!(first, second);
+    assert_eq!(first.profiles().len(), 1);
+    assert_eq!(first.profiles()[0].id, "default");
+    assert_eq!(
+        first.profiles()[0].assigned_device.as_deref(),
+        Some("192.168.1.100")
+    );
+    assert_eq!(first.profiles()[0].location_mode, LocationMode::Manual);
+    assert_eq!(first.profiles()[0].manual_latitude, Some(22.3193));
+}
+
+#[test]
+fn explicit_profiles_reject_duplicates_and_invalid_addresses() {
+    let duplicate = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("phone", "192.168.1.11"),
+    ]);
+    assert!(matches!(duplicate, Err(ProfileError::DuplicateId(_))));
+
+    let invalid = ProfileModel::new(vec![profile("phone", "not-an-address")]);
+    assert!(matches!(
+        invalid,
+        Err(ProfileError::InvalidDeviceAddress(_))
+    ));
+}
+
+#[test]
+fn validation_accepts_ip_and_mac_device_addresses() {
+    let ipv6 = ProfileModel::new(vec![profile("phone", "2001:db8::10")]).unwrap();
+    assert_eq!(
+        ipv6.profiles()[0].assigned_device.as_deref(),
+        Some("2001:db8::10")
+    );
+    let mac = ProfileModel::new(vec![profile("tablet", "aa:bb:cc:dd:ee:ff")]).unwrap();
+    assert_eq!(
+        mac.profiles()[0].assigned_device.as_deref(),
+        Some("aa:bb:cc:dd:ee:ff")
+    );
+}
+
+#[test]
+fn manual_location_requires_a_complete_finite_in_range_pair() {
+    let mut value = profile("phone", "192.168.1.10");
+    value.location_mode = LocationMode::Manual;
+    value.manual_latitude = Some(1.0);
+    assert!(matches!(
+        ProfileModel::new(vec![value.clone()]),
+        Err(ProfileError::IncompleteLocation)
+    ));
+
+    value.manual_longitude = Some(181.0);
+    assert!(matches!(
+        ProfileModel::new(vec![value.clone()]),
+        Err(ProfileError::InvalidLocation)
+    ));
+
+    value.manual_longitude = Some(2.0);
+    value.manual_latitude = Some(f64::NAN);
+    assert!(matches!(
+        ProfileModel::new(vec![value]),
+        Err(ProfileError::InvalidLocation)
+    ));
+}
+
+#[test]
+fn transactional_update_does_not_partially_replace_model() {
+    let original = ProfileModel::new(vec![profile("phone", "192.168.1.10")]).unwrap();
+    let mut model = original.clone();
+    let result = model.replace(vec![profile("phone", "bad")]);
+    assert!(result.is_err());
+    assert_eq!(model, original);
+}
+
+#[test]
+fn profile_status_is_redacted_and_bounded() {
+    let model = ProfileModel::new(vec![profile("phone", "192.168.1.10")]).unwrap();
+    let status = model.redacted_status().unwrap();
+    let text = serde_json::to_string(&status).unwrap();
+    assert!(text.contains("phone"));
+    assert!(!text.contains("192.168.1.10"));
+    assert!(!text.contains("node-a"));
+    assert!(text.len() <= 4096);
+}
+
+#[test]
+fn profile_count_and_serialized_size_are_bounded() {
+    let too_many = (0..=8)
+        .map(|index| {
+            profile(
+                &format!("phone-{index}"),
+                &format!("192.168.1.{}", index + 10),
+            )
+        })
+        .collect();
+    assert!(matches!(
+        ProfileModel::new(too_many),
+        Err(ProfileError::TooManyProfiles)
+    ));
+
+    let mut oversized = profile("phone", "192.168.1.10");
+    oversized.label = "x".repeat(10_000);
+    assert!(matches!(
+        ProfileModel::new(vec![oversized]),
+        Err(ProfileError::FieldTooLong { .. })
+    ));
+}
+
+#[test]
+fn explicit_device_sections_parse_and_profile_model_prefers_them() {
+    let text = r#"
+config wloc-service 'main'
+    option enabled '0'
+config device 'phone'
+    option label 'Living room phone'
+    option assigned_device 'aa:bb:cc:dd:ee:ff'
+    option node_ref 'node-a'
+    option node_mode 'fixed'
+    option geo_source 'manual'
+    option manual_lat '22.3'
+    option manual_lon '114.1'
+    option manual_location_ref 'hong-kong'
+    option enabled '1'
+"#;
+    let config = WlocUciConfig::parse(text).expect("explicit profile parses");
+    assert!(!config.profiles.is_empty());
+    let model = config.profile_model().unwrap();
+    assert_eq!(model.profiles().len(), 1);
+    assert_eq!(model.profiles()[0].id, "phone");
+    assert_eq!(
+        model.profiles()[0].manual_location_ref.as_deref(),
+        Some("hong-kong")
+    );
+}
+
+#[test]
+fn explicit_device_section_rejects_unknown_modes() {
+    let text = "config device 'phone'\n\toption node_mode 'random'\n";
+    assert!(matches!(
+        WlocUciConfig::parse(text),
+        Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn explicit_device_section_requires_an_assigned_address() {
+    let text = "config device 'phone'\n\toption node_ref 'node-a'\n";
+    assert!(matches!(
+        WlocUciConfig::parse(text),
+        Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn unused_import_guard_keeps_the_test_explicit_about_ip_support() {
+    let _: IpAddr = "192.168.1.10".parse().unwrap();
+}

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -74,6 +74,27 @@ fn validation_accepts_ip_and_mac_device_addresses() {
 }
 
 #[test]
+fn unusable_ip_and_mac_addresses_are_rejected() {
+    for address in [
+        "0.0.0.0",
+        "127.0.0.1",
+        "169.254.1.2",
+        "224.0.0.1",
+        "::",
+        "::1",
+        "ff02::1",
+        "00:00:00:00:00:00",
+        "01:00:00:00:00:01",
+    ] {
+        let rejected = matches!(
+            ProfileModel::new(vec![profile("phone", address)]),
+            Err(ProfileError::InvalidDeviceAddress(_))
+        );
+        assert!(rejected, "address should not be accepted: {address}");
+    }
+}
+
+#[test]
 fn manual_location_requires_a_complete_finite_in_range_pair() {
     let mut value = profile("phone", "192.168.1.10");
     value.location_mode = LocationMode::Manual;
@@ -104,6 +125,19 @@ fn transactional_update_does_not_partially_replace_model() {
     let result = model.replace(vec![profile("phone", "bad")]);
     assert!(result.is_err());
     assert_eq!(model, original);
+}
+
+#[test]
+fn multiple_profiles_cannot_be_selected_by_the_single_runtime() {
+    let model = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("tablet", "192.168.1.11"),
+    ])
+    .unwrap();
+    assert!(matches!(
+        model.single_runtime_profile(),
+        Err(ProfileError::MultipleProfilesRequireUnifiedRuntime)
+    ));
 }
 
 #[test]
@@ -182,6 +216,18 @@ fn explicit_device_section_requires_an_assigned_address() {
     assert!(matches!(
         WlocUciConfig::parse(text),
         Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn oversized_uci_text_is_rejected_before_profile_accumulation() {
+    let text = format!(
+        "config device 'phone'\n\toption label '{}'\n",
+        "x".repeat(33_000)
+    );
+    assert!(matches!(
+        WlocUciConfig::parse(&text),
+        Err(wificalling_location_gateway::config::UciError::ConfigTooLarge)
     ));
 }
 

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -61,10 +61,10 @@ fn explicit_profiles_reject_duplicates_and_invalid_addresses() {
 
 #[test]
 fn validation_accepts_ip_and_mac_device_addresses() {
-    let ipv6 = ProfileModel::new(vec![profile("phone", "2001:db8::10")]).unwrap();
+    let ipv6 = ProfileModel::new(vec![profile("phone", "fd00::10")]).unwrap();
     assert_eq!(
         ipv6.profiles()[0].assigned_device.as_deref(),
-        Some("2001:db8::10")
+        Some("fd00::10")
     );
     let mac = ProfileModel::new(vec![profile("tablet", "aa:bb:cc:dd:ee:ff")]).unwrap();
     assert_eq!(
@@ -77,12 +77,15 @@ fn validation_accepts_ip_and_mac_device_addresses() {
 fn unusable_ip_and_mac_addresses_are_rejected() {
     for address in [
         "0.0.0.0",
+        "0.0.0.1",
         "127.0.0.1",
+        "192.0.2.10",
         "169.254.1.2",
         "224.0.0.1",
         "::",
         "::1",
         "ff02::1",
+        "2001:db8::10",
         "00:00:00:00:00:00",
         "01:00:00:00:00:01",
     ] {

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -70,6 +70,12 @@ fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
         decode_v2_profile_request(bad_address).unwrap_err(),
         ApiV2ErrorCode::InvalidParams
     );
+
+    let list_with_mutation = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.list","params":{"label":"unexpected"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(list_with_mutation).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
 }
 
 #[test]

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -12,8 +12,13 @@ fn profile_methods_decode_only_on_the_v2_contract() {
         ("profile.update", ProfileApiMethod::Update),
         ("profile.delete", ProfileApiMethod::Delete),
     ] {
+        let params = if method == "profile.create" {
+            r#"{"profile_id":"phone","label":"Phone","assigned_device":"192.168.1.10","node_ref":"node-a","node_mode":"fixed","geo_source":"auto","enabled":true}"#
+        } else {
+            r#"{"profile_id":"phone"}"#
+        };
         let payload = format!(
-            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{{"profile_id":"phone"}}}}"#
+            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{params}}}"#
         );
         assert_eq!(
             decode_v2_profile_request(payload.as_bytes())
@@ -74,6 +79,12 @@ fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
     let list_with_mutation = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.list","params":{"label":"unexpected"}}"#;
     assert_eq!(
         decode_v2_profile_request(list_with_mutation).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let incomplete_create = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.create","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(incomplete_create).unwrap_err(),
         ApiV2ErrorCode::InvalidParams
     );
 }

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -1,0 +1,92 @@
+use wificalling_location_gateway::service::api::{
+    decode_v2_profile_request, encode_v2_result_response, ApiV2ErrorCode, ProfileApiMethod,
+    MAX_CONTROL_FRAME_BYTES, SERVICE_API_V2_ID,
+};
+
+#[test]
+fn profile_methods_decode_only_on_the_v2_contract() {
+    for (method, expected) in [
+        ("profile.list", ProfileApiMethod::List),
+        ("profile.get", ProfileApiMethod::Get),
+        ("profile.create", ProfileApiMethod::Create),
+        ("profile.update", ProfileApiMethod::Update),
+        ("profile.delete", ProfileApiMethod::Delete),
+    ] {
+        let payload = format!(
+            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{{"profile_id":"phone"}}}}"#
+        );
+        assert_eq!(
+            decode_v2_profile_request(payload.as_bytes())
+                .unwrap()
+                .method(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn v1_and_unknown_v2_methods_are_not_reinterpreted_as_profile_operations() {
+    let v1 = br#"{"api_version":"wloc.service/v1","request_id":"req-1","method":"profile.list","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(v1).unwrap_err(),
+        ApiV2ErrorCode::IncompatibleVersion
+    );
+
+    let unknown = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"debug.dump","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(unknown).unwrap_err(),
+        ApiV2ErrorCode::UnknownMethod
+    );
+}
+
+#[test]
+fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
+    let unknown = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{"profile_id":"phone","raw":true}}"#;
+    assert_eq!(
+        decode_v2_profile_request(unknown).unwrap_err(),
+        ApiV2ErrorCode::MalformedRequest
+    );
+
+    let invalid = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{"profile_id":"../phone"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(invalid).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let missing = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(missing).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let bad_mode = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.update","params":{"profile_id":"phone","node_mode":"random"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(bad_mode).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let bad_address = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.update","params":{"profile_id":"phone","assigned_device":"not-an-address"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(bad_address).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+}
+
+#[test]
+fn v2_frame_bound_is_enforced() {
+    let oversized = vec![b' '; MAX_CONTROL_FRAME_BYTES + 1];
+    assert_eq!(
+        decode_v2_profile_request(&oversized).unwrap_err(),
+        ApiV2ErrorCode::FrameTooLarge
+    );
+}
+
+#[test]
+fn v2_result_uses_the_v2_envelope_and_frame_limit() {
+    let body = serde_json::json!({"profiles": []});
+    let encoded = encode_v2_result_response("req-1", &body).unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+    assert_eq!(value["api_version"], SERVICE_API_V2_ID);
+    assert_eq!(value["request_id"], "req-1");
+    assert!(value.get("error").is_none());
+}


### PR DESCRIPTION
## Summary

Closes #31.

- Add bounded multi-device profile model and deterministic v1 singleton migration.
- Parse explicit config device UCI sections with strict profile validation.
- Add additive v2 profile request decoding and bounded v2 result envelope.
- Add redacted status, transactional model replacement, AX6S resource ceilings, tests, and API documentation.
- Fix profile-bound probes so route-only/stale sing-box rules cannot bypass the matching Gateway UCI device policy.

## Verification

- ./scripts/ci/verify.sh passed.
- 69 Python tests passed.
- Rust unit and integration tests passed; total coverage 80.96%.
- cargo clippy --all-targets -- -D warnings passed.
- Dependency advisories, secret scan, OpenWrt package, AX6S resource, and release gates passed.

## Risks and rollback

This PR does not change runtime dispatch, nftables routing, procd supervision, LuCI pages, logs, updates, or the current v1 interception path. If profile parsing or migration is rejected, retain the v1.2.2 config and runtime; reverting this PR restores the previous tree.

Handoff capsule: `.handoffs/issue-31.md`