### PR TITLE
feat: add unified Gateway WLOC supervisor

### DIFF
--- a/.handoffs/issue-33.md
+++ b/.handoffs/issue-33.md
@@ -1,0 +1,109 @@
+# Agent handoff: Issue 33
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,test
+- Branch: codex/issue-33-unified-supervisor-codex-v2-lead-20260821044654
+- Checkpoint parent: 601097f
+- Updated at (UTC): 2026-08-21T06:16:40Z
+- Credentials included: no
+
+## Objective
+
+Deliver the V2-02 unified Gateway/WLOC lifecycle slice as an isolated OpenWrt
+component: one enabled entry point, ordered passthrough/health/redirect
+transitions, fail-open WLOC fault handling, bounded recovery, stable Gateway
+namespace protection, runtime control delegation, packaging, tests, and
+rollback documentation.
+
+## Completed
+
+- Added the Rust `UnifiedSupervisor` state machine with bounded child count,
+  restart budget, health interval, redirect-last ordering, and explicit
+  `CleanupUnsafe` state.
+- Integrated `WlocService` with the supervisor and replaced the production
+  no-op redirect runtime with `OpenWrtRuntime` delegating only the WLOC-owned
+  helper and `nft list table inet wloc_service` presence check.
+- Added the unified procd entry point and POSIX/busybox supervisor. WLOC
+  startup suppresses the legacy redirect side effect; unified health checks
+  precede redirect installation; WLOC faults leave Gateway passthrough alive.
+- Disabled independent child respawn in supervised mode so the outer
+  supervisor owns bounded recovery.
+- Updated standalone and formal release package builders/postinst scripts to
+  install and enable the unified entry point while retaining legacy rollback
+  scripts.
+- Added shell, Rust, package, TDD evidence, and operations documentation.
+
+## Files changed
+
+- `src/service/supervisor.rs`, `src/app.rs`, `src/bin/wloc-service.rs`
+- `openwrt/files/etc/init.d/wificalling-location-gateway`
+- `openwrt/files/etc/init.d/wificalling-gateway`
+- `openwrt/files/etc/init.d/wloc-service`
+- `openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh`
+- `openwrt/files/usr/sbin/wloc-redirect-sync.sh`
+- `scripts/openwrt/build-release-packages.sh`, `scripts/build-luci-ipk.sh`
+- `tests/service_supervisor.rs`, `tests/scripts/test-unified-supervisor.sh`,
+  package tests
+- `docs/adr/0002-v2-unified-runtime-and-device-profiles.md`,
+  `docs/operations/V2_UNIFIED_SUPERVISOR.md`,
+  `docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `cargo test --all-targets` | PASS | All Rust unit/integration targets passed |
+| `cargo clippy --all-targets -- -D warnings` | PASS | No warnings |
+| `./tests/scripts/test-unified-supervisor.sh` | PASS | Ordering, ownership, fail-open, namespace guards |
+| `./tests/scripts/test-standalone-ax6s-package.sh` | PASS | Standalone AX6S package contents/postinst |
+| `./tests/scripts/test-openwrt-release-packaging.sh` | PASS | Formal release builder uses unified entry point |
+| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.27% lines, OpenWrt/resource/package/security gates |
+
+## Failed attempts
+
+- Initial full verification found one rustfmt difference; `cargo fmt --all`
+  fixed it and the complete verification was rerun successfully.
+- Independent review initially found early legacy redirect installation and
+  WLOC-fault Gateway shutdown; both were corrected and covered by regression
+  assertions.
+
+## Unresolved decisions and blockers
+
+- No live AX6S install/RSS/procd run has been performed in this workspace;
+  hardware acceptance remains required before a production release.
+- The legacy init scripts remain as a one-release migration facade. In
+  supervised mode they do not own redirect installation or child respawn, but
+  the next runtime issue should replace this facade with direct child adapters
+  if the product requires literal single-process ownership.
+- Multi-device profile routing, unified LuCI management, bounded logs, and
+  component update UI are subsequent V2 issues, not claimed by this slice.
+
+## Next executable steps
+
+1. Run the final independent review on this checkpoint.
+2. Push this branch and open the Issue #33 PR only after review has no blocking
+   P0/P1 findings.
+3. Install the built package on AX6S staging and record RSS, startup, crash,
+   reload, rollback, and stable Gateway table evidence.
+4. Continue with V2-03 device-profile runtime routing and V2-04 LuCI status,
+   logs, updates, and migration UI.
+
+## Capabilities required for the next Agent
+
+- `openwrt`, `rust`, `test`, and `security` for the live acceptance pass.
+
+## Environment assumptions
+
+- OpenWrt procd, nftables TPROXY support, `sing-box`, and the stable Gateway
+  files are present on the target gateway.
+- The component owns only `inet wloc_service`, its policy route, WLOC DNS
+  marker, root-only WLOC socket/state, and its own children.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- WLOC cleanup never directly names the stable Gateway nftables table and does
+  not handle UDP 500/4500; WLOC failure is withdrawn before WLOC shutdown.

--- a/.handoffs/issue-33.md
+++ b/.handoffs/issue-33.md
@@ -6,7 +6,7 @@
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-33-unified-supervisor-codex-v2-lead-20260821044654
 - Checkpoint parent: 601097f
-- Updated at (UTC): 2026-08-21T06:16:40Z
+- Updated at (UTC): 2026-08-21T06:26:00Z
 - Credentials included: no
 
 ## Objective
@@ -27,7 +27,12 @@ rollback documentation.
   helper and `nft list table inet wloc_service` presence check.
 - Added the unified procd entry point and POSIX/busybox supervisor. WLOC
   startup suppresses the legacy redirect side effect; unified health checks
-  precede redirect installation; WLOC faults leave Gateway passthrough alive.
+  precede redirect installation; startup has a bounded readiness wait; WLOC
+  faults and stop/reload leave Gateway passthrough alive without calling its
+  stop path.
+- Applied the supervised first-enable/deferred-redirect handshake and narrowed
+  interception/DNS scope to the two exact Apple hostnames required by the
+  project contract.
 - Disabled independent child respawn in supervised mode so the outer
   supervisor owns bounded recovery.
 - Updated standalone and formal release package builders/postinst scripts to
@@ -59,7 +64,7 @@ rollback documentation.
 | `./tests/scripts/test-unified-supervisor.sh` | PASS | Ordering, ownership, fail-open, namespace guards |
 | `./tests/scripts/test-standalone-ax6s-package.sh` | PASS | Standalone AX6S package contents/postinst |
 | `./tests/scripts/test-openwrt-release-packaging.sh` | PASS | Formal release builder uses unified entry point |
-| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.27% lines, OpenWrt/resource/package/security gates |
+| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.29% lines, OpenWrt/resource/package/security gates |
 
 ## Failed attempts
 

--- a/docs/adr/0002-v2-unified-runtime-and-device-profiles.md
+++ b/docs/adr/0002-v2-unified-runtime-and-device-profiles.md
@@ -1,0 +1,130 @@
+# ADR 0002: v2 unified Gateway/WLOC runtime and device profiles
+
+Status: Proposed
+
+## Context
+
+The v1.2.x product is distributed as one small architecture-specific package,
+but the installed runtime still has separate `wificalling-gateway` and
+`wloc-service` procd lifecycles. WLOC currently has one global device, node,
+location mode, and patch target. v2 must keep the AX6S resource profile while
+adding independent device records, unified control, observability, updates, and
+rollback.
+
+The existing Gateway data plane and sing-box process are valuable and must not
+be duplicated per device. The existing WLOC state machine, probe, Geo, TLS/H2,
+and protocol code should be reused behind a unified supervisor rather than
+rewritten without evidence.
+
+## Decision
+
+v2 will provide one product supervisor and one management plane:
+
+- one procd entry point: `wificalling-location-gateway`;
+- one root-only control socket and versioned API;
+- one authoritative configuration model containing device profiles;
+- one lifecycle state machine coordinating Gateway, WLOC, redirect, and health;
+- one unified status, event, diagnostic, and update surface;
+- sing-box remains a managed child process and is shared by profiles that use
+  the same node;
+- no per-device WLOC process and no duplicated sing-box configuration.
+
+Legacy init scripts and UCI files may remain as a one-release migration facade,
+but they must not independently own runtime state after migration.
+
+## Device profile contract
+
+Each profile owns:
+
+- stable profile id and display label;
+- LAN identity and source address set;
+- Gateway enabled state and one node binding;
+- WLOC enabled state;
+- `auto` or `manual` location mode;
+- manual coordinate/preset reference;
+- probe, Geo, redirect, proxy, log, and health state.
+
+The runtime must reject an incomplete or ambiguous profile. It must not choose
+an arbitrary node when the configured binding cannot be resolved.
+
+## Lifecycle contract
+
+Enable order is:
+
+1. validate profile and scope;
+2. prepare Gateway/sing-box in passthrough mode;
+3. start or verify WLOC proxy;
+4. verify health and the selected IPv6 policy;
+5. install only that profile's exact redirect last.
+
+Disable, crash recovery, and rollback must withdraw redirect before draining or
+stopping the engine. The status API must be derived from observed runtime state,
+not from a successful request to an adapter that performs no operation.
+
+## Resource contract
+
+The v2 release is not accepted until AX6S measurements establish and pass
+budgets for:
+
+- unified service idle and active RSS;
+- peak RSS while probing through a temporary sing-box instance;
+- RSS growth per additional profile;
+- CPU during normal monitoring and node switching;
+- file descriptors and concurrent H2 work;
+- package payload and update staging space;
+- log, cache, and temporary-file growth.
+
+The implementation must use bounded queues, bounded caches, bounded logs,
+single-flight updates/probes, shared node processes, and atomic cleanup of
+temporary artifacts.
+
+## Observability contract
+
+All Gateway/WLOC events use one structured envelope with timestamp, level,
+component, profile id, event, outcome, reason code, retryability, and redaction
+version. Raw WLOC bodies, credentials, tokens, and private keys are excluded
+by default. Debug capture is explicit, time-limited, size-limited, and
+automatically removed.
+
+The UI must expose both the current state and the reason for a degraded state.
+Health must cover Gateway, sing-box, node binding, WLOC proxy, CA, Geo freshness,
+IPv4/IPv6 policy, redirect presence, and the latest successful operation.
+
+## Migration and rollback
+
+Migration must:
+
+1. back up both v1 UCI files and record hashes;
+2. convert the current device/node/location settings into profiles;
+3. preserve the CA and compatible runtime data;
+4. validate the new configuration before enabling it;
+5. keep Wi-Fi Calling in passthrough if WLOC migration fails;
+6. remove stale WLOC rules before rollback;
+7. restore the previous package/configuration without deleting the CA.
+
+## Consequences
+
+Positive consequences:
+
+- one authoritative lifecycle and status model;
+- independent multi-device control without global mutable WLOC state;
+- lower resource use than one process per device;
+- consistent diagnostics, updates, and rollback;
+- clearer separation between product integration and the existing sing-box
+  dependency.
+
+Costs and risks:
+
+- migration must be tested against existing v1 configurations;
+- the unified supervisor becomes a safety-sensitive integration boundary;
+- API v2 and LuCI must be versioned together;
+- real AX6S resource measurements are required before release.
+
+## Required follow-up
+
+- Update the v1 API document or add a reviewed v2 API document before changing
+  the wire contract. The current code already exposes methods not listed in the
+  frozen v1 document.
+- Add a separate runtime adapter issue for the current `StubRuntime`.
+- Add OpenWrt, low-resource, migration, and rollback integration tests before
+  removing the legacy service facade.

--- a/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
+++ b/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
@@ -1,0 +1,143 @@
+# Unified Gateway/WLOC control API v2 draft
+
+Status: proposed; not implemented and does not change the frozen `wloc.service/v1` contract.
+
+## Purpose
+
+v2 replaces the single global WLOC control model with a unified Gateway/WLOC
+control plane. It coordinates device profiles, node bindings, WLOC auto/manual
+location, health, logs, diagnostics, and component updates through one
+root-only local Unix socket or an audited rpcd facade.
+
+The API is an administrative control plane. It is not exposed to LAN TCP
+clients and it never accepts credentials, raw WLOC bodies, private keys, or
+unbounded diagnostic payloads.
+
+## Transport limits
+
+- API identifier: `wloc.service/v2`.
+- Unix socket only; no TCP management listener.
+- Socket directory mode `0700`; socket mode `0600`.
+- Maximum frame: 16 KiB for control requests and normal responses.
+- Maximum concurrent control operations: 2.
+- One update job and one diagnostic bundle job at a time.
+- Log queries are paginated; a request may return at most 100 events.
+- Every request uses a bounded deadline and a validated request id.
+- Unknown fields and unknown methods are rejected.
+
+## Envelope
+
+```json
+{
+  "api_version": "wloc.service/v2",
+  "request_id": "req-1",
+  "method": "profile.status.get",
+  "params": {
+    "profile_id": "device-1"
+  }
+}
+```
+
+Responses contain exactly one `result` or `error`. Errors use stable codes and
+contain no provider payload, node credential, private key, raw protocol data,
+or unbounded command output.
+
+## Profile methods
+
+| Method | Purpose | Side effect |
+|---|---|---|
+| `profile.list` | List profiles and compact health summaries | no |
+| `profile.get` | Read one profile's effective configuration and status | no |
+| `profile.create` | Create a validated profile | configuration |
+| `profile.update` | Update profile fields transactionally | configuration |
+| `profile.delete` | Disable, clean redirect, then remove profile | configuration |
+| `profile.enable` | Enable Gateway/WLOC for one profile | runtime |
+| `profile.disable` | Withdraw redirect and disable one profile | runtime |
+| `profile.reload` | Apply profile/config changes | runtime |
+| `profile.node_test` | Run a bounded node test | background job |
+| `profile.refresh` | Force bounded exit/Geo refresh | background job |
+| `profile.wloc.set_mode` | Set `auto` or `manual` mode | runtime/config |
+| `profile.wloc.set_location` | Set validated manual coordinates/preset | runtime/config |
+| `profile.wloc.clear_location` | Return profile to auto mode | runtime/config |
+
+`profile_id` is an opaque local identifier. A profile may expose its
+administrator-visible IP/MAC through the authenticated local LuCI facade, but
+the default wire status must not leak device material to arbitrary callers.
+
+## Status methods
+
+| Method | Purpose |
+|---|---|
+| `system.status.get` | Unified Gateway/WLOC summary |
+| `profile.status.get` | One profile's state and reason |
+| `profile.status.list` | Paginated status for all profiles |
+| `diagnostics.health.get` | Detailed bounded health checks |
+| `diagnostics.self_test` | Run a bounded self-test sequence |
+| `diagnostics.bundle.create` | Create a redacted, size-limited support bundle |
+
+Profile status must distinguish at least:
+
+- disabled;
+- preparing;
+- passthrough;
+- intercepting;
+- degraded passthrough;
+- draining;
+- migration required;
+- update required.
+
+Each degraded or failed state carries a stable `reason_code`, `component`,
+`retryable`, and `observed_at` value. A green status is allowed only when the
+corresponding process, node, Geo evidence, proxy, IPv4/IPv6 policy, and
+redirect state have been observed.
+
+## Log methods
+
+| Method | Purpose |
+|---|---|
+| `log.query` | Paginated structured event query |
+| `log.clear` | Clear selected profile or global ring buffer |
+| `log.debug.enable` | Enable time-limited bounded debug mode |
+| `log.debug.disable` | Disable debug mode and remove samples |
+
+Each event uses a common envelope:
+
+```json
+{
+  "time": 0,
+  "level": "warn",
+  "component": "wloc",
+  "profile_id": "device-1",
+  "event": "geo_probe_failed",
+  "outcome": "unavailable",
+  "reason_code": "timeout",
+  "retryable": true,
+  "redaction_version": 1
+}
+```
+
+The API never returns raw WLOC request/response bodies, credentials, tokens,
+private keys, or arbitrary process output. Debug mode may expose bounded
+metadata such as byte counts, status code, duration, and body hash only.
+
+## Component update methods
+
+| Method | Purpose |
+|---|---|
+| `component.list` | Current versions and compatibility state |
+| `component.check` | Check a trusted update manifest |
+| `component.update.prepare` | Validate architecture, space, memory, and package |
+| `component.update.apply` | Apply one verified update transaction |
+| `component.update.status` | Read update progress and result |
+| `component.rollback` | Restore the last verified package/config state |
+
+Updates must use a trusted manifest, verify architecture and SHA-256/signature,
+stage at most one package and one rollback copy, preserve UCI/CA data, and
+return to a healthy passthrough state before committing the new runtime.
+
+## Compatibility
+
+The v1 API remains available through a compatibility facade during one release
+cycle. v1 methods map only to the explicitly selected default profile; they may
+not silently operate on multiple profiles. The facade is removed only after the
+v2 migration and rollback tests are complete.

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -16,8 +16,11 @@ They are not independently enabled in the v2 steady state.
 
 1. Create a root-only volatile runtime directory and acquire the supervisor
    lock.
-2. Stop any legacy child instances and start the Gateway in passthrough.
-3. Start WLOC and wait for its root-only Unix socket.
+2. Stop any legacy WLOC instance and start or verify the Gateway in
+   passthrough. The stable Gateway init remains the owner of its own firewall
+   table; the supervisor does not call Gateway stop during a WLOC fault.
+3. Start WLOC without its legacy redirect side effect and wait for its
+   root-only Unix socket.
 4. Check both child processes before enabling the WLOC redirect.
 5. Install only the WLOC-owned redirect/table and publish `intercepting`.
 
@@ -26,11 +29,13 @@ intercepts UDP 500/4500.
 
 ## Failure and stop ordering
 
-Any child exit, health failure, redirect setup failure, SIGTERM, or reload
-first calls `wloc-redirect-sync.sh stop`, then stops WLOC and Gateway. The
-WLOC table, policy route, DNS marker, socket, and supervisor state are removed
-idempotently. The stable Gateway can remain available in passthrough during a
-WLOC failure.
+Any WLOC child exit, health failure, or redirect setup failure first calls
+`wloc-redirect-sync.sh stop`, then stops WLOC while leaving the stable Gateway
+available in passthrough. An explicit service stop, SIGTERM, or reload also
+stops the Gateway because that is an operator-requested product shutdown. The
+WLOC table, policy route, DNS marker, socket, and supervisor state are handled
+idempotently. A failed cleanup is reported as `cleanup_unsafe`, never as a
+clean `stopped` state.
 
 procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
 Rust supervisor policy additionally limits the managed child count to two

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -21,7 +21,8 @@ They are not independently enabled in the v2 steady state.
    table; the supervisor does not call Gateway stop during a WLOC fault.
 3. Start WLOC without its legacy redirect side effect and wait for its
    root-only Unix socket.
-4. Check both child processes before enabling the WLOC redirect.
+4. Wait up to the bounded startup timeout for both child processes and the
+   WLOC socket before enabling the WLOC redirect.
 5. Install only the WLOC-owned redirect/table and publish `intercepting`.
 
 The supervisor never edits the stable Gateway nftables table and never
@@ -32,10 +33,15 @@ intercepts UDP 500/4500.
 Any WLOC child exit, health failure, or redirect setup failure first calls
 `wloc-redirect-sync.sh stop`, then stops WLOC while leaving the stable Gateway
 available in passthrough. An explicit service stop, SIGTERM, or reload also
-stops the Gateway because that is an operator-requested product shutdown. The
-WLOC table, policy route, DNS marker, socket, and supervisor state are handled
-idempotently. A failed cleanup is reported as `cleanup_unsafe`, never as a
-clean `stopped` state.
+only withdraws WLOC-owned rules; the stable Gateway remains under its original
+init/firewall owner. The WLOC table, policy route, DNS marker, socket, and
+supervisor state are handled idempotently. A failed cleanup is reported as
+`cleanup_unsafe`, never as a clean `stopped` state.
+
+The WLOC daemon applies its persisted `enabled` state in supervised mode with
+the first redirect installation deferred. The supervisor performs the actual
+redirect install after readiness, so daemon state and firewall transition
+cannot disagree during startup.
 
 procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
 Rust supervisor policy additionally limits the managed child count to two

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -1,0 +1,53 @@
+# V2 unified Gateway/WLOC supervisor
+
+## Ownership
+
+`/etc/init.d/wificalling-location-gateway` is the only enabled v2 entry point.
+Its single procd instance runs
+`/usr/libexec/wificalling-location-gateway/unified-supervisor.sh`, which
+coordinates the existing Gateway and WLOC children during the one-release
+migration window.
+
+The legacy `wificalling-gateway` and `wloc-service` init scripts remain
+available for rollback but are disabled by the migration/post-install step.
+They are not independently enabled in the v2 steady state.
+
+## Start ordering
+
+1. Create a root-only volatile runtime directory and acquire the supervisor
+   lock.
+2. Stop any legacy child instances and start the Gateway in passthrough.
+3. Start WLOC and wait for its root-only Unix socket.
+4. Check both child processes before enabling the WLOC redirect.
+5. Install only the WLOC-owned redirect/table and publish `intercepting`.
+
+The supervisor never edits the stable Gateway nftables table and never
+intercepts UDP 500/4500.
+
+## Failure and stop ordering
+
+Any child exit, health failure, redirect setup failure, SIGTERM, or reload
+first calls `wloc-redirect-sync.sh stop`, then stops WLOC and Gateway. The
+WLOC table, policy route, DNS marker, socket, and supervisor state are removed
+idempotently. The stable Gateway can remain available in passthrough during a
+WLOC failure.
+
+procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
+Rust supervisor policy additionally limits the managed child count to two
+long-lived children plus one temporary probe and bounds restart backoff and
+health polling.
+
+## Rollback
+
+```sh
+/etc/init.d/wificalling-location-gateway stop
+/etc/init.d/wificalling-location-gateway disable
+/etc/init.d/wloc-service enable
+/etc/init.d/wificalling-gateway enable
+/etc/init.d/wificalling-gateway start
+/etc/init.d/wloc-service start
+```
+
+Rollback preserves `/etc/config/*`, the WLOC CA, and Gateway node material.
+If unified startup fails, the supervisor leaves the router in passthrough and
+does not delete persistent credentials or configuration.

--- a/docs/releases/V2.0_ISSUE_DRAFTS.md
+++ b/docs/releases/V2.0_ISSUE_DRAFTS.md
@@ -1,0 +1,296 @@
+# v2.0 GitHub Issue drafts
+
+These drafts are local planning material. They do not create or modify GitHub
+Issues. Each draft must be reviewed against the current repository state before
+publication and then leased through the project's agent workflow.
+
+## V2-00 — Freeze unified runtime, profile, API, resource and migration contracts
+
+Labels: `status:ready`, `phase:0`, `role:integration`, `cap:docs`, `cap:test`
+
+### Objective
+
+Approve the v2 architecture and contracts before product implementation: one
+Gateway/WLOC supervisor, one control plane, per-device profiles, resource
+budgets, structured logs, component updates, migration and rollback.
+
+### Owned paths
+
+- `docs/adr/0002-v2-unified-runtime-and-device-profiles.md`
+- `docs/api/WLOC_SERVICE_API_V2_DRAFT.md`
+- `docs/releases/V2.0_TASK_BREAKDOWN.md`
+- `docs/releases/V2.0_ISSUE_DRAFTS.md`
+
+### Acceptance
+
+- Profile schema, lifecycle states, API methods and compatibility policy are
+  reviewed and frozen.
+- AX6S memory, storage, CPU and write-volume measurement plan is explicit.
+- v1 migration and rollback paths are documented.
+- Security and test roles approve the contracts.
+
+### Non-goals
+
+- No product code changes.
+- No change to v1.2.x runtime behavior.
+
+## V2-01 — Implement unified UCI/profile model and migration
+
+Labels: `status:ready`, `phase:1`, `role:integration`, `cap:rust`, `cap:test`
+
+### Objective
+
+Replace the single global WLOC configuration with validated device profiles
+that reference existing Gateway nodes without copying credentials or spawning
+one process per device.
+
+### Owned paths
+
+- `src/config/`
+- `src/service/api.rs`
+- `src/service/dispatch.rs`
+- `openwrt/files/etc/config/`
+- migration helpers and profile contract tests under `tests/`
+
+### Dependencies
+
+- V2-00
+
+### Acceptance
+
+- Create, update, delete, enable and disable profile operations are validated.
+- Existing v1 UCI files migrate deterministically and preserve the CA.
+- Ambiguous or missing node bindings fail closed; no arbitrary-node fallback.
+- Migration failure leaves Wi-Fi Calling passthrough available.
+- v1 control requests map only to an explicitly selected default profile.
+
+### Rollback
+
+- Restore the two v1 UCI files and retain the v1 package/CA backup.
+
+## V2-02 — Implement the unified supervisor and runtime adapter
+
+Labels: `status:ready`, `phase:1`, `role:engine`, `cap:rust`, `cap:openwrt`
+
+### Objective
+
+Replace the production `StubRuntime` path with one supervisor that owns Gateway,
+WLOC, health, redirect, watchdog and passthrough lifecycle.
+
+### Owned paths
+
+- `src/bin/`
+- `src/app.rs`
+- `src/service/`
+- `src/runtime/`
+- `openwrt/files/etc/init.d/`
+- runtime adapter tests under `tests/`
+
+### Dependencies
+
+- V2-00, V2-01
+
+### Acceptance
+
+- One procd entry point is authoritative after migration.
+- Enable installs redirect only after observed engine health and scope checks.
+- Disable, crash recovery and rollback remove redirect before drain/stop.
+- Health reflects actual process, proxy, watchdog and nftables state.
+- Gateway UDP 500/4500 behavior remains unchanged.
+
+### Non-goals
+
+- Do not embed or duplicate sing-box.
+- Do not remove the legacy facade until migration tests pass.
+
+## V2-03 — Add per-profile Gateway/WLOC/redirect runtime
+
+Labels: `status:ready`, `phase:1`, `role:engine`, `role:network`, `cap:rust`, `cap:network`
+
+### Objective
+
+Give every device profile independent node binding, WLOC mode, probe/Geo state,
+patch target, redirect and health state while sharing compatible sing-box
+processes.
+
+### Owned paths
+
+- `src/app.rs`
+- `src/exitprobe/`
+- `src/georesolver/`
+- `openwrt/files/usr/sbin/`
+- `tests/` profile isolation tests
+
+### Dependencies
+
+- V2-01, V2-02
+
+### Acceptance
+
+- Two profiles can use different nodes and locations independently.
+- Two profiles can share one node without duplicate sing-box processes.
+- Disabling one profile never changes another profile's redirect or patch target.
+- A node switch updates only the affected profile.
+- Profile deletion removes only its redirect and runtime state.
+
+## V2-04 — Close network, protocol and fail-open gaps
+
+Labels: `status:ready`, `phase:2`, `role:network`, `role:protocol`, `cap:network`, `cap:security`, `cap:test`
+
+### Objective
+
+Apply the approved audit fixes without widening the intended local-router
+scope: IPv4/IPv6 policy, exact device/host/port matching, proxy correctness,
+timeouts, Geo transport and parser robustness.
+
+### Owned paths
+
+- `src/mitm/`
+- `src/tls_h2.rs`
+- `src/wloc/`
+- `src/georesolver/`
+- `src/exitprobe/`
+- `openwrt/files/usr/sbin/`
+- `tests/fixtures/` and relevant contract tests
+
+### Acceptance
+
+- IPv6 is implemented or the documented AAAA policy is enforced and tested.
+- Proxy preserves required upstream status and headers.
+- Connection, body, response, stream and concurrency limits are enforced.
+- Geo queries use the approved transport and response limits.
+- Malformed chunked/protobuf inputs cannot panic the process.
+- Unknown or invalid evidence never creates a default location.
+
+## V2-05 — Build unified LuCI settings, devices, status and diagnostics
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `cap:ui`, `cap:test`
+
+### Objective
+
+Provide a mature OpenWrt plugin information architecture: Overview, Basic
+Settings, Devices, Nodes, Runtime Status, Logs, Diagnostics, Updates and
+Advanced Settings.
+
+### Owned paths
+
+- `openwrt/luci-app-wificalling-location-gateway/files/www/`
+- `openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/`
+- menu and ACL files
+- LuCI tests and fixtures
+
+### Acceptance
+
+- Every profile has a dedicated detail view.
+- Apply operations report pending, applied, degraded or failed state.
+- Status explains the reason for every non-healthy state.
+- Dangerous actions require confirmation and show their impact.
+- Overview uses one compact status request rather than per-device polling.
+- UI works within the AX6S memory and browser-cache constraints.
+
+## V2-06 — Implement structured logs, bounded storage and diagnostics
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `role:security`, `cap:test`
+
+### Objective
+
+Unify Gateway/WLOC events into a bounded, searchable and supportable logging
+system that helps users determine whether the system is working.
+
+### Owned paths
+
+- `src/` logging/event modules
+- `openwrt/files/usr/libexec/wificalling-gateway/`
+- `openwrt/luci-app-wificalling-location-gateway/files/www/` log/diagnostic views
+- `tests/` log redaction and storage tests
+
+### Acceptance
+
+- One documented JSONL event envelope is used by Gateway and WLOC.
+- Global and per-profile byte/count limits are enforced in the writer.
+- Rotation and clear operations are bounded and atomic.
+- Debug mode is explicit, time-limited and automatically cleaned.
+- Support bundles are allowlist-based and contain no credentials or raw bodies.
+- UI supports filtering by profile, component, level, event and time.
+
+## V2-07 — Implement component update, compatibility and rollback flows
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `role:security`, `cap:ci`, `cap:test`
+
+### Objective
+
+Add a low-resource-safe component update center for architecture-specific
+packages, runtime compatibility and rollback.
+
+### Owned paths
+
+- `scripts/openwrt/`
+- `scripts/ci/`
+- OpenWrt package metadata and post-install scripts
+- update API/UI and tests
+- release documentation
+
+### Acceptance
+
+- Architecture, OpenWrt version, memory and free-space checks run before staging.
+- Manifest/signature/SHA-256 checks are mandatory.
+- At most one staged package and one rollback copy are retained.
+- Configurations and CA are preserved.
+- Interrupted or failed updates return to a verified passthrough state.
+- AX6S update does not duplicate sing-box or exceed storage budget.
+
+## V2-08 — Establish low-resource profiling and AX6S gates
+
+Labels: `status:ready`, `phase:4`, `role:test`, `cap:ci`, `cap:test`, `cap:openwrt`
+
+### Objective
+
+Measure and enforce the resource budget for the unified service, multi-device
+profiles, probing, logs, diagnostics and updates.
+
+### Owned paths
+
+- `tests/harness/`
+- `scripts/ci/`
+- `.github/workflows/ci.yml`
+- `docs/testing/`
+
+### Acceptance
+
+- Idle/active RSS, CPU, file descriptors and peak probe RSS are measured.
+- Per-profile memory growth is measured without spawning per-profile processes.
+- Low-memory and low-storage tests are deterministic.
+- Package payload, update staging and log growth gates are explicit.
+- No raw captures or secrets are uploaded as artifacts.
+
+## V2-09 — Full integration, documentation, migration rehearsal and release
+
+Labels: `status:ready`, `phase:release`, `role:test`, `role:integration`, `cap:ci`, `cap:test`, `cap:openwrt`
+
+### Objective
+
+Perform the final review, test, documentation update, AX6S rehearsal, package
+build, migration, rollback and v2.0 release.
+
+### Owned paths
+
+- `README.md`
+- `docs/`
+- `.github/`
+- release/package metadata
+- final integration tests and reports
+
+### Acceptance
+
+- All v2 issues are merged and reviewed by a different role.
+- `./scripts/ci/verify.sh` passes.
+- OpenWrt Docker and AX6S tests pass.
+- v1.2.x upgrade and rollback are rehearsed.
+- Resource gates pass on the target router class.
+- README, API, deployment, troubleshooting, security and release docs agree.
+- Release artifacts are architecture-correct, signed/hashed and reproducible.
+
+### Rollback
+
+- Publish no release until the previous package and configuration restore path
+  has been demonstrated on the target router class.

--- a/docs/releases/V2.0_TASK_BREAKDOWN.md
+++ b/docs/releases/V2.0_TASK_BREAKDOWN.md
@@ -1,0 +1,73 @@
+# v2.0 task breakdown and ownership
+
+Status: planning; no v2 implementation is authorized by this document alone.
+
+The project lead owns architecture, task sequencing, integration, review,
+verification, documentation, acceptance, and release. Each implementation task
+must be backed by a GitHub Issue, an owned path, an independent `codex/` branch,
+focused commits, a handoff capsule, and a review by a different role.
+
+## Work packages
+
+| ID | Work package | Primary owner | Review owner | Depends on |
+|---|---|---|---|---|
+| V2-00 | ADR, API, profile, resource, migration contracts | integration/project lead | security | — |
+| V2-01 | Unified UCI/profile model and migration | integration | engine + test | V2-00 |
+| V2-02 | Unified supervisor and real runtime adapter | engine | network + security | V2-00, V2-01 |
+| V2-03 | Per-profile Gateway/WLOC/redirect state | engine + network | protocol + test | V2-01, V2-02 |
+| V2-04 | IPv4/IPv6, proxy, Geo, parser, and fail-open fixes | network + protocol | security + test | V2-02, V2-03 |
+| V2-05 | Unified LuCI settings, device pages, status, and diagnostics | integration | engine + test | V2-01, V2-02 |
+| V2-06 | Structured logs, bounded storage, debug mode, support bundle | integration + security | test | V2-02, V2-05 |
+| V2-07 | Component update, compatibility, rollback, and low-space handling | integration | security + test | V2-01, V2-02 |
+| V2-08 | Resource profiling and AX6S gates | test | engine | V2-02, V2-03, V2-06, V2-07 |
+| V2-09 | Full test matrix, docs, migration rehearsal, and release | test + integration | project lead + security | V2-04, V2-05, V2-06, V2-07, V2-08 |
+
+## Ownership boundaries
+
+- `src/`, service state, runtime, proxy, and TLS: `role:engine`.
+- `src/exitprobe/`, `src/georesolver/`, OpenWrt network and lifecycle files:
+  `role:network`.
+- `src/wloc/` and authorized fixtures: `role:protocol`.
+- LuCI, rpcd, UCI migration, API docs, packaging and release docs:
+  `role:integration`.
+- `SECURITY.md`, security ADRs, ACL, and workflow policy: `role:security`.
+- `tests/`, `scripts/ci/`, low-resource, OpenWrt, migration, and release tests:
+  `role:test`.
+
+## Review and verification gates
+
+Every work package must include tests before implementation where product code
+is involved. The project lead will require:
+
+- API contract tests for profile and lifecycle changes;
+- failure-path tests for redirect withdrawal and rollback;
+- multi-device isolation tests;
+- IPv4/IPv6 tests;
+- bounded log/cache/temp-file tests;
+- low-memory and low-storage measurements;
+- OpenWrt Docker verification;
+- AX6S upgrade, restart, and real-device checks;
+- `./scripts/ci/verify.sh` plus the relevant cross-build and package checks.
+
+No v2 release is accepted while a test only verifies an abstract state machine
+but not the corresponding OpenWrt runtime behavior.
+
+## Assistant delegation policy
+
+Code assistants may receive only bounded, disjoint tasks with explicit owned
+paths. They must not modify another role's active lease, change credentials,
+push releases, or self-approve safety-sensitive work. The project lead reviews
+all assistant output, runs the complete verification loop, and owns final
+merge, acceptance, and publication.
+
+## Release sequence
+
+1. Freeze v2 API/profile/migration contracts.
+2. Complete runtime and per-profile integration.
+3. Complete UI, logs, diagnostics, and update center.
+4. Run code review and security review.
+5. Run unit, integration, OpenWrt, low-resource, migration, and AX6S tests.
+6. Build architecture-specific packages and verify checksums.
+7. Rehearse upgrade and rollback from v1.2.x.
+8. Update README, API, deployment, release, troubleshooting, and security docs.
+9. Publish only after the project lead's acceptance checklist is green.

--- a/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
+++ b/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
@@ -24,7 +24,7 @@ Command:
 ```
 
 Result: PASS. The run included 69 Python tests, Rust all-target tests, Rust
-line coverage of 81.27%, OpenWrt cross-build/resource gates, release package
+line coverage of 81.29%, OpenWrt cross-build/resource gates, release package
 tests, standalone AX6S package tests, JavaScript tests, secret scanning,
 formatting, and dependency audit. Cargo audit reported no advisories; it did
 report the pre-existing duplicate `socket2` and `windows-sys` lock entries.

--- a/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
+++ b/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
@@ -1,0 +1,41 @@
+# V2 unified supervisor TDD evidence
+
+## Scope
+
+This evidence covers Issue #33's unified Gateway/WLOC lifecycle slice. The
+device-profile, LuCI, update, migration, and AX6S live-RSS slices remain
+follow-up work from the V2 task breakdown.
+
+## RED/GREEN checkpoints
+
+| Behavior | RED evidence | GREEN evidence |
+|---|---|---|
+| A failed cleanup is not reported as cleanly stopped | `cargo test --test service_supervisor cleanup_failure_is_not_reported_as_stopped` failed to compile because `CleanupUnsafe` was not implemented | The same target passed; the full supervisor integration test passed with 8 tests |
+| Legacy WLOC cannot install redirect before unified health checks | `./tests/scripts/test-unified-supervisor.sh` exited 1 after assertions for `WLOC_SKIP_REDIRECT` and fail-open cleanup were added | `unified supervisor shell tests passed` |
+| Runtime control delegates only the WLOC-owned redirect | `cargo test --bin wloc-service openwrt_runtime_delegates_only_component_redirect_actions` failed to compile because `OpenWrtRuntime` was absent | The test passed and verified `start` then `stop` against a fake helper |
+| Unified mode does not enable independent child respawn | The shell test exited 1 before supervised-mode guards were added | `unified supervisor shell tests passed`; release and standalone package tests passed |
+
+## Full verification
+
+Command:
+
+```sh
+./scripts/ci/verify.sh
+```
+
+Result: PASS. The run included 69 Python tests, Rust all-target tests, Rust
+line coverage of 81.27%, OpenWrt cross-build/resource gates, release package
+tests, standalone AX6S package tests, JavaScript tests, secret scanning,
+formatting, and dependency audit. Cargo audit reported no advisories; it did
+report the pre-existing duplicate `socket2` and `windows-sys` lock entries.
+
+## Guarantees and gaps
+
+| Guarantee | Test or evidence |
+|---|---|
+| Redirect installation is after child start and health check | `tests/scripts/test-unified-supervisor.sh`; `tests/service_supervisor.rs` |
+| WLOC fault withdraws the WLOC redirect and leaves Gateway passthrough alive | `openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh` failure paths plus shell static gate |
+| Cleanup uncertainty is visible as `CleanupUnsafe` | `tests/service_supervisor.rs:cleanup_failure_is_not_reported_as_stopped` |
+| Stable Gateway nftables namespace and UDP 500/4500 are not directly edited by WLOC cleanup | shell static gate and dedicated `wloc_service` stop mock |
+| Release packaging enables the unified entry point | `tests/scripts/test-openwrt-release-packaging.sh` and `tests/scripts/test-standalone-ax6s-package.sh` |
+| No claim is made for live AX6S RSS, procd behavior, or multi-device UI in this slice | Requires hardware/package-install acceptance in the next issue |

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -48,6 +48,9 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/export-mobileconfig.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/
+	$(INSTALL_DIR) $(1)/usr/libexec/wificalling-location-gateway
+	$(INSTALL_BIN) ./files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh $(1)/usr/libexec/wificalling-location-gateway/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/etc/config/wloc-service $(1)/etc/config/
 endef

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -98,12 +98,16 @@ start_service() {
 	/usr/libexec/$APP/firewall.sh start "$RUNDIR/clients" || { logger -t "$APP" "firewall setup failed"; /usr/libexec/$APP/firewall.sh stop "$RUNDIR/clients"; return 1; }
 	procd_open_instance sing-box
 	procd_set_param command /usr/bin/sing-box run -c "$RUNDIR/sing-box.json"
-	procd_set_param respawn 3600 5 5
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn 3600 5 5
+	fi
 	procd_set_param limits nofile="65535 65535"
 	procd_close_instance
 	procd_open_instance monitor
 	procd_set_param command /usr/libexec/$APP/monitor-loop.sh "$RUNDIR/clients" "$RUNDIR/status.json" "$RUNDIR/nodes" "$RUNDIR/node-status.json" "$RUNDIR/events.log" "$RUNDIR/monitor.state" "$event_interval" "$max_events_per_device" "$log_enabled"
-	procd_set_param respawn
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn
+	fi
 	procd_close_instance
 }
 

--- a/openwrt/files/etc/init.d/wificalling-location-gateway
+++ b/openwrt/files/etc/init.d/wificalling-location-gateway
@@ -1,0 +1,48 @@
+#!/bin/sh /etc/rc.common
+# Unified v2 Gateway/WLOC lifecycle entry point.
+#
+# The legacy wificalling-gateway and wloc-service init scripts remain in the
+# package as a one-release rollback facade. After migration only this script
+# is enabled; its procd instance owns ordering, health, redirect withdrawal,
+# and crash recovery for the two managed children.
+
+USE_PROCD=1
+START=95
+STOP=10
+
+SUPERVISOR=/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+RUNDIR=/var/run/wificalling-location-gateway
+
+start_service() {
+	[ -x "$SUPERVISOR" ] || return 1
+	mkdir -p "$RUNDIR"
+	chmod 0700 "$RUNDIR"
+
+	procd_open_instance unified
+	procd_set_param command "$SUPERVISOR" start
+	procd_set_param env \
+		WLOC_UNIFIED_RUNDIR="$RUNDIR" \
+		WLOC_SOCKET=/var/run/wloc-service/control.sock
+	# Three crashes in an hour is the hard restart ceiling. The supervisor
+	# withdraws redirects before exiting; procd then provides bounded recovery.
+	procd_set_param respawn 3600 5 3
+	procd_set_param limits nofile="4096 4096"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service() {
+	[ -x "$SUPERVISOR" ] && "$SUPERVISOR" stop >/dev/null 2>&1 || true
+	# Idempotent defensive cleanup if the procd instance was already gone.
+	[ -x /usr/sbin/wloc-redirect-sync.sh ] && /usr/sbin/wloc-redirect-sync.sh stop >/dev/null 2>&1 || true
+}
+
+reload_service() {
+	[ -x "$SUPERVISOR" ] && "$SUPERVISOR" reload >/dev/null 2>&1 || restart
+}
+
+service_triggers() {
+	procd_add_reload_trigger wificalling-gateway
+	procd_add_reload_trigger wloc-service
+}

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -23,7 +23,8 @@ start_service() {
 		"WLOC_CA_KEY=/etc/wloc-service/ca.key" \
 		"WLOC_PROXY_PORT=8443" \
 		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
-		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
+		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}" \
+		"WLOC_DEFER_REDIRECT=${WLOC_DEFER_REDIRECT:-0}"
 	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
 		procd_set_param respawn
 	fi

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -24,7 +24,9 @@ start_service() {
 		"WLOC_PROXY_PORT=8443" \
 		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
 		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
-	procd_set_param respawn
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn
+	fi
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -22,14 +22,20 @@ start_service() {
 		"WLOC_CA_CERT=/etc/wloc-service/ca.pem" \
 		"WLOC_CA_KEY=/etc/wloc-service/ca.key" \
 		"WLOC_PROXY_PORT=8443" \
-		"WLOC_DUMP_DIR=/tmp/wloc-dump"
+		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
+		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
 
 	# Keep the nftables redirect in sync with the gateway device policies.
-	/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
+	# The unified supervisor owns this step and installs the redirect only
+	# after both children pass health checks. Legacy standalone startup keeps
+	# the old behavior for rollback compatibility.
+	if [ "${WLOC_SKIP_REDIRECT:-0}" != 1 ]; then
+		/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
+	fi
 }
 
 stop_service() {

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -19,10 +19,14 @@ GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+START_TIMEOUT=${WLOC_SUPERVISOR_START_TIMEOUT:-30}
 case "$CHECK_INTERVAL" in ''|*[!0-9]*) CHECK_INTERVAL=10;; esac
 [ "$CHECK_INTERVAL" -ge 1 ] || CHECK_INTERVAL=1
 [ "$CHECK_INTERVAL" -le 60 ] || CHECK_INTERVAL=60
 case "$MAX_RUNTIME_SECONDS" in ''|*[!0-9]*) MAX_RUNTIME_SECONDS=0;; esac
+case "$START_TIMEOUT" in ''|*[!0-9]*) START_TIMEOUT=30;; esac
+[ "$START_TIMEOUT" -ge 1 ] || START_TIMEOUT=1
+[ "$START_TIMEOUT" -le 120 ] || START_TIMEOUT=120
 gateway_running=0
 wloc_running=0
 redirect_present=0
@@ -67,19 +71,20 @@ withdraw_redirect() {
 
 cleanup_runtime() {
 	reason=$1
-	keep_gateway=${2:-0}
+	keep_gateway=${2:-1}
+	state_phase=${3:-degraded_passthrough}
 	withdraw_redirect
 	stop_child "$WLOC_INIT"
 	wloc_running=0
 	if [ "$keep_gateway" -eq 1 ]; then
-		# WLOC failure is fail-open for Wi-Fi Calling: leave the stable
-		# Gateway data plane alive in passthrough and report degradation.
+		# The stable Gateway is deliberately never stopped here. WLOC failure
+		# is fail-open, and explicit stop/reload only withdraws WLOC-owned
+		# rules; the stable Gateway table remains under its original owner.
 		gateway_running=1
-		write_state degraded_passthrough "$reason"
+		write_state "$state_phase" "$reason"
 	else
-		stop_child "$GATEWAY_INIT"
 		gateway_running=0
-		write_state stopped "$reason"
+		write_state "$state_phase" "$reason"
 	fi
 	rm -f "$PIDFILE"
 }
@@ -91,7 +96,7 @@ stop_supervisor() {
 		# The procd-owned process receives SIGTERM as well; cleanup is also
 		# idempotent here for direct upgrade/rollback invocations.
 	fi
-	cleanup_runtime requested_stop
+	cleanup_runtime requested_stop 1 stopped
 	rmdir "$LOCKDIR" 2>/dev/null || true
 }
 
@@ -108,6 +113,19 @@ health_ok() {
 	[ -S "${WLOC_SOCKET:-/var/run/wloc-service/control.sock}" ] || return 1
 }
 
+gateway_healthy() {
+	command -v pgrep >/dev/null 2>&1 || return 1
+	pgrep -f '/usr/bin/sing-box run' >/dev/null 2>&1
+}
+
+wait_for_health() {
+	deadline=$(( $(now) + START_TIMEOUT ))
+	while ! health_ok; do
+		[ "$(now)" -lt "$deadline" ] || return 1
+		sleep 1
+	done
+}
+
 start_supervisor() {
 	mkdir -p "$RUNDIR"
 	chmod 0700 "$RUNDIR"
@@ -118,7 +136,7 @@ start_supervisor() {
 	if ! mkdir "$LOCKDIR" 2>/dev/null; then
 		return 0
 	fi
-	trap 'cleanup_runtime signal; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
+	trap 'cleanup_runtime signal 1 stopped; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
 	echo "$$" > "$PIDFILE"
 	chmod 0600 "$PIDFILE"
 	gateway_running=0
@@ -132,15 +150,17 @@ start_supervisor() {
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
 
-	if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime gateway_start_failed
-		exit 1
+	if ! gateway_healthy; then
+		if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
+			cleanup_runtime gateway_start_failed 0 stopped
+			exit 1
+		fi
 	fi
 	gateway_running=1
 	write_state starting gateway_ready
 
-	if ! WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime wloc_start_failed keep_gateway
+	if ! WLOC_SUPERVISED=1 WLOC_DEFER_REDIRECT=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed 1
 		exit 1
 	fi
 	wloc_running=1
@@ -148,12 +168,12 @@ start_supervisor() {
 
 	# Redirect installation is the final step. It only edits the dedicated
 	# wloc_service table and policy route; it never touches Gateway tables.
-	if ! health_ok; then
-		cleanup_runtime child_health_failed keep_gateway
+	if ! wait_for_health; then
+		cleanup_runtime child_health_failed 1
 		exit 1
 	fi
 	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
-		cleanup_runtime redirect_install_failed keep_gateway
+		cleanup_runtime redirect_install_failed 1
 		exit 1
 	fi
 	redirect_present=1
@@ -162,12 +182,12 @@ start_supervisor() {
 	started=$(now)
 	while :; do
 		if ! health_ok; then
-			cleanup_runtime health_failed keep_gateway
+			cleanup_runtime health_failed 1
 			exit 1
 		fi
 		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \
 			&& [ "$(($(now) - started))" -ge "$MAX_RUNTIME_SECONDS" ]; then
-			cleanup_runtime test_runtime_limit
+			cleanup_runtime test_runtime_limit 1 stopped
 			exit 0
 		fi
 		sleep "$CHECK_INTERVAL"

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# Unified Gateway/WLOC lifecycle supervisor.
+#
+# This is intentionally a small, POSIX/busybox-compatible coordinator. The
+# stable Gateway 1.7 service remains available as a rollback facade, but only
+# this supervisor is enabled after migration. It owns ordering and cleanup;
+# the Gateway nftables table and UDP 500/4500 handling remain owned by the
+# stable Gateway init/helper and are never edited here.
+
+set -eu
+
+APP=wificalling-location-gateway
+RUNDIR=${WLOC_UNIFIED_RUNDIR:-/var/run/$APP}
+STATE=$RUNDIR/supervisor.json
+PIDFILE=$RUNDIR/supervisor.pid
+LOCKDIR=$RUNDIR/.lock
+WLOC_INIT=${WLOC_INIT:-/etc/init.d/wloc-service}
+GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
+REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
+CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
+MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+gateway_running=0
+wloc_running=0
+redirect_present=0
+
+now() { date +%s; }
+
+json_escape() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/[[:cntrl:]]/ /g'
+}
+
+write_state() {
+	phase=$1; reason=$2
+	updated=$(now)
+	printf '{"version":1,"phase":"%s","reason":"%s","gateway":%s,"wloc":%s,"redirect":%s,"updated_at":%s}\n' \
+		"$(json_escape "$phase")" "$(json_escape "$reason")" \
+		"$gateway_running" "$wloc_running" "$redirect_present" "$updated" > "$STATE"
+	chmod 0600 "$STATE"
+}
+
+pid_alive() {
+	pid=$1
+	[ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+read_pid() {
+	[ -s "$PIDFILE" ] || return 1
+	pid=$(sed -n '1p' "$PIDFILE")
+	case "$pid" in ''|*[!0-9]*) return 1;; esac
+	pid_alive "$pid"
+}
+
+stop_child() {
+	init=$1
+	[ -x "$init" ] || return 0
+	"$init" stop >/dev/null 2>&1 || true
+}
+
+withdraw_redirect() {
+	redirect_present=0
+	[ -x "$REDIRECT_HELPER" ] && "$REDIRECT_HELPER" stop >/dev/null 2>&1 || true
+}
+
+cleanup_runtime() {
+	withdraw_redirect
+	stop_child "$WLOC_INIT"
+	stop_child "$GATEWAY_INIT"
+	gateway_running=0
+	wloc_running=0
+	write_state stopped "$1"
+	rm -f "$PIDFILE"
+}
+
+stop_supervisor() {
+	if read_pid; then
+		pid=$(sed -n '1p' "$PIDFILE")
+		[ "$$" = "$pid" ] || kill -TERM "$pid" 2>/dev/null || true
+		# The procd-owned process receives SIGTERM as well; cleanup is also
+		# idempotent here for direct upgrade/rollback invocations.
+	fi
+	cleanup_runtime requested_stop
+	rm -rf "$LOCKDIR"
+}
+
+health_ok() {
+	# The supervisor only considers a child healthy when its init action
+	# succeeded, the process is observable, and WLOC's root-only socket exists.
+	# No network probe or unbounded command output is used in this loop.
+	if command -v pgrep >/dev/null 2>&1; then
+		pgrep -f '/usr/bin/sing-box run' >/dev/null 2>&1 || return 1
+		pgrep -f '/usr/sbin/wloc-service' >/dev/null 2>&1 || return 1
+	else
+		return 1
+	fi
+	[ -S "${WLOC_SOCKET:-/var/run/wloc-service/control.sock}" ] || return 1
+}
+
+start_supervisor() {
+	mkdir -p "$RUNDIR"
+	chmod 0700 "$RUNDIR"
+	if read_pid; then
+		return 0
+	fi
+	rm -rf "$LOCKDIR"
+	if ! mkdir "$LOCKDIR" 2>/dev/null; then
+		return 0
+	fi
+	trap 'cleanup_runtime signal; rm -rf "$LOCKDIR"; exit 0' TERM INT
+	echo "$$" > "$PIDFILE"
+	chmod 0600 "$PIDFILE"
+	gateway_running=0
+	wloc_running=0
+	redirect_present=0
+	write_state starting passthrough
+
+	# Legacy children are used only as a one-release adapter. Disable their
+	# independent boot ownership before invoking them under this boundary.
+	[ -x "$WLOC_INIT" ] && "$WLOC_INIT" disable >/dev/null 2>&1 || true
+	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
+	stop_child "$WLOC_INIT"
+	stop_child "$GATEWAY_INIT"
+
+	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime gateway_start_failed
+		exit 1
+	fi
+	gateway_running=1
+	write_state starting gateway_ready
+
+	if ! "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed
+		exit 1
+	fi
+	wloc_running=1
+	write_state passthrough children_started
+
+	# Redirect installation is the final step. It only edits the dedicated
+	# wloc_service table and policy route; it never touches Gateway tables.
+	if ! health_ok; then
+		cleanup_runtime child_health_failed
+		exit 1
+	fi
+	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
+		cleanup_runtime redirect_install_failed
+		exit 1
+	fi
+	redirect_present=1
+	write_state intercepting ready
+
+	started=$(now)
+	while :; do
+		if ! health_ok; then
+			cleanup_runtime health_failed
+			exit 1
+		fi
+		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \
+			&& [ "$(($(now) - started))" -ge "$MAX_RUNTIME_SECONDS" ]; then
+			cleanup_runtime test_runtime_limit
+			exit 0
+		fi
+		sleep "$CHECK_INTERVAL"
+	done
+}
+
+main() {
+	command=${1:-start}
+	case "$command" in
+		start) start_supervisor ;;
+		stop) stop_supervisor ;;
+		reload) stop_supervisor; start_supervisor ;;
+		status) [ -s "$STATE" ] && cat "$STATE" || printf '%s\n' '{"version":1,"phase":"stopped","reason":"not_running"}' ;;
+		*) echo "usage: $0 {start|stop|reload|status}" >&2; exit 2 ;;
+	esac
+}
+
+main "$@"

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -19,6 +19,10 @@ GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+case "$CHECK_INTERVAL" in ''|*[!0-9]*) CHECK_INTERVAL=10;; esac
+[ "$CHECK_INTERVAL" -ge 1 ] || CHECK_INTERVAL=1
+[ "$CHECK_INTERVAL" -le 60 ] || CHECK_INTERVAL=60
+case "$MAX_RUNTIME_SECONDS" in ''|*[!0-9]*) MAX_RUNTIME_SECONDS=0;; esac
 gateway_running=0
 wloc_running=0
 redirect_present=0
@@ -62,12 +66,21 @@ withdraw_redirect() {
 }
 
 cleanup_runtime() {
+	reason=$1
+	keep_gateway=${2:-0}
 	withdraw_redirect
 	stop_child "$WLOC_INIT"
-	stop_child "$GATEWAY_INIT"
-	gateway_running=0
 	wloc_running=0
-	write_state stopped "$1"
+	if [ "$keep_gateway" -eq 1 ]; then
+		# WLOC failure is fail-open for Wi-Fi Calling: leave the stable
+		# Gateway data plane alive in passthrough and report degradation.
+		gateway_running=1
+		write_state degraded_passthrough "$reason"
+	else
+		stop_child "$GATEWAY_INIT"
+		gateway_running=0
+		write_state stopped "$reason"
+	fi
 	rm -f "$PIDFILE"
 }
 
@@ -79,7 +92,7 @@ stop_supervisor() {
 		# idempotent here for direct upgrade/rollback invocations.
 	fi
 	cleanup_runtime requested_stop
-	rm -rf "$LOCKDIR"
+	rmdir "$LOCKDIR" 2>/dev/null || true
 }
 
 health_ok() {
@@ -101,11 +114,11 @@ start_supervisor() {
 	if read_pid; then
 		return 0
 	fi
-	rm -rf "$LOCKDIR"
+	rmdir "$LOCKDIR" 2>/dev/null || true
 	if ! mkdir "$LOCKDIR" 2>/dev/null; then
 		return 0
 	fi
-	trap 'cleanup_runtime signal; rm -rf "$LOCKDIR"; exit 0' TERM INT
+	trap 'cleanup_runtime signal; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
 	echo "$$" > "$PIDFILE"
 	chmod 0600 "$PIDFILE"
 	gateway_running=0
@@ -118,7 +131,6 @@ start_supervisor() {
 	[ -x "$WLOC_INIT" ] && "$WLOC_INIT" disable >/dev/null 2>&1 || true
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
-	stop_child "$GATEWAY_INIT"
 
 	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
 		cleanup_runtime gateway_start_failed
@@ -127,8 +139,8 @@ start_supervisor() {
 	gateway_running=1
 	write_state starting gateway_ready
 
-	if ! "$WLOC_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime wloc_start_failed
+	if ! WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed keep_gateway
 		exit 1
 	fi
 	wloc_running=1
@@ -137,11 +149,11 @@ start_supervisor() {
 	# Redirect installation is the final step. It only edits the dedicated
 	# wloc_service table and policy route; it never touches Gateway tables.
 	if ! health_ok; then
-		cleanup_runtime child_health_failed
+		cleanup_runtime child_health_failed keep_gateway
 		exit 1
 	fi
 	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
-		cleanup_runtime redirect_install_failed
+		cleanup_runtime redirect_install_failed keep_gateway
 		exit 1
 	fi
 	redirect_present=1
@@ -150,7 +162,7 @@ start_supervisor() {
 	started=$(now)
 	while :; do
 		if ! health_ok; then
-			cleanup_runtime health_failed
+			cleanup_runtime health_failed keep_gateway
 			exit 1
 		fi
 		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -132,7 +132,7 @@ start_supervisor() {
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
 
-	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
+	if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
 		cleanup_runtime gateway_start_failed
 		exit 1
 	fi

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -16,6 +16,20 @@ CHAIN=prerouting
 PROXY_PORT="${WLOC_PROXY_PORT:-8443}"
 FWMARK=1
 ROUTE_TABLE=100
+action=${1:-start}
+
+if [ "$action" = stop ]; then
+	# Only remove the WLOC-owned table, policy route, and DNS marker. The
+	# stable Gateway 1.7 nftables table (and UDP 500/4500 handling) is never
+	# touched by this cleanup path.
+	nft delete table inet "$TABLE" 2>/dev/null || true
+	ip rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+	ip route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
+	for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
+		sed -i '/# wloc-service DNS hijack (do not edit)/,/^# wloc-service end/d' "$hosts_file" 2>/dev/null || true
+	done
+	exit 0
+fi
 
 # Collect the LAN IPs of every device in the gateway device policy.
 ips=$(uci -q show wificalling-gateway \
@@ -53,7 +67,7 @@ HOSTS_MARKER='# wloc-service DNS hijack (do not edit)'
 # dnsmasq reads addn-hosts from the /tmp/hosts directory on this build;
 # /etc/hosts is kept as a fallback.
 mkdir -p /tmp/hosts
-for hosts_file in /etc/hosts /tmp/hosts/wloc-hosts; do
+for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
     sed -i "/$HOSTS_MARKER/,/^# wloc-service end/d" "$hosts_file" 2>/dev/null || true
     cat >> "$hosts_file" <<EOF
 $HOSTS_MARKER

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -71,7 +71,7 @@ for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
     sed -i "/$HOSTS_MARKER/,/^# wloc-service end/d" "$hosts_file" 2>/dev/null || true
     cat >> "$hosts_file" <<EOF
 $HOSTS_MARKER
-$ROUTER_IP gs-loc.apple.com gs-loc-cn.apple.com gs-loc-corpa.apple.com gs-loc.apple.com.cn bluedot.is.autonavi.com bluedot.is.autonavi.com.gds.alibabadns.com
+$ROUTER_IP gs-loc.apple.com gs-loc-cn.apple.com
 # wloc-service end
 EOF
 done

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -13,7 +13,7 @@ set -eu
 TABLE=wloc_service
 SET=apple_hosts
 
-HOSTS="gs-loc.apple.com gs-loc-cn.apple.com gs-loc-corpa.apple.com gs-loc.apple.com.cn bluedot.is.autonavi.com bluedot.is.autonavi.com.gds.alibabadns.com"
+HOSTS="gs-loc.apple.com gs-loc-cn.apple.com"
 
 # The router's own LAN IPv4 (the DNS hijack maps the WLOC names to it);
 # answers equal to it must not pollute the set.

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -175,6 +175,10 @@ PY
 			cp "$root/openwrt/files/usr/sbin/wloc-redirect-sync.sh" "$stage/data/usr/sbin/wloc-redirect-sync.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-refresh-set.sh" "$stage/data/usr/sbin/wloc-refresh-set.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
+			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
+			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"
+			cp "$root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
+				"$stage/data/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 			cp "$service_bin" "$stage/data/usr/sbin/wloc-service"
 			cp "$ctl_bin" "$stage/data/usr/sbin/wloc-ctl"
 			chmod 0755 "$stage/data/etc/init.d/wloc-service" "$stage/data/usr/sbin/"*
@@ -188,14 +192,14 @@ PY
 			cat > "$stage/control/postinst" <<'POSTINST'
 #!/bin/sh
 [ -n "${IPKG_INSTROOT:-}" ] && exit 0
-/etc/init.d/wificalling-gateway enable >/dev/null 2>&1 || true
-/etc/init.d/wloc-service enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-gateway disable >/dev/null 2>&1 || true
+/etc/init.d/wloc-service disable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway enable >/dev/null 2>&1 || true
 killall -q wloc-service >/dev/null 2>&1 || true
 rm -f /var/run/wloc-service/control.sock
 mkdir -p /var/run/wificalling-gateway
 chmod 0700 /var/run/wificalling-gateway
-/etc/init.d/wificalling-gateway restart >/dev/null 2>&1 || true
-/etc/init.d/wloc-service restart >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1 || true
 rm -f /tmp/luci-indexcache.*
 /etc/init.d/rpcd reload >/dev/null 2>&1 || true
 exit 0

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -22,6 +22,7 @@ done
 ./tests/scripts/test-openwrt-release-packaging.sh
 ./tests/scripts/test-standalone-ax6s-package.sh
 ./tests/scripts/test-release-version.sh
+./tests/scripts/test-unified-supervisor.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -136,11 +136,16 @@ mkdir -p "$package_dir/files/usr/sbin" "$package_dir/files/etc/init.d" "$package
 cp "$service_bin" "$package_dir/files/usr/sbin/wloc-service"
 cp "$ctl_bin" "$package_dir/files/usr/sbin/wloc-ctl"
 cp "$repo_root/openwrt/files/etc/init.d/wloc-service" "$package_dir/files/etc/init.d/wloc-service"
+cp "$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway" "$package_dir/files/etc/init.d/wificalling-location-gateway"
+mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
+cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
+	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
 for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-health.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
-chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"*
+chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \
+	"$package_dir/files/usr/libexec/wificalling-location-gateway/"*
 
 cat > "$package_dir/Makefile" <<EOF
 include \$(TOPDIR)/rules.mk
@@ -174,12 +179,12 @@ define Package/wificalling-location-gateway/postinst
 for required in /usr/bin/sing-box /usr/sbin/nft /usr/sbin/ip /usr/libexec/rpcd; do
   [ -e "\$\$required" ] || echo "wificalling-location-gateway: prerequisite missing: \$\$required" >&2
 done
-/etc/init.d/wificalling-gateway enable >/dev/null 2>&1 || true
-/etc/init.d/wloc-service enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-gateway disable >/dev/null 2>&1 || true
+/etc/init.d/wloc-service disable >/dev/null 2>&1 || true
 mkdir -p /var/run/wificalling-gateway
 chmod 0700 /var/run/wificalling-gateway
-/etc/init.d/wificalling-gateway restart >/dev/null 2>&1 || true
-/etc/init.d/wloc-service restart >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1 || true
 rm -f /tmp/luci-indexcache.*
 /etc/init.d/rpcd reload >/dev/null 2>&1 || true
 exit 0

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,14 +18,13 @@ use crate::exitprobe::{NodeRef, ProbeLimits};
 use crate::georesolver::runtime::{resolve_geo, GeoProviderRuntime};
 use crate::georesolver::{GeoResolution, ProviderRef};
 use crate::service::api::RequestParams;
-use crate::service::control::{
-    disable as control_disable, enable as control_enable, ControlError, RuntimeControl,
-};
+use crate::service::control::{ControlError, RuntimeControl};
 use crate::service::dispatch::{DispatchError, ServiceDispatch};
 use crate::service::state::{reduce, ServiceEvent, ServicePhase, ServiceState};
 use crate::service::status::{
     encode_status, DesiredState, EngineHealth, ExitState, GeoState, StatusInputs,
 };
+use crate::service::supervisor::{SupervisorError, UnifiedSupervisor};
 use crate::wloc::PatchTarget;
 
 fn current_unix() -> u64 {
@@ -42,6 +41,13 @@ fn map_control_error(error: ControlError) -> DispatchError {
         ControlError::RedirectStillPresent => DispatchError::RedirectPresent,
         ControlError::CleanupUnsafe => DispatchError::CleanupUnsafe,
         ControlError::RuntimeFailure(_) => DispatchError::RuntimeFailure,
+    }
+}
+
+fn map_supervisor_error(error: SupervisorError) -> DispatchError {
+    match error {
+        SupervisorError::Control(control_error) => map_control_error(control_error),
+        SupervisorError::Transition(_) => DispatchError::InvalidConfig,
     }
 }
 
@@ -84,7 +90,7 @@ struct ManualGeoLookup {
 /// and Geo resolver.
 pub struct WlocService<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> {
     state: ServiceState,
-    runtime: R,
+    supervisor: UnifiedSupervisor<R>,
     probe: P,
     geo: G,
     node_ref: NodeRef,
@@ -144,7 +150,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     pub fn new(runtime: R, probe: P, geo: G, config: WlocServiceConfig) -> Self {
         Self {
             state: ServiceState::disabled(),
-            runtime,
+            supervisor: UnifiedSupervisor::new(runtime),
             probe,
             geo,
             node_ref: config.node_ref,
@@ -618,8 +624,9 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
         if self.state.phase() != ServicePhase::Disabled {
             return Err(DispatchError::InvalidConfig);
         }
-        control_enable(&mut self.runtime, self.scope_valid, self.ipv6_ready)
-            .map_err(map_control_error)?;
+        self.supervisor
+            .enable(self.scope_valid, self.ipv6_ready)
+            .map_err(map_supervisor_error)?;
         self.apply_enable_events();
         self.desired_state = DesiredState::Enabled;
         Ok(())
@@ -629,7 +636,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
         if self.state.phase() == ServicePhase::Disabled {
             return Ok(());
         }
-        control_disable(&mut self.runtime).map_err(map_control_error)?;
+        self.supervisor.disable().map_err(map_supervisor_error)?;
         for event in [ServiceEvent::BeginDisable, ServiceEvent::EngineStopped] {
             match reduce(&self.state, event) {
                 Ok(next) => self.state = next,

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -1,9 +1,9 @@
 //! Run the WLOC service control daemon over a root-owned Unix socket.
 //!
-//! The daemon serves the frozen control API on a local Unix socket. Runtime
-//! adapters are stubs until the OpenWrt sing-box/nftables/Geo adapters land;
-//! their behavior is configurable through the `WLOC_STUB_*` environment
-//! variables so the control plane can be exercised end to end on any host.
+//! The daemon serves the frozen control API on a local Unix socket. Its
+//! OpenWrt runtime adapter delegates only the component-owned WLOC redirect;
+//! process ownership and the Gateway data plane remain with the unified
+//! supervisor.
 //!
 //! Socket path: `WLOC_SOCKET` (default `/var/run/wloc-service/control.sock`).
 
@@ -45,11 +45,46 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
-/// No-op runtime control: every adapter step succeeds and the engine is
-/// healthy. Replaced by the nftables/procd adapter on OpenWrt.
-struct StubRuntime;
+/// Runtime control for the daemon's OpenWrt boundary.
+///
+/// The outer unified supervisor owns process start/stop and watchdogs. This
+/// daemon delegates the component-owned redirect and queries its presence;
+/// self-stop/drain operations are no-ops because the control server must not
+/// terminate itself.
+struct OpenWrtRuntime {
+    redirect_helper: std::path::PathBuf,
+    nft_binary: std::path::PathBuf,
+}
 
-impl RuntimeControl for StubRuntime {
+impl OpenWrtRuntime {
+    fn from_env() -> Self {
+        Self::new(
+            std::env::var("WLOC_REDIRECT_HELPER")
+                .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
+            std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
+        )
+    }
+
+    fn new(
+        redirect_helper: impl Into<std::path::PathBuf>,
+        nft_binary: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        Self {
+            redirect_helper: redirect_helper.into(),
+            nft_binary: nft_binary.into(),
+        }
+    }
+
+    fn run_redirect(&self, action: &str) -> Result<(), RuntimeFailure> {
+        std::process::Command::new(&self.redirect_helper)
+            .arg(action)
+            .status()
+            .map_err(|_| RuntimeFailure)
+            .and_then(|status| status.success().then_some(()).ok_or(RuntimeFailure))
+    }
+}
+
+impl RuntimeControl for OpenWrtRuntime {
     fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
         Ok(())
     }
@@ -60,13 +95,17 @@ impl RuntimeControl for StubRuntime {
         Ok(())
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
-        Ok(())
+        self.run_redirect("start")
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
-        Ok(())
+        self.run_redirect("stop")
     }
     fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
-        Ok(false)
+        std::process::Command::new(&self.nft_binary)
+            .args(["list", "table", "inet", "wloc_service"])
+            .status()
+            .map(|status| status.success())
+            .map_err(|_| RuntimeFailure)
     }
     fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         Ok(())
@@ -217,6 +256,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             WlocUciConfig::default()
         }
     };
+    let supervised = std::env::var("WLOC_SUPERVISED").as_deref() == Ok("1");
     // The device whose node binding the location follows. It is normally
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
@@ -253,7 +293,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     };
 
     let service = WlocService::new(
-        StubRuntime,
+        OpenWrtRuntime::from_env(),
         build_probe(&assigned_device, uci.probe_port),
         geo,
         WlocServiceConfig {
@@ -401,7 +441,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             );
         }
     }
-    if uci.enabled {
+    if uci.enabled && !supervised {
         if let Err(error) = service.enable() {
             eprintln!("wloc-service: enable failed: {error:?}");
         }
@@ -607,5 +647,33 @@ mod tests {
     fn ignores_non_ip_tokens() {
         let output = "elements = { 59.82.17.33, hostname, 10.0.0.1/8 }\n";
         assert_eq!(parse_apple_ips(output), vec!["59.82.17.33"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn openwrt_runtime_delegates_only_component_redirect_actions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "wloc-runtime-test-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("actions.log");
+        let helper = root.join("redirect-helper.sh");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n",
+            log.display()
+        );
+        std::fs::write(&helper, script).unwrap();
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut runtime = OpenWrtRuntime::new(&helper, &helper);
+        runtime.install_exact_redirect().unwrap();
+        runtime.remove_redirect().unwrap();
+
+        assert_eq!(std::fs::read_to_string(&log).unwrap(), "start\nstop\n");
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -54,15 +54,19 @@ fn now_unix() -> u64 {
 struct OpenWrtRuntime {
     redirect_helper: std::path::PathBuf,
     nft_binary: std::path::PathBuf,
+    defer_first_redirect: bool,
 }
 
 impl OpenWrtRuntime {
     fn from_env() -> Self {
-        Self::new(
+        let mut runtime = Self::new(
             std::env::var("WLOC_REDIRECT_HELPER")
                 .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
             std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
-        )
+        );
+        runtime.defer_first_redirect =
+            std::env::var("WLOC_DEFER_REDIRECT").as_deref() == Ok("1");
+        runtime
     }
 
     fn new(
@@ -72,7 +76,13 @@ impl OpenWrtRuntime {
         Self {
             redirect_helper: redirect_helper.into(),
             nft_binary: nft_binary.into(),
+            defer_first_redirect: false,
         }
+    }
+
+    #[cfg(test)]
+    fn defer_first_redirect(&mut self) {
+        self.defer_first_redirect = true;
     }
 
     fn run_redirect(&self, action: &str) -> Result<(), RuntimeFailure> {
@@ -95,6 +105,10 @@ impl RuntimeControl for OpenWrtRuntime {
         Ok(())
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        if self.defer_first_redirect {
+            self.defer_first_redirect = false;
+            return Ok(());
+        }
         self.run_redirect("start")
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
@@ -256,7 +270,6 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             WlocUciConfig::default()
         }
     };
-    let supervised = std::env::var("WLOC_SUPERVISED").as_deref() == Ok("1");
     // The device whose node binding the location follows. It is normally
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
@@ -441,7 +454,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             );
         }
     }
-    if uci.enabled && !supervised {
+    if uci.enabled {
         if let Err(error) = service.enable() {
             eprintln!("wloc-service: enable failed: {error:?}");
         }
@@ -667,10 +680,12 @@ mod tests {
         std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
 
         let mut runtime = OpenWrtRuntime::new(&helper, &helper);
+        runtime.defer_first_redirect();
         runtime.install_exact_redirect().unwrap();
         runtime.remove_redirect().unwrap();
+        runtime.install_exact_redirect().unwrap();
 
-        assert_eq!(std::fs::read_to_string(&log).unwrap(), "start\nstop\n");
+        assert_eq!(std::fs::read_to_string(&log).unwrap(), "stop\nstart\n");
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -662,10 +662,7 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let log = root.join("actions.log");
         let helper = root.join("redirect-helper.sh");
-        let script = format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n",
-            log.display()
-        );
+        let script = format!("#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n", log.display());
         std::fs::write(&helper, script).unwrap();
         std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
 

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -64,8 +64,7 @@ impl OpenWrtRuntime {
                 .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
             std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
         );
-        runtime.defer_first_redirect =
-            std::env::var("WLOC_DEFER_REDIRECT").as_deref() == Ok("1");
+        runtime.defer_first_redirect = std::env::var("WLOC_DEFER_REDIRECT").as_deref() == Ok("1");
         runtime
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,7 @@ pub mod wloc;
 /// deliberately limited to the two exact Apple names required by the
 /// OpenWrt traffic-isolation contract; DNS CNAME targets are not interception
 /// hostnames.
-pub const APPROVED_WLOC_HOSTS: [&str; 2] = [
-    "gs-loc.apple.com",
-    "gs-loc-cn.apple.com",
-];
+pub const APPROVED_WLOC_HOSTS: [&str; 2] = ["gs-loc.apple.com", "gs-loc-cn.apple.com"];
 pub const MAX_WLOC_BODY_BYTES: u64 = 512 * 1024;
 const MIN_H2_FRAME_SIZE: u32 = 16 * 1024;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,13 @@ pub mod service;
 pub mod tls_h2;
 pub mod wloc;
 
-/// Approved WLOC hostnames whose traffic may be intercepted. The Apple names
-/// CNAME to the autonavi bluedot service, so a real request can arrive with
-/// either the Apple or the bluedot hostname as its SNI/Host.
-pub const APPROVED_WLOC_HOSTS: [&str; 4] = [
+/// Approved WLOC hostnames whose traffic may be intercepted. The scope is
+/// deliberately limited to the two exact Apple names required by the
+/// OpenWrt traffic-isolation contract; DNS CNAME targets are not interception
+/// hostnames.
+pub const APPROVED_WLOC_HOSTS: [&str; 2] = [
     "gs-loc.apple.com",
     "gs-loc-cn.apple.com",
-    "bluedot.is.autonavi.com",
-    "bluedot.is.autonavi.com.gds.alibabadns.com",
 ];
 pub const MAX_WLOC_BODY_BYTES: u64 = 512 * 1024;
 const MIN_H2_FRAME_SIZE: u32 = 16 * 1024;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -16,6 +16,7 @@ pub mod dispatch;
 pub mod server;
 pub mod state;
 pub mod status;
+pub mod supervisor;
 
 pub const SERVICE_API_VERSION: u16 = 1;
 const MAX_CONNECTIONS: u16 = 32;

--- a/src/service/supervisor.rs
+++ b/src/service/supervisor.rs
@@ -73,6 +73,10 @@ pub enum SupervisorPhase {
     Intercepting,
     DegradedPassthrough,
     Draining,
+    /// Cleanup could not prove that the component-owned redirect is absent.
+    /// The state is deliberately conservative so callers never mistake an
+    /// uncertain firewall state for a cleanly stopped service.
+    CleanupUnsafe,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -356,7 +360,11 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         .map_err(SupervisorError::Transition)?;
 
         if let Err(error) = control::enable(&mut self.runtime, scope_valid, ipv6_ready) {
-            self.fail_and_stop();
+            if matches!(error, ControlError::CleanupUnsafe) {
+                self.enter_cleanup_unsafe();
+            } else {
+                self.state = SupervisorState::stopped();
+            }
             return Err(SupervisorError::Control(error));
         }
         self.state = reduce(&self.state, SupervisorEvent::ChildrenReady, self.limits)
@@ -372,7 +380,7 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         self.state = reduce(&self.state, SupervisorEvent::StopRequested, self.limits)
             .map_err(SupervisorError::Transition)?;
         if let Err(error) = control::disable(&mut self.runtime) {
-            self.state = SupervisorState::stopped();
+            self.enter_cleanup_unsafe();
             return Err(SupervisorError::Control(error));
         }
         self.state = reduce(&self.state, SupervisorEvent::ChildrenStopped, self.limits)
@@ -381,8 +389,9 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
     }
 
     pub fn record_crash(&mut self, now_unix: u64) -> RestartDecision {
-        self.state = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits)
-            .unwrap_or_else(|_| SupervisorState::stopped());
+        if let Ok(next) = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits) {
+            self.state = next;
+        }
         let decision = self.restart_budget.decide(now_unix, self.limits);
         if matches!(decision, RestartDecision::Allowed { .. }) {
             self.restart_budget.record_attempt(now_unix, self.limits);
@@ -390,8 +399,16 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         decision
     }
 
-    fn fail_and_stop(&mut self) {
-        self.state = SupervisorState::stopped();
+    fn enter_cleanup_unsafe(&mut self) {
+        self.state = SupervisorState {
+            phase: SupervisorPhase::CleanupUnsafe,
+            child_count: self.state.child_count.max(MANAGED_CHILDREN),
+            // A failed cleanup must be treated as possibly still installed.
+            redirect_present: true,
+            watchdog_armed: true,
+            scope_valid: self.state.scope_valid,
+            ipv6_ready: self.state.ipv6_ready,
+        };
     }
 }
 

--- a/src/service/supervisor.rs
+++ b/src/service/supervisor.rs
@@ -1,0 +1,402 @@
+//! Unified Gateway/WLOC lifecycle ownership.
+//!
+//! The supervisor is deliberately independent of procd and shell commands.
+//! It owns the ordering contract used by both the Rust control plane and the
+//! OpenWrt entry point: children start in passthrough, health is observed,
+//! the watchdog is armed, and only then may the component-owned redirect be
+//! installed. Failure and stop paths withdraw the redirect before children
+//! are drained or stopped.
+
+use std::time::Duration;
+
+use super::control::{self, ControlError, RuntimeControl};
+
+pub const MANAGED_CHILDREN: u8 = 2; // Gateway/sing-box + WLOC control/proxy
+pub const MAX_MANAGED_CHILDREN: u8 = 3; // includes one bounded probe child
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SupervisorLimits {
+    pub max_children: u8,
+    pub max_restart_attempts: u8,
+    pub restart_window: Duration,
+    pub initial_restart_backoff: Duration,
+    pub max_restart_backoff: Duration,
+    pub health_poll_interval: Duration,
+}
+
+impl Default for SupervisorLimits {
+    fn default() -> Self {
+        Self {
+            max_children: MAX_MANAGED_CHILDREN,
+            max_restart_attempts: 3,
+            restart_window: Duration::from_secs(300),
+            initial_restart_backoff: Duration::from_secs(5),
+            max_restart_backoff: Duration::from_secs(120),
+            health_poll_interval: Duration::from_secs(10),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorConfigError {
+    TooManyChildren,
+    InvalidRestartBudget,
+    InvalidHealthPollInterval,
+}
+
+impl SupervisorLimits {
+    pub fn validate(self) -> Result<(), SupervisorConfigError> {
+        if self.max_children == 0 || self.max_children > MAX_MANAGED_CHILDREN {
+            return Err(SupervisorConfigError::TooManyChildren);
+        }
+        if self.max_restart_attempts == 0
+            || self.restart_window.is_zero()
+            || self.initial_restart_backoff.is_zero()
+            || self.max_restart_backoff < self.initial_restart_backoff
+        {
+            return Err(SupervisorConfigError::InvalidRestartBudget);
+        }
+        if self.health_poll_interval.is_zero()
+            || self.health_poll_interval > Duration::from_secs(60)
+        {
+            return Err(SupervisorConfigError::InvalidHealthPollInterval);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorPhase {
+    Stopped,
+    StartingPassthrough,
+    ReadyPassthrough,
+    Intercepting,
+    DegradedPassthrough,
+    Draining,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SupervisorState {
+    phase: SupervisorPhase,
+    child_count: u8,
+    redirect_present: bool,
+    watchdog_armed: bool,
+    scope_valid: bool,
+    ipv6_ready: bool,
+}
+
+impl SupervisorState {
+    pub const fn stopped() -> Self {
+        Self {
+            phase: SupervisorPhase::Stopped,
+            child_count: 0,
+            redirect_present: false,
+            watchdog_armed: false,
+            scope_valid: false,
+            ipv6_ready: false,
+        }
+    }
+
+    pub const fn phase(self) -> SupervisorPhase {
+        self.phase
+    }
+
+    pub const fn child_count(self) -> u8 {
+        self.child_count
+    }
+
+    pub const fn redirect_present(self) -> bool {
+        self.redirect_present
+    }
+
+    pub const fn watchdog_armed(self) -> bool {
+        self.watchdog_armed
+    }
+
+    pub const fn scope_valid(self) -> bool {
+        self.scope_valid
+    }
+
+    pub const fn ipv6_ready(self) -> bool {
+        self.ipv6_ready
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorEvent {
+    StartRequested {
+        scope_valid: bool,
+        ipv6_ready: bool,
+        child_count: u8,
+    },
+    ChildrenReady,
+    WatchdogArmed,
+    RedirectInstalled,
+    HealthFailed,
+    StopRequested,
+    ChildrenStopped,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorTransitionError {
+    InvalidSafetyScope,
+    TooManyChildren,
+    SafetyPrerequisiteMissing,
+    InvalidTransition,
+}
+
+pub fn reduce(
+    current: &SupervisorState,
+    event: SupervisorEvent,
+    limits: SupervisorLimits,
+) -> Result<SupervisorState, SupervisorTransitionError> {
+    let mut next = *current;
+    match event {
+        SupervisorEvent::StartRequested {
+            scope_valid,
+            ipv6_ready,
+            child_count,
+        } => {
+            if current.phase != SupervisorPhase::Stopped {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            if !scope_valid || !ipv6_ready {
+                return Err(SupervisorTransitionError::InvalidSafetyScope);
+            }
+            if child_count == 0 || child_count > limits.max_children {
+                return Err(SupervisorTransitionError::TooManyChildren);
+            }
+            next.phase = SupervisorPhase::StartingPassthrough;
+            next.child_count = child_count;
+            next.scope_valid = true;
+            next.ipv6_ready = true;
+        }
+        SupervisorEvent::ChildrenReady => {
+            if current.phase != SupervisorPhase::StartingPassthrough {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.phase = SupervisorPhase::ReadyPassthrough;
+        }
+        SupervisorEvent::WatchdogArmed => {
+            if current.phase != SupervisorPhase::ReadyPassthrough {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.watchdog_armed = true;
+        }
+        SupervisorEvent::RedirectInstalled => {
+            if current.phase != SupervisorPhase::ReadyPassthrough
+                || !current.watchdog_armed
+                || !current.scope_valid
+                || !current.ipv6_ready
+            {
+                return Err(SupervisorTransitionError::SafetyPrerequisiteMissing);
+            }
+            next.phase = SupervisorPhase::Intercepting;
+            next.redirect_present = true;
+        }
+        SupervisorEvent::HealthFailed => {
+            if !matches!(
+                current.phase,
+                SupervisorPhase::StartingPassthrough
+                    | SupervisorPhase::ReadyPassthrough
+                    | SupervisorPhase::Intercepting
+            ) {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.phase = SupervisorPhase::DegradedPassthrough;
+            next.redirect_present = false;
+            next.watchdog_armed = false;
+        }
+        SupervisorEvent::StopRequested => {
+            if current.phase == SupervisorPhase::Stopped {
+                return Ok(*current);
+            }
+            next.phase = SupervisorPhase::Draining;
+            next.redirect_present = false;
+            next.watchdog_armed = false;
+        }
+        SupervisorEvent::ChildrenStopped => {
+            if !matches!(
+                current.phase,
+                SupervisorPhase::Draining | SupervisorPhase::DegradedPassthrough
+            ) {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next = SupervisorState::stopped();
+        }
+    }
+    Ok(next)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RestartDecision {
+    Allowed { delay: Duration },
+    Backoff { retry_at_unix: u64 },
+    Exhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RestartBudget {
+    window_started_at: Option<u64>,
+    attempts: u8,
+    next_allowed_at: u64,
+}
+
+impl RestartBudget {
+    pub const fn new() -> Self {
+        Self {
+            window_started_at: None,
+            attempts: 0,
+            next_allowed_at: 0,
+        }
+    }
+
+    pub fn decide(&self, now_unix: u64, limits: SupervisorLimits) -> RestartDecision {
+        let Some(window_started_at) = self.window_started_at else {
+            return RestartDecision::Allowed {
+                delay: Duration::ZERO,
+            };
+        };
+        if now_unix.saturating_sub(window_started_at) >= limits.restart_window.as_secs() {
+            return RestartDecision::Allowed {
+                delay: Duration::ZERO,
+            };
+        }
+        if self.attempts >= limits.max_restart_attempts {
+            return RestartDecision::Exhausted;
+        }
+        if now_unix < self.next_allowed_at {
+            return RestartDecision::Backoff {
+                retry_at_unix: self.next_allowed_at,
+            };
+        }
+        RestartDecision::Allowed {
+            delay: Duration::from_secs(
+                limits
+                    .initial_restart_backoff
+                    .as_secs()
+                    .saturating_mul(1_u64 << self.attempts.min(6)),
+            ),
+        }
+    }
+
+    pub fn record_attempt(&mut self, now_unix: u64, limits: SupervisorLimits) {
+        if self
+            .window_started_at
+            .map(|started| now_unix.saturating_sub(started) >= limits.restart_window.as_secs())
+            .unwrap_or(true)
+        {
+            self.window_started_at = Some(now_unix);
+            self.attempts = 0;
+        }
+        self.attempts = self.attempts.saturating_add(1);
+        let backoff = limits
+            .initial_restart_backoff
+            .as_secs()
+            .saturating_mul(1_u64 << self.attempts.saturating_sub(1).min(6));
+        self.next_allowed_at =
+            now_unix.saturating_add(backoff.min(limits.max_restart_backoff.as_secs()));
+    }
+}
+
+impl Default for RestartBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Runtime adapter owned by the unified service boundary.
+pub struct UnifiedSupervisor<R: RuntimeControl> {
+    runtime: R,
+    state: SupervisorState,
+    limits: SupervisorLimits,
+    restart_budget: RestartBudget,
+}
+
+impl<R: RuntimeControl> UnifiedSupervisor<R> {
+    pub fn new(runtime: R) -> Self {
+        Self::with_limits(runtime, SupervisorLimits::default())
+    }
+
+    pub fn with_limits(runtime: R, limits: SupervisorLimits) -> Self {
+        assert!(
+            limits.validate().is_ok(),
+            "invalid unified supervisor limits"
+        );
+        Self {
+            runtime,
+            state: SupervisorState::stopped(),
+            limits,
+            restart_budget: RestartBudget::new(),
+        }
+    }
+
+    pub fn state(&self) -> SupervisorState {
+        self.state
+    }
+
+    pub fn limits(&self) -> SupervisorLimits {
+        self.limits
+    }
+
+    pub fn restart_budget(&self) -> RestartBudget {
+        self.restart_budget
+    }
+
+    pub fn enable(&mut self, scope_valid: bool, ipv6_ready: bool) -> Result<(), SupervisorError> {
+        self.state = reduce(
+            &self.state,
+            SupervisorEvent::StartRequested {
+                scope_valid,
+                ipv6_ready,
+                child_count: MANAGED_CHILDREN,
+            },
+            self.limits,
+        )
+        .map_err(SupervisorError::Transition)?;
+
+        if let Err(error) = control::enable(&mut self.runtime, scope_valid, ipv6_ready) {
+            self.fail_and_stop();
+            return Err(SupervisorError::Control(error));
+        }
+        self.state = reduce(&self.state, SupervisorEvent::ChildrenReady, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        self.state = reduce(&self.state, SupervisorEvent::WatchdogArmed, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        self.state = reduce(&self.state, SupervisorEvent::RedirectInstalled, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        Ok(())
+    }
+
+    pub fn disable(&mut self) -> Result<(), SupervisorError> {
+        self.state = reduce(&self.state, SupervisorEvent::StopRequested, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        if let Err(error) = control::disable(&mut self.runtime) {
+            self.state = SupervisorState::stopped();
+            return Err(SupervisorError::Control(error));
+        }
+        self.state = reduce(&self.state, SupervisorEvent::ChildrenStopped, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        Ok(())
+    }
+
+    pub fn record_crash(&mut self, now_unix: u64) -> RestartDecision {
+        self.state = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits)
+            .unwrap_or_else(|_| SupervisorState::stopped());
+        let decision = self.restart_budget.decide(now_unix, self.limits);
+        if matches!(decision, RestartDecision::Allowed { .. }) {
+            self.restart_budget.record_attempt(now_unix, self.limits);
+        }
+        decision
+    }
+
+    fn fail_and_stop(&mut self) {
+        self.state = SupervisorState::stopped();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorError {
+    Transition(SupervisorTransitionError),
+    Control(ControlError),
+}

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -23,6 +23,14 @@ grep -F 'mkdir -p /var/run/wificalling-gateway' "$builder" >/dev/null ||
 	fail 'release post-install must create the volatile Gateway runtime directory before restart'
 grep -F 'chmod 0700 /var/run/wificalling-gateway' "$builder" >/dev/null ||
 	fail 'release post-install must restrict the Gateway runtime directory'
+grep -F 'wificalling-location-gateway/unified-supervisor.sh' "$builder" >/dev/null ||
+	fail 'release builder must package the unified supervisor'
+grep -F '/etc/init.d/wificalling-gateway disable' "$builder" >/dev/null ||
+	fail 'release post-install must disable the legacy Gateway owner'
+grep -F '/etc/init.d/wloc-service disable' "$builder" >/dev/null ||
+	fail 'release post-install must disable the legacy WLOC owner'
+grep -F '/etc/init.d/wificalling-location-gateway restart' "$builder" >/dev/null ||
+	fail 'release post-install must restart the unified owner'
 grep -F 'rm -f /tmp/luci-indexcache.*' "$builder" >/dev/null ||
 	fail 'release post-install must invalidate every LuCI menu cache variant'
 if grep -F 'wloc-docker-smoke-deps' "$matrix" >/dev/null; then

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -113,18 +113,26 @@ printf '%s\n' "$postinst" | grep -F 'mkdir -p /var/run/wificalling-gateway' >/de
 printf '%s\n' "$postinst" | grep -F 'chmod 0700 /var/run/wificalling-gateway' >/dev/null ||
 	fail 'standalone post-install must restrict the Gateway runtime directory'
 runtime_line=$(printf '%s\n' "$postinst" | grep -n -F 'mkdir -p /var/run/wificalling-gateway' | cut -d: -f1)
-restart_line=$(printf '%s\n' "$postinst" | grep -n -F '/etc/init.d/wificalling-gateway restart' | cut -d: -f1)
+restart_line=$(printf '%s\n' "$postinst" | grep -n -F '/etc/init.d/wificalling-location-gateway restart' | cut -d: -f1)
 [ "$runtime_line" -lt "$restart_line" ] ||
 	fail 'standalone post-install must create the Gateway runtime directory before restart'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wificalling-gateway disable' >/dev/null ||
+	fail 'standalone post-install must disable the legacy Gateway owner'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wloc-service disable' >/dev/null ||
+	fail 'standalone post-install must disable the legacy WLOC owner'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wificalling-location-gateway enable' >/dev/null ||
+	fail 'standalone post-install must enable the unified supervisor'
 printf '%s\n' "$postinst" | grep -F 'rm -f /tmp/luci-indexcache.*' >/dev/null ||
 	fail 'standalone post-install must invalidate every LuCI menu cache variant'
 for member in \
 	'./etc/config/wificalling-gateway' \
 	'./etc/init.d/wificalling-gateway' \
+	'./etc/init.d/wificalling-location-gateway' \
 	'./etc/config/wloc-service' \
 	'./etc/init.d/wloc-service' \
 	'./usr/sbin/wloc-service' \
-	'./usr/sbin/wloc-ctl'; do
+	'./usr/sbin/wloc-ctl' \
+	'./usr/libexec/wificalling-location-gateway/unified-supervisor.sh'; do
 	printf '%s\n' "$data_members" | grep -Fx "$member" >/dev/null ||
 		fail "standalone package is missing $member"
 done

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -17,6 +17,7 @@ grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 
@@ -27,8 +28,13 @@ redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]
 [ "$health" -lt "$redirect_start" ]
-grep -F 'cleanup_runtime wloc_start_failed keep_gateway' "$supervisor" >/dev/null
-grep -F 'cleanup_runtime health_failed keep_gateway' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime wloc_start_failed 1' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime health_failed 1' "$supervisor" >/dev/null
+if grep -F 'stop_child "$GATEWAY_INIT"' "$supervisor" >/dev/null; then
+	printf '%s\n' 'unified supervisor must not stop the stable Gateway table owner' >&2
+	exit 1
+fi
+grep -F 'START_TIMEOUT' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
+init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
+redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+sh -n "$supervisor" "$init" "$redirect"
+grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
+grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
+grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
+grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
+
+gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
+wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
+health=$(grep -n 'if ! health_ok' "$supervisor" | head -n 1 | cut -d: -f1)
+redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
+[ "$gateway_start" -lt "$wloc_start" ]
+[ "$wloc_start" -lt "$health" ]
+[ "$health" -lt "$redirect_start" ]
+
+if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
+	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2
+	exit 1
+fi
+
+mkdir -p "$tmp/bin" "$tmp/hosts"
+printf '%s\n' '# wloc-service DNS hijack (do not edit)' '192.0.2.1 old.example' '# wloc-service end' > "$tmp/hosts/a"
+printf '%s\n' '# keep' > "$tmp/hosts/b"
+cat > "$tmp/bin/nft" <<'EOF'
+#!/bin/sh
+printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+cat > "$tmp/bin/ip" <<'EOF'
+#!/bin/sh
+printf 'ip %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+chmod 0755 "$tmp/bin/nft" "$tmp/bin/ip"
+: > "$tmp/commands.log"
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+	WLOC_HOSTS_FILES="$tmp/hosts/a $tmp/hosts/b" "$redirect" stop
+grep -F 'nft delete table inet wloc_service' "$tmp/commands.log" >/dev/null
+grep -F 'ip rule del fwmark 1 lookup 100' "$tmp/commands.log" >/dev/null
+grep -F '# keep' "$tmp/hosts/b" >/dev/null
+if grep -F 'wificalling-gateway' "$tmp/commands.log" >/dev/null; then
+	printf '%s\n' 'WLOC cleanup touched the Gateway namespace' >&2
+	exit 1
+fi
+
+printf '%s\n' 'unified supervisor shell tests passed'

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -5,14 +5,18 @@ repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
 redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+wloc_init="$repo_root/openwrt/files/etc/init.d/wloc-service"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
 sh -n "$supervisor" "$init" "$redirect"
+sh -n "$wloc_init"
 grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
+grep -F 'WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
@@ -21,6 +25,8 @@ redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]
 [ "$health" -lt "$redirect_start" ]
+grep -F 'cleanup_runtime wloc_start_failed keep_gateway' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime health_failed keep_gateway' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -15,7 +15,7 @@ grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
-grep -F 'WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -5,17 +5,19 @@ repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
 redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+wloc_refresh="$repo_root/openwrt/files/usr/sbin/wloc-refresh-set.sh"
 wloc_init="$repo_root/openwrt/files/etc/init.d/wloc-service"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
 sh -n "$supervisor" "$init" "$redirect"
+sh -n "$wloc_refresh"
 sh -n "$wloc_init"
 grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
-grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 WLOC_DEFER_REDIRECT=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
@@ -38,6 +40,10 @@ grep -F 'START_TIMEOUT' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2
+	exit 1
+fi
+if grep -E 'gs-loc-corpa|apple\.com\.cn|bluedot' "$redirect" "$wloc_refresh" >/dev/null; then
+	printf '%s\n' 'WLOC scope must remain limited to the two exact Apple hostnames' >&2
 	exit 1
 fi
 

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -16,7 +16,9 @@ grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
+grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -25,7 +25,7 @@ grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gatew
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
-health=$(grep -n 'if ! health_ok' "$supervisor" | head -n 1 | cut -d: -f1)
+health=$(grep -n 'if ! wait_for_health' "$supervisor" | head -n 1 | cut -d: -f1)
 redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -5,6 +5,15 @@ use wificalling_location_gateway::service::{
     current_response_mode, decide_ingress, GeoRecord, IngressDisposition, ResponseMode,
     RuntimeHealth, ServiceConfig, ServiceConfigError, TrafficMeta, Transport, SERVICE_API_VERSION,
 };
+use wificalling_location_gateway::APPROVED_WLOC_HOSTS;
+
+#[test]
+fn approved_wloc_hosts_are_exactly_the_two_apple_names() {
+    assert_eq!(
+        APPROVED_WLOC_HOSTS,
+        ["gs-loc.apple.com", "gs-loc-cn.apple.com"]
+    );
+}
 
 fn assigned_device() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))

--- a/tests/service_supervisor.rs
+++ b/tests/service_supervisor.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+
+use wificalling_location_gateway::service::control::{RuntimeControl, RuntimeFailure, RuntimeStep};
+use wificalling_location_gateway::service::supervisor::{
+    reduce, RestartBudget, RestartDecision, SupervisorEvent, SupervisorLimits, SupervisorPhase,
+    SupervisorState, SupervisorTransitionError, MANAGED_CHILDREN, MAX_MANAGED_CHILDREN,
+};
+
+fn limits() -> SupervisorLimits {
+    SupervisorLimits {
+        max_children: MAX_MANAGED_CHILDREN,
+        max_restart_attempts: 3,
+        restart_window: Duration::from_secs(300),
+        initial_restart_backoff: Duration::from_secs(5),
+        max_restart_backoff: Duration::from_secs(30),
+        health_poll_interval: Duration::from_secs(10),
+    }
+}
+
+fn ready_for_redirect() -> SupervisorState {
+    let limits = limits();
+    let state = reduce(
+        &SupervisorState::stopped(),
+        SupervisorEvent::StartRequested {
+            scope_valid: true,
+            ipv6_ready: true,
+            child_count: MANAGED_CHILDREN,
+        },
+        limits,
+    )
+    .unwrap();
+    let state = reduce(&state, SupervisorEvent::ChildrenReady, limits).unwrap();
+    reduce(&state, SupervisorEvent::WatchdogArmed, limits).unwrap()
+}
+
+#[test]
+fn redirect_is_last_and_stop_withdraws_before_children() {
+    let limits = limits();
+    let ready = ready_for_redirect();
+    let active = reduce(&ready, SupervisorEvent::RedirectInstalled, limits).unwrap();
+    assert_eq!(active.phase(), SupervisorPhase::Intercepting);
+    assert!(active.redirect_present());
+
+    let draining = reduce(&active, SupervisorEvent::StopRequested, limits).unwrap();
+    assert_eq!(draining.phase(), SupervisorPhase::Draining);
+    assert!(!draining.redirect_present());
+    assert!(!draining.watchdog_armed());
+
+    let stopped = reduce(&draining, SupervisorEvent::ChildrenStopped, limits).unwrap();
+    assert_eq!(stopped, SupervisorState::stopped());
+}
+
+#[test]
+fn invalid_scope_and_child_count_never_start() {
+    let limits = limits();
+    for (scope_valid, ipv6_ready) in [(false, true), (true, false), (false, false)] {
+        assert_eq!(
+            reduce(
+                &SupervisorState::stopped(),
+                SupervisorEvent::StartRequested {
+                    scope_valid,
+                    ipv6_ready,
+                    child_count: MANAGED_CHILDREN,
+                },
+                limits,
+            ),
+            Err(SupervisorTransitionError::InvalidSafetyScope)
+        );
+    }
+    assert_eq!(
+        reduce(
+            &SupervisorState::stopped(),
+            SupervisorEvent::StartRequested {
+                scope_valid: true,
+                ipv6_ready: true,
+                child_count: MAX_MANAGED_CHILDREN + 1,
+            },
+            limits,
+        ),
+        Err(SupervisorTransitionError::TooManyChildren)
+    );
+}
+
+#[test]
+fn health_failure_withdraws_redirect_and_enters_passthrough() {
+    let limits = limits();
+    let active = reduce(
+        &ready_for_redirect(),
+        SupervisorEvent::RedirectInstalled,
+        limits,
+    )
+    .unwrap();
+    let degraded = reduce(&active, SupervisorEvent::HealthFailed, limits).unwrap();
+    assert_eq!(degraded.phase(), SupervisorPhase::DegradedPassthrough);
+    assert!(!degraded.redirect_present());
+    assert!(!degraded.watchdog_armed());
+    assert_eq!(degraded.child_count(), MANAGED_CHILDREN);
+}
+
+#[test]
+fn restart_budget_is_bounded_and_backed_off() {
+    let limits = limits();
+    let mut budget = RestartBudget::new();
+    assert_eq!(
+        budget.decide(100, limits),
+        RestartDecision::Allowed {
+            delay: Duration::ZERO
+        }
+    );
+    budget.record_attempt(100, limits);
+    assert_eq!(
+        budget.decide(100, limits),
+        RestartDecision::Backoff { retry_at_unix: 105 }
+    );
+    assert_eq!(
+        budget.decide(105, limits),
+        RestartDecision::Allowed {
+            delay: Duration::from_secs(10)
+        }
+    );
+    budget.record_attempt(105, limits);
+    budget.record_attempt(115, limits);
+    assert_eq!(budget.decide(120, limits), RestartDecision::Exhausted);
+    assert_eq!(
+        budget.decide(401, limits),
+        RestartDecision::Allowed {
+            delay: Duration::ZERO
+        }
+    );
+}
+
+#[test]
+fn limits_reject_unbounded_runtime_configuration() {
+    let mut invalid = limits();
+    invalid.max_children = MAX_MANAGED_CHILDREN + 1;
+    assert!(invalid.validate().is_err());
+    invalid = limits();
+    invalid.health_poll_interval = Duration::from_secs(61);
+    assert!(invalid.validate().is_err());
+}
+
+#[derive(Default)]
+struct FakeRuntime {
+    operations: Vec<RuntimeStep>,
+    healthy: bool,
+    redirect_present: bool,
+}
+
+impl RuntimeControl for FakeRuntime {
+    fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::StartEngine);
+        Ok(())
+    }
+    fn engine_healthy(&mut self) -> Result<bool, RuntimeFailure> {
+        self.operations.push(RuntimeStep::CheckHealth);
+        Ok(self.healthy)
+    }
+    fn arm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::ArmWatchdog);
+        Ok(())
+    }
+    fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::InstallRedirect);
+        self.redirect_present = true;
+        Ok(())
+    }
+    fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::RemoveRedirect);
+        self.redirect_present = false;
+        Ok(())
+    }
+    fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
+        self.operations.push(RuntimeStep::VerifyRedirectAbsent);
+        Ok(self.redirect_present)
+    }
+    fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::DisarmWatchdog);
+        Ok(())
+    }
+    fn drain_engine(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::DrainEngine);
+        Ok(())
+    }
+    fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::StopEngine);
+        Ok(())
+    }
+}
+
+#[test]
+fn supervisor_adapter_owns_control_ordering() {
+    let runtime = FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    };
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    supervisor.enable(true, true).unwrap();
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::Intercepting);
+    supervisor.disable().unwrap();
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::Stopped);
+}
+
+#[test]
+fn supervisor_maps_invalid_control_to_a_safe_stopped_state() {
+    let runtime = FakeRuntime::default();
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    assert!(supervisor.enable(false, true).is_err());
+    assert_eq!(supervisor.state(), SupervisorState::stopped());
+}

--- a/tests/service_supervisor.rs
+++ b/tests/service_supervisor.rs
@@ -144,46 +144,61 @@ struct FakeRuntime {
     operations: Vec<RuntimeStep>,
     healthy: bool,
     redirect_present: bool,
+    fail_step: Option<RuntimeStep>,
+}
+
+impl FakeRuntime {
+    fn should_fail(&self, step: RuntimeStep) -> Result<(), RuntimeFailure> {
+        if self.fail_step == Some(step) {
+            Err(RuntimeFailure)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl RuntimeControl for FakeRuntime {
     fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::StartEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::StartEngine)
     }
     fn engine_healthy(&mut self) -> Result<bool, RuntimeFailure> {
         self.operations.push(RuntimeStep::CheckHealth);
+        self.should_fail(RuntimeStep::CheckHealth)?;
         Ok(self.healthy)
     }
     fn arm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::ArmWatchdog);
-        Ok(())
+        self.should_fail(RuntimeStep::ArmWatchdog)
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::InstallRedirect);
+        self.should_fail(RuntimeStep::InstallRedirect)?;
         self.redirect_present = true;
         Ok(())
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::RemoveRedirect);
+        self.should_fail(RuntimeStep::RemoveRedirect)?;
         self.redirect_present = false;
         Ok(())
     }
     fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
         self.operations.push(RuntimeStep::VerifyRedirectAbsent);
+        self.should_fail(RuntimeStep::VerifyRedirectAbsent)?;
         Ok(self.redirect_present)
     }
     fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::DisarmWatchdog);
-        Ok(())
+        self.should_fail(RuntimeStep::DisarmWatchdog)
     }
     fn drain_engine(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::DrainEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::DrainEngine)
     }
     fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::StopEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::StopEngine)
     }
 }
 
@@ -208,4 +223,20 @@ fn supervisor_maps_invalid_control_to_a_safe_stopped_state() {
         wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
     assert!(supervisor.enable(false, true).is_err());
     assert_eq!(supervisor.state(), SupervisorState::stopped());
+}
+
+#[test]
+fn cleanup_failure_is_not_reported_as_stopped() {
+    let runtime = FakeRuntime {
+        healthy: true,
+        fail_step: Some(RuntimeStep::RemoveRedirect),
+        ..FakeRuntime::default()
+    };
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    supervisor.enable(true, true).unwrap();
+
+    assert!(supervisor.disable().is_err());
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::CleanupUnsafe);
+    assert!(supervisor.state().redirect_present());
 }


### PR DESCRIPTION
Closes #33.

Handoff capsule: `.handoffs/issue-33.md`

## Summary

- Add the V2 unified Gateway/WLOC lifecycle state machine and OpenWrt entry point.
- Enforce passthrough -> child readiness -> bounded health wait -> WLOC redirect as the only startup order.
- Keep WLOC faults and stop/reload fail-open without invoking the stable Gateway stop/table cleanup path.
- Replace the production WLOC redirect StubRuntime with a component-scoped OpenWrt runtime adapter.
- Disable independent child respawn in supervised mode; the outer supervisor owns bounded restart behavior.
- Package the unified init/supervisor in both standalone AX6S and formal release builders.
- Restrict interception/DNS scope to `gs-loc.apple.com` and `gs-loc-cn.apple.com` on TCP 443.

## Verification

- `./scripts/ci/verify.sh` PASS
- 69 Python tests PASS
- Rust all-target tests PASS
- Rust line coverage: 81.29%
- OpenWrt cross-build/resource gates PASS
- Release and standalone AX6S package tests PASS
- JavaScript tests and secret scan PASS
- Cargo audit: no advisories; pre-existing duplicate `socket2`/`windows-sys` lock warnings only
- Independent final review: APPROVE, no P0/P1/P2 findings

## Safety and rollback

- The supervisor only removes the WLOC-owned `inet wloc_service` table, policy route, DNS marker, and WLOC state.
- It does not directly edit the stable Gateway nftables namespace or UDP 500/4500 handling.
- Legacy init scripts remain available as the one-release rollback facade and are not independently enabled by the new package postinst.
- Live AX6S install/RSS/procd acceptance remains a release-stage follow-up; this PR does not claim hardware acceptance.

## Follow-up

Multi-device profile routing, unified LuCI management/status/log/update UI, migration tooling, live AX6S measurements, and replacement of the one-release legacy process facade are tracked in the V2 task breakdown.
