### PR TITLE
feat: add bounded per-profile runtime foundations

### DIFF
--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -1,0 +1,70 @@
+# Agent handoff: Issue 31
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,test
+- Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
+- Checkpoint parent: 601097f
+- Updated at (UTC): 2026-08-21T05:05:00Z
+- Credentials included: no
+
+## Objective
+
+Implement the bounded v2 device-profile model, legacy singleton projection,
+explicit UCI profile parsing, and additive v2 profile API decoding without
+changing the current runtime interception path.
+
+## Completed
+
+- Added `DeviceProfile`, `ProfileModel`, node selection and location mode
+  fields, validation, AX6S-oriented resource ceilings, redacted status, and
+  transactional replacement.
+- Added deterministic v1-to-singleton migration and explicit `config device`
+  UCI sections with duplicate, address, mode, coordinate, and required-device
+  validation.
+- Added v2 profile request decoding and bounded v2 result envelopes while
+  preserving the frozen v1 API.
+- Added profile tests, API tests, UCI example documentation, and the v2 profile
+  contract document.
+
+## Verification
+
+- `cargo test --all-targets`: passed.
+- `cargo clippy --all-targets -- -D warnings`: passed.
+- `./scripts/ci/verify.sh`: passed.
+- Python suite: 69 passed.
+- Rust coverage: 80.54% total.
+- Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
+  release gates: passed.
+- Relevant commits: `7542dd9`, `f38def9`.
+
+## Failed attempts
+
+- No product-code verification failure occurred. The repository commit hook
+  reports that `lefthook` is unavailable in the local PATH; the required CI
+  verification script passed independently.
+
+## Next executable steps
+
+1. Perform an independent review of the two implementation commits.
+2. Merge the branch through the Issue #31 pull request after review.
+3. Start V2-02 for the unified procd supervisor and runtime lifecycle.
+
+## Capabilities required for the next Agent
+
+- rust
+- openwrt
+- test
+- security
+
+## Security and privacy notes
+
+- No credentials, private keys, raw production traffic, device identifiers, or
+  precise location data are included.
+- Explicit v2 profiles require an assigned local IPv4/IPv6 or MAC address, but
+  redacted status exposes only configured/not-configured booleans.
+- Legacy singleton migration remains compatible with an empty assigned device;
+  it does not create a multi-device routing policy.
+- Runtime dispatch, nftables routing, procd supervision, LuCI, logs, and update
+  operations remain out of scope for this Issue.

--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -5,8 +5,8 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
-- Checkpoint parent: 601097f
-- Updated at (UTC): 2026-08-21T05:05:00Z
+- Checkpoint parent: 6b0a744
+- Updated at (UTC): 2026-08-21T05:50:00Z
 - Credentials included: no
 
 ## Objective
@@ -27,17 +27,22 @@ changing the current runtime interception path.
   preserving the frozen v1 API.
 - Added profile tests, API tests, UCI example documentation, and the v2 profile
   contract document.
+- Runtime now consumes an explicit single profile, rejects unsupported MAC and
+  multiple-profile runtime selection, and fail-closes invalid existing UCI.
+- Profile-bound probes require a matching Gateway UCI device policy and reject
+  route-only or stale sing-box rule fallback.
 
 ## Verification
 
-- `cargo test --all-targets`: passed.
+- `cargo test --all-targets`: passed (64 unit tests plus all integration suites).
 - `cargo clippy --all-targets -- -D warnings`: passed.
 - `./scripts/ci/verify.sh`: passed.
 - Python suite: 69 passed.
-- Rust coverage: 80.54% total.
+- Rust coverage: 80.96% total.
 - Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
   release gates: passed.
-- Relevant commits: `7542dd9`, `f38def9`.
+- Relevant commits: `7542dd9`, `f38def9`, `a9ad40a`, `4663edb`, `05d1b42`,
+  `6b0a744`, `0061686`.
 
 ## Failed attempts
 
@@ -47,7 +52,7 @@ changing the current runtime interception path.
 
 ## Next executable steps
 
-1. Perform an independent review of the two implementation commits.
+1. Complete independent review of the implementation and binding fallback fix.
 2. Merge the branch through the Issue #31 pull request after review.
 3. Start V2-02 for the unified procd supervisor and runtime lifecycle.
 
@@ -68,3 +73,5 @@ changing the current runtime interception path.
   it does not create a multi-device routing policy.
 - Runtime dispatch, nftables routing, procd supervision, LuCI, logs, and update
   operations remain out of scope for this Issue.
+- The route-only binding regression is covered by
+  `required_device_binding_rejects_route_only_match`.

--- a/.handoffs/issue-31.md
+++ b/.handoffs/issue-31.md
@@ -5,8 +5,8 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-31-v2-device-profiles-codex-v2-lead-20260821044654-a86aad99
-- Checkpoint parent: 6b0a744
-- Updated at (UTC): 2026-08-21T05:50:00Z
+- Checkpoint parent: 05002bf
+- Updated at (UTC): 2026-08-21T05:58:00Z
 - Credentials included: no
 
 ## Objective
@@ -31,6 +31,8 @@ changing the current runtime interception path.
   multiple-profile runtime selection, and fail-closes invalid existing UCI.
 - Profile-bound probes require a matching Gateway UCI device policy and reject
   route-only or stale sing-box rule fallback.
+- Invalid or unsupported profile scope now blocks status/periodic/forced
+  background probes and withdraws any stale patch target.
 
 ## Verification
 
@@ -38,11 +40,11 @@ changing the current runtime interception path.
 - `cargo clippy --all-targets -- -D warnings`: passed.
 - `./scripts/ci/verify.sh`: passed.
 - Python suite: 69 passed.
-- Rust coverage: 80.96% total.
+- Rust coverage: 81.00% total.
 - Dependency advisories, secret scan, OpenWrt package, AX6S resource, and
   release gates: passed.
 - Relevant commits: `7542dd9`, `f38def9`, `a9ad40a`, `4663edb`, `05d1b42`,
-  `6b0a744`, `0061686`.
+  `6b0a744`, `0061686`, `05002bf`.
 
 ## Failed attempts
 
@@ -75,3 +77,5 @@ changing the current runtime interception path.
   operations remain out of scope for this Issue.
 - The route-only binding regression is covered by
   `required_device_binding_rejects_route_only_match`.
+- The invalid-scope background-probe regression is covered by
+  `invalid_scope_never_runs_an_unbound_probe_or_publishes_target`.

--- a/.handoffs/issue-33.md
+++ b/.handoffs/issue-33.md
@@ -1,0 +1,109 @@
+# Agent handoff: Issue 33
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,test
+- Branch: codex/issue-33-unified-supervisor-codex-v2-lead-20260821044654
+- Checkpoint parent: 601097f
+- Updated at (UTC): 2026-08-21T06:16:40Z
+- Credentials included: no
+
+## Objective
+
+Deliver the V2-02 unified Gateway/WLOC lifecycle slice as an isolated OpenWrt
+component: one enabled entry point, ordered passthrough/health/redirect
+transitions, fail-open WLOC fault handling, bounded recovery, stable Gateway
+namespace protection, runtime control delegation, packaging, tests, and
+rollback documentation.
+
+## Completed
+
+- Added the Rust `UnifiedSupervisor` state machine with bounded child count,
+  restart budget, health interval, redirect-last ordering, and explicit
+  `CleanupUnsafe` state.
+- Integrated `WlocService` with the supervisor and replaced the production
+  no-op redirect runtime with `OpenWrtRuntime` delegating only the WLOC-owned
+  helper and `nft list table inet wloc_service` presence check.
+- Added the unified procd entry point and POSIX/busybox supervisor. WLOC
+  startup suppresses the legacy redirect side effect; unified health checks
+  precede redirect installation; WLOC faults leave Gateway passthrough alive.
+- Disabled independent child respawn in supervised mode so the outer
+  supervisor owns bounded recovery.
+- Updated standalone and formal release package builders/postinst scripts to
+  install and enable the unified entry point while retaining legacy rollback
+  scripts.
+- Added shell, Rust, package, TDD evidence, and operations documentation.
+
+## Files changed
+
+- `src/service/supervisor.rs`, `src/app.rs`, `src/bin/wloc-service.rs`
+- `openwrt/files/etc/init.d/wificalling-location-gateway`
+- `openwrt/files/etc/init.d/wificalling-gateway`
+- `openwrt/files/etc/init.d/wloc-service`
+- `openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh`
+- `openwrt/files/usr/sbin/wloc-redirect-sync.sh`
+- `scripts/openwrt/build-release-packages.sh`, `scripts/build-luci-ipk.sh`
+- `tests/service_supervisor.rs`, `tests/scripts/test-unified-supervisor.sh`,
+  package tests
+- `docs/adr/0002-v2-unified-runtime-and-device-profiles.md`,
+  `docs/operations/V2_UNIFIED_SUPERVISOR.md`,
+  `docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `cargo test --all-targets` | PASS | All Rust unit/integration targets passed |
+| `cargo clippy --all-targets -- -D warnings` | PASS | No warnings |
+| `./tests/scripts/test-unified-supervisor.sh` | PASS | Ordering, ownership, fail-open, namespace guards |
+| `./tests/scripts/test-standalone-ax6s-package.sh` | PASS | Standalone AX6S package contents/postinst |
+| `./tests/scripts/test-openwrt-release-packaging.sh` | PASS | Formal release builder uses unified entry point |
+| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.27% lines, OpenWrt/resource/package/security gates |
+
+## Failed attempts
+
+- Initial full verification found one rustfmt difference; `cargo fmt --all`
+  fixed it and the complete verification was rerun successfully.
+- Independent review initially found early legacy redirect installation and
+  WLOC-fault Gateway shutdown; both were corrected and covered by regression
+  assertions.
+
+## Unresolved decisions and blockers
+
+- No live AX6S install/RSS/procd run has been performed in this workspace;
+  hardware acceptance remains required before a production release.
+- The legacy init scripts remain as a one-release migration facade. In
+  supervised mode they do not own redirect installation or child respawn, but
+  the next runtime issue should replace this facade with direct child adapters
+  if the product requires literal single-process ownership.
+- Multi-device profile routing, unified LuCI management, bounded logs, and
+  component update UI are subsequent V2 issues, not claimed by this slice.
+
+## Next executable steps
+
+1. Run the final independent review on this checkpoint.
+2. Push this branch and open the Issue #33 PR only after review has no blocking
+   P0/P1 findings.
+3. Install the built package on AX6S staging and record RSS, startup, crash,
+   reload, rollback, and stable Gateway table evidence.
+4. Continue with V2-03 device-profile runtime routing and V2-04 LuCI status,
+   logs, updates, and migration UI.
+
+## Capabilities required for the next Agent
+
+- `openwrt`, `rust`, `test`, and `security` for the live acceptance pass.
+
+## Environment assumptions
+
+- OpenWrt procd, nftables TPROXY support, `sing-box`, and the stable Gateway
+  files are present on the target gateway.
+- The component owns only `inet wloc_service`, its policy route, WLOC DNS
+  marker, root-only WLOC socket/state, and its own children.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- WLOC cleanup never directly names the stable Gateway nftables table and does
+  not handle UDP 500/4500; WLOC failure is withdrawn before WLOC shutdown.

--- a/.handoffs/issue-33.md
+++ b/.handoffs/issue-33.md
@@ -6,7 +6,7 @@
 - Capabilities used: rust,openwrt,test
 - Branch: codex/issue-33-unified-supervisor-codex-v2-lead-20260821044654
 - Checkpoint parent: 601097f
-- Updated at (UTC): 2026-08-21T06:16:40Z
+- Updated at (UTC): 2026-08-21T06:26:00Z
 - Credentials included: no
 
 ## Objective
@@ -27,7 +27,12 @@ rollback documentation.
   helper and `nft list table inet wloc_service` presence check.
 - Added the unified procd entry point and POSIX/busybox supervisor. WLOC
   startup suppresses the legacy redirect side effect; unified health checks
-  precede redirect installation; WLOC faults leave Gateway passthrough alive.
+  precede redirect installation; startup has a bounded readiness wait; WLOC
+  faults and stop/reload leave Gateway passthrough alive without calling its
+  stop path.
+- Applied the supervised first-enable/deferred-redirect handshake and narrowed
+  interception/DNS scope to the two exact Apple hostnames required by the
+  project contract.
 - Disabled independent child respawn in supervised mode so the outer
   supervisor owns bounded recovery.
 - Updated standalone and formal release package builders/postinst scripts to
@@ -59,7 +64,7 @@ rollback documentation.
 | `./tests/scripts/test-unified-supervisor.sh` | PASS | Ordering, ownership, fail-open, namespace guards |
 | `./tests/scripts/test-standalone-ax6s-package.sh` | PASS | Standalone AX6S package contents/postinst |
 | `./tests/scripts/test-openwrt-release-packaging.sh` | PASS | Formal release builder uses unified entry point |
-| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.27% lines, OpenWrt/resource/package/security gates |
+| `./scripts/ci/verify.sh` | PASS | 69 Python tests, Rust coverage 81.29% lines, OpenWrt/resource/package/security gates |
 
 ## Failed attempts
 

--- a/.handoffs/issue-35.md
+++ b/.handoffs/issue-35.md
@@ -1,0 +1,105 @@
+# Agent handoff: Issue 35
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,test
+- Branch: codex/issue-35-v2-profile-runtime-codex-v2-lead-20260821044654
+- Checkpoint parent: dda770e
+- Updated at (UTC): 2026-08-21T07:00:00Z
+- Credentials included: no
+
+## Objective
+
+Implement the bounded V2-03 per-profile runtime foundations while preserving
+the frozen V1 facade and the OpenWrt fail-open traffic-isolation contract.
+
+## Completed
+
+- Added bounded `ProfileRuntimeManager` with independent profile phases,
+  redirect cleanup, degraded passthrough, duplicate-device rejection, and a
+  shared-engine health check on every new profile admission.
+- Added OpenWrt `wloc-profile-redirect.sh` with validated profile IDs/private
+  IPv4 bindings, exact TCP/443 `@apple_hosts` matching, isolated nft tables,
+  and profile-only cleanup.
+- Updated DNS/IP set refresh to populate live profile tables even when the
+  legacy `wloc_service` table is absent.
+- Added redacted profile health projection and unified LuCI device-profile and
+  service-status views, plus unified supervisor restart RPC/ACL wiring.
+- Added bounded WLOC/Gateway logs, bounded synthesized-client cache, and
+  bounded debug samples for AX6S storage/memory safety.
+- Added package-builder coverage for the profile helpers.
+
+## Files changed
+
+- `src/service/profile_runtime.rs`, `src/service/mod.rs`
+- `src/bin/wloc-service.rs`, `src/app.rs`, `src/mitm/proxy.rs`,
+  `src/config/profile.rs`
+- OpenWrt profile redirect, status, refresh, health, and package wiring
+- LuCI device-profile/status pages, menu, RPC, and ACL wiring
+- Profile/runtime/log/cache/package/UI tests
+- `docs/releases/V2.0_TASK_BREAKDOWN.md`,
+  `docs/api/WLOC_SERVICE_API_V2_DRAFT.md`
+- `.handoffs/issue-35.md`
+
+## Verification
+
+- `./scripts/ci/verify.sh` — passed; advisory scan reports no advisories.
+- `cargo test --all-targets` — passed.
+- `cargo clippy --all-targets --all-features -- -D warnings` — passed.
+- `tests/scripts/test-profile-redirect.sh` — passed.
+- `tests/scripts/test-profile-status.sh` — passed.
+- `tests/scripts/test-gateway-log-bound.sh` — passed.
+- `tests/scripts/test-unified-supervisor.sh` — passed.
+- `python3 -m unittest tests.test_v2_ui_contract tests.test_wloc_luci_mode` — passed.
+- Independent review after fixes: no P0-P3 findings; handoff approved.
+
+## Failed attempts
+
+- The first handoff capsule used a project-specific heading and was rejected
+  by the repository handoff validator; it was corrected to the canonical
+  template before publication.
+
+## Unresolved decisions and blockers
+
+- Production still uses one `WlocService` patch/Geo context and intentionally
+  refuses multi-profile runtime selection.
+- No live AX6S RSS/storage measurement has been performed in this workspace.
+
+## Explicit release boundary
+
+The production daemon still constructs one `WlocService` patch/Geo context and
+still refuses to select one profile when multiple profiles are configured.
+Therefore this handoff does not claim live multi-profile node probing or
+source-device-specific WLOC patch routing. The next implementation must add
+the shared-engine profile dispatcher and per-profile Geo/patch sink before
+enabling multiple profiles in production.
+
+## Next executable steps
+
+1. Integrate profile dispatcher into the unified service/API without changing
+   the frozen v1 facade.
+2. Add source-device-to-profile patch selection and per-profile auto/manual
+   Geo refresh tests.
+3. Re-run AX6S real-device memory/storage measurements before merging/release.
+
+## Capabilities required for the next Agent
+
+- rust
+- openwrt
+- network
+- test
+- security
+
+## Environment assumptions
+
+- Rust, Python 3, POSIX shell, Git, and GitHub CLI are available.
+- Verification is offline/synthetic; no router, device, credential, or raw
+  production traffic is required.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- Profile health output remains redacted and profile interception remains
+  restricted to exact Apple hostnames and TCP 443.

--- a/docs/adr/0002-v2-unified-runtime-and-device-profiles.md
+++ b/docs/adr/0002-v2-unified-runtime-and-device-profiles.md
@@ -1,0 +1,130 @@
+# ADR 0002: v2 unified Gateway/WLOC runtime and device profiles
+
+Status: Proposed
+
+## Context
+
+The v1.2.x product is distributed as one small architecture-specific package,
+but the installed runtime still has separate `wificalling-gateway` and
+`wloc-service` procd lifecycles. WLOC currently has one global device, node,
+location mode, and patch target. v2 must keep the AX6S resource profile while
+adding independent device records, unified control, observability, updates, and
+rollback.
+
+The existing Gateway data plane and sing-box process are valuable and must not
+be duplicated per device. The existing WLOC state machine, probe, Geo, TLS/H2,
+and protocol code should be reused behind a unified supervisor rather than
+rewritten without evidence.
+
+## Decision
+
+v2 will provide one product supervisor and one management plane:
+
+- one procd entry point: `wificalling-location-gateway`;
+- one root-only control socket and versioned API;
+- one authoritative configuration model containing device profiles;
+- one lifecycle state machine coordinating Gateway, WLOC, redirect, and health;
+- one unified status, event, diagnostic, and update surface;
+- sing-box remains a managed child process and is shared by profiles that use
+  the same node;
+- no per-device WLOC process and no duplicated sing-box configuration.
+
+Legacy init scripts and UCI files may remain as a one-release migration facade,
+but they must not independently own runtime state after migration.
+
+## Device profile contract
+
+Each profile owns:
+
+- stable profile id and display label;
+- LAN identity and source address set;
+- Gateway enabled state and one node binding;
+- WLOC enabled state;
+- `auto` or `manual` location mode;
+- manual coordinate/preset reference;
+- probe, Geo, redirect, proxy, log, and health state.
+
+The runtime must reject an incomplete or ambiguous profile. It must not choose
+an arbitrary node when the configured binding cannot be resolved.
+
+## Lifecycle contract
+
+Enable order is:
+
+1. validate profile and scope;
+2. prepare Gateway/sing-box in passthrough mode;
+3. start or verify WLOC proxy;
+4. verify health and the selected IPv6 policy;
+5. install only that profile's exact redirect last.
+
+Disable, crash recovery, and rollback must withdraw redirect before draining or
+stopping the engine. The status API must be derived from observed runtime state,
+not from a successful request to an adapter that performs no operation.
+
+## Resource contract
+
+The v2 release is not accepted until AX6S measurements establish and pass
+budgets for:
+
+- unified service idle and active RSS;
+- peak RSS while probing through a temporary sing-box instance;
+- RSS growth per additional profile;
+- CPU during normal monitoring and node switching;
+- file descriptors and concurrent H2 work;
+- package payload and update staging space;
+- log, cache, and temporary-file growth.
+
+The implementation must use bounded queues, bounded caches, bounded logs,
+single-flight updates/probes, shared node processes, and atomic cleanup of
+temporary artifacts.
+
+## Observability contract
+
+All Gateway/WLOC events use one structured envelope with timestamp, level,
+component, profile id, event, outcome, reason code, retryability, and redaction
+version. Raw WLOC bodies, credentials, tokens, and private keys are excluded
+by default. Debug capture is explicit, time-limited, size-limited, and
+automatically removed.
+
+The UI must expose both the current state and the reason for a degraded state.
+Health must cover Gateway, sing-box, node binding, WLOC proxy, CA, Geo freshness,
+IPv4/IPv6 policy, redirect presence, and the latest successful operation.
+
+## Migration and rollback
+
+Migration must:
+
+1. back up both v1 UCI files and record hashes;
+2. convert the current device/node/location settings into profiles;
+3. preserve the CA and compatible runtime data;
+4. validate the new configuration before enabling it;
+5. keep Wi-Fi Calling in passthrough if WLOC migration fails;
+6. remove stale WLOC rules before rollback;
+7. restore the previous package/configuration without deleting the CA.
+
+## Consequences
+
+Positive consequences:
+
+- one authoritative lifecycle and status model;
+- independent multi-device control without global mutable WLOC state;
+- lower resource use than one process per device;
+- consistent diagnostics, updates, and rollback;
+- clearer separation between product integration and the existing sing-box
+  dependency.
+
+Costs and risks:
+
+- migration must be tested against existing v1 configurations;
+- the unified supervisor becomes a safety-sensitive integration boundary;
+- API v2 and LuCI must be versioned together;
+- real AX6S resource measurements are required before release.
+
+## Required follow-up
+
+- Update the v1 API document or add a reviewed v2 API document before changing
+  the wire contract. The current code already exposes methods not listed in the
+  frozen v1 document.
+- Add a separate runtime adapter issue for the current `StubRuntime`.
+- Add OpenWrt, low-resource, migration, and rollback integration tests before
+  removing the legacy service facade.

--- a/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
+++ b/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
@@ -1,6 +1,9 @@
 # Unified Gateway/WLOC control API v2 draft
 
-Status: proposed; not implemented and does not change the frozen `wloc.service/v1` contract.
+Status: proposed contract; profile request decoding and bounded local runtime
+primitives are implemented, but the v2 dispatcher and production multi-profile
+Geo/patch routing are not complete. It does not change the frozen
+`wloc.service/v1` contract.
 
 ## Purpose
 
@@ -60,7 +63,8 @@ or unbounded command output.
 | `profile.wloc.set_location` | Set validated manual coordinates/preset | runtime/config |
 | `profile.wloc.clear_location` | Return profile to auto mode | runtime/config |
 
-`profile_id` is an opaque local identifier. A profile may expose its
+`profile_id` is a bounded local identifier (`[a-z0-9_-]{1,32}`) validated at
+the API boundary. A profile may expose its
 administrator-visible IP/MAC through the authenticated local LuCI facade, but
 the default wire status must not leak device material to arbitrary callers.
 
@@ -115,6 +119,11 @@ Each event uses a common envelope:
   "redaction_version": 1
 }
 ```
+
+The shipped runtime keeps the WLOC structured event file under 64 KiB and
+rejects individual events over 2 KiB. Gateway activity logs also enforce a
+64 KiB default byte cap after the per-device record cap; deployments may lower
+that cap through the local OpenWrt runtime environment.
 
 The API never returns raw WLOC request/response bodies, credentials, tokens,
 private keys, or arbitrary process output. Debug mode may expose bounded

--- a/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
+++ b/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
@@ -1,0 +1,143 @@
+# Unified Gateway/WLOC control API v2 draft
+
+Status: proposed; not implemented and does not change the frozen `wloc.service/v1` contract.
+
+## Purpose
+
+v2 replaces the single global WLOC control model with a unified Gateway/WLOC
+control plane. It coordinates device profiles, node bindings, WLOC auto/manual
+location, health, logs, diagnostics, and component updates through one
+root-only local Unix socket or an audited rpcd facade.
+
+The API is an administrative control plane. It is not exposed to LAN TCP
+clients and it never accepts credentials, raw WLOC bodies, private keys, or
+unbounded diagnostic payloads.
+
+## Transport limits
+
+- API identifier: `wloc.service/v2`.
+- Unix socket only; no TCP management listener.
+- Socket directory mode `0700`; socket mode `0600`.
+- Maximum frame: 16 KiB for control requests and normal responses.
+- Maximum concurrent control operations: 2.
+- One update job and one diagnostic bundle job at a time.
+- Log queries are paginated; a request may return at most 100 events.
+- Every request uses a bounded deadline and a validated request id.
+- Unknown fields and unknown methods are rejected.
+
+## Envelope
+
+```json
+{
+  "api_version": "wloc.service/v2",
+  "request_id": "req-1",
+  "method": "profile.status.get",
+  "params": {
+    "profile_id": "device-1"
+  }
+}
+```
+
+Responses contain exactly one `result` or `error`. Errors use stable codes and
+contain no provider payload, node credential, private key, raw protocol data,
+or unbounded command output.
+
+## Profile methods
+
+| Method | Purpose | Side effect |
+|---|---|---|
+| `profile.list` | List profiles and compact health summaries | no |
+| `profile.get` | Read one profile's effective configuration and status | no |
+| `profile.create` | Create a validated profile | configuration |
+| `profile.update` | Update profile fields transactionally | configuration |
+| `profile.delete` | Disable, clean redirect, then remove profile | configuration |
+| `profile.enable` | Enable Gateway/WLOC for one profile | runtime |
+| `profile.disable` | Withdraw redirect and disable one profile | runtime |
+| `profile.reload` | Apply profile/config changes | runtime |
+| `profile.node_test` | Run a bounded node test | background job |
+| `profile.refresh` | Force bounded exit/Geo refresh | background job |
+| `profile.wloc.set_mode` | Set `auto` or `manual` mode | runtime/config |
+| `profile.wloc.set_location` | Set validated manual coordinates/preset | runtime/config |
+| `profile.wloc.clear_location` | Return profile to auto mode | runtime/config |
+
+`profile_id` is an opaque local identifier. A profile may expose its
+administrator-visible IP/MAC through the authenticated local LuCI facade, but
+the default wire status must not leak device material to arbitrary callers.
+
+## Status methods
+
+| Method | Purpose |
+|---|---|
+| `system.status.get` | Unified Gateway/WLOC summary |
+| `profile.status.get` | One profile's state and reason |
+| `profile.status.list` | Paginated status for all profiles |
+| `diagnostics.health.get` | Detailed bounded health checks |
+| `diagnostics.self_test` | Run a bounded self-test sequence |
+| `diagnostics.bundle.create` | Create a redacted, size-limited support bundle |
+
+Profile status must distinguish at least:
+
+- disabled;
+- preparing;
+- passthrough;
+- intercepting;
+- degraded passthrough;
+- draining;
+- migration required;
+- update required.
+
+Each degraded or failed state carries a stable `reason_code`, `component`,
+`retryable`, and `observed_at` value. A green status is allowed only when the
+corresponding process, node, Geo evidence, proxy, IPv4/IPv6 policy, and
+redirect state have been observed.
+
+## Log methods
+
+| Method | Purpose |
+|---|---|
+| `log.query` | Paginated structured event query |
+| `log.clear` | Clear selected profile or global ring buffer |
+| `log.debug.enable` | Enable time-limited bounded debug mode |
+| `log.debug.disable` | Disable debug mode and remove samples |
+
+Each event uses a common envelope:
+
+```json
+{
+  "time": 0,
+  "level": "warn",
+  "component": "wloc",
+  "profile_id": "device-1",
+  "event": "geo_probe_failed",
+  "outcome": "unavailable",
+  "reason_code": "timeout",
+  "retryable": true,
+  "redaction_version": 1
+}
+```
+
+The API never returns raw WLOC request/response bodies, credentials, tokens,
+private keys, or arbitrary process output. Debug mode may expose bounded
+metadata such as byte counts, status code, duration, and body hash only.
+
+## Component update methods
+
+| Method | Purpose |
+|---|---|
+| `component.list` | Current versions and compatibility state |
+| `component.check` | Check a trusted update manifest |
+| `component.update.prepare` | Validate architecture, space, memory, and package |
+| `component.update.apply` | Apply one verified update transaction |
+| `component.update.status` | Read update progress and result |
+| `component.rollback` | Restore the last verified package/config state |
+
+Updates must use a trusted manifest, verify architecture and SHA-256/signature,
+stage at most one package and one rollback copy, preserve UCI/CA data, and
+return to a healthy passthrough state before committing the new runtime.
+
+## Compatibility
+
+The v1 API remains available through a compatibility facade during one release
+cycle. v1 methods map only to the explicitly selected default profile; they may
+not silently operate on multiple profiles. The facade is removed only after the
+v2 migration and rollback tests are complete.

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -52,7 +52,13 @@ rejected. MAC addresses are accepted in the profile schema for the future
 multi-device resolver, but the current single-runtime daemon accepts only IP
 bindings and stays disabled for a MAC-only profile. The legacy singleton
 projection may still have no address so an existing installation can continue
-its current Gateway-policy discovery path.
+its current Gateway-policy discovery path. Explicit IP bindings are limited to
+RFC1918 IPv4 or ULA IPv6 and the sing-box probe requires a matching Gateway
+device policy; it never falls back to an unrelated outbound for a profile.
+
+A missing UCI file retains the v1 unconfigured-default behavior. An existing
+but malformed or oversized UCI file is fail-closed and cannot be re-enabled by
+the v1 control socket until the file is corrected.
 
 ## v2 request envelope
 

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -1,0 +1,70 @@
+# WLOC service v2 profile slice
+
+This document records the V2-01 profile-management slice. It is additive to
+the existing `wloc.service/v1` API; no v1 request is interpreted as a profile
+request.
+
+## Bounded profile model
+
+One `device` profile is the unit of configuration for a LAN device. The model
+contains:
+
+- a stable lower-case `id`;
+- a display `label`;
+- an assigned IPv4/IPv6 address or six-octet MAC address for explicit v2
+  device sections;
+- a node reference and `node_mode` (`fixed` or `gateway_default`);
+- a WLOC source (`auto` or `manual`), optional manual coordinates, and an
+  optional manual location reference;
+- an `enabled` flag.
+
+The model is deliberately bounded for small OpenWrt gateways:
+
+- at most 8 profiles;
+- profile IDs up to 32 bytes;
+- labels up to 48 bytes;
+- node references up to 96 bytes;
+- manual location references up to 64 bytes;
+- serialized profile configuration up to 8 KiB;
+- redacted status output up to 4 KiB.
+
+Validation is performed before a model replacement. A failed replacement
+leaves the previous model unchanged.
+
+## Legacy migration
+
+If no `config device` sections exist, the v1 singleton fields are projected
+into a deterministic profile with ID `default`. The projection preserves the
+assigned device, node reference, enabled state, WLOC source, and manual
+coordinates. Repeating the projection is idempotent.
+
+When explicit device sections exist, they take precedence over the legacy
+singleton fields. Invalid IDs, addresses, node modes, location pairs, or
+duplicate IDs reject the UCI parse before any runtime operation.
+
+## v2 request envelope
+
+Profile methods use the existing control-frame bound and the version string
+`wloc.service/v2`:
+
+```json
+{
+  "api_version": "wloc.service/v2",
+  "request_id": "req-1",
+  "method": "profile.get",
+  "params": { "profile_id": "phone" }
+}
+```
+
+The V2-01 decoder accepts `profile.list`, `profile.get`, `profile.create`,
+`profile.update`, and `profile.delete`. Unknown top-level or parameter fields,
+invalid profile IDs, invalid modes, invalid addresses, and out-of-range
+coordinates fail before dispatch. `get`, `update`, and `delete` require a
+profile ID.
+
+Profile status is redacted: it reports whether an assigned device or manual
+location is configured, but never returns the device address, node reference,
+coordinates, credentials, or private key material.
+
+Runtime dispatch, multi-device nftables routing, the unified procd supervisor,
+LuCI pages, and component updates are subsequent v2 issues.

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -27,6 +27,7 @@ The model is deliberately bounded for small OpenWrt gateways:
 - manual location references up to 64 bytes;
 - serialized profile configuration up to 8 KiB;
 - redacted status output up to 4 KiB.
+- complete UCI input up to 32 KiB before section accumulation.
 
 Validation is performed before a model replacement. A failed replacement
 leaves the previous model unchanged.
@@ -41,6 +42,14 @@ coordinates. Repeating the projection is idempotent.
 When explicit device sections exist, they take precedence over the legacy
 singleton fields. Invalid IDs, addresses, node modes, location pairs, or
 duplicate IDs reject the UCI parse before any runtime operation.
+
+The current daemon consumes exactly one explicit profile. If more than one
+profile is configured before the unified multi-device runtime lands, it stays
+disabled rather than selecting a profile implicitly. Explicit addresses must
+be usable unicast LAN bindings: unspecified, loopback, multicast, broadcast,
+IPv4 link-local, IPv6 link-local, zero MAC, and multicast MAC values are
+rejected. The legacy singleton projection may still have no address so an
+existing installation can continue its current Gateway-policy discovery path.
 
 ## v2 request envelope
 
@@ -60,7 +69,9 @@ The V2-01 decoder accepts `profile.list`, `profile.get`, `profile.create`,
 `profile.update`, and `profile.delete`. Unknown top-level or parameter fields,
 invalid profile IDs, invalid modes, invalid addresses, and out-of-range
 coordinates fail before dispatch. `get`, `update`, and `delete` require a
-profile ID.
+profile ID. `create` requires the complete profile identity, label, assigned
+device, node, node mode, location source, and enabled fields; manual creates
+also require both coordinates.
 
 Profile status is redacted: it reports whether an assigned device or manual
 location is configured, but never returns the device address, node reference,

--- a/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
+++ b/docs/api/WLOC_SERVICE_API_V2_PROFILES.md
@@ -48,8 +48,11 @@ profile is configured before the unified multi-device runtime lands, it stays
 disabled rather than selecting a profile implicitly. Explicit addresses must
 be usable unicast LAN bindings: unspecified, loopback, multicast, broadcast,
 IPv4 link-local, IPv6 link-local, zero MAC, and multicast MAC values are
-rejected. The legacy singleton projection may still have no address so an
-existing installation can continue its current Gateway-policy discovery path.
+rejected. MAC addresses are accepted in the profile schema for the future
+multi-device resolver, but the current single-runtime daemon accepts only IP
+bindings and stays disabled for a MAC-only profile. The legacy singleton
+projection may still have no address so an existing installation can continue
+its current Gateway-policy discovery path.
 
 ## v2 request envelope
 

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -16,8 +16,11 @@ They are not independently enabled in the v2 steady state.
 
 1. Create a root-only volatile runtime directory and acquire the supervisor
    lock.
-2. Stop any legacy child instances and start the Gateway in passthrough.
-3. Start WLOC and wait for its root-only Unix socket.
+2. Stop any legacy WLOC instance and start or verify the Gateway in
+   passthrough. The stable Gateway init remains the owner of its own firewall
+   table; the supervisor does not call Gateway stop during a WLOC fault.
+3. Start WLOC without its legacy redirect side effect and wait for its
+   root-only Unix socket.
 4. Check both child processes before enabling the WLOC redirect.
 5. Install only the WLOC-owned redirect/table and publish `intercepting`.
 
@@ -26,11 +29,13 @@ intercepts UDP 500/4500.
 
 ## Failure and stop ordering
 
-Any child exit, health failure, redirect setup failure, SIGTERM, or reload
-first calls `wloc-redirect-sync.sh stop`, then stops WLOC and Gateway. The
-WLOC table, policy route, DNS marker, socket, and supervisor state are removed
-idempotently. The stable Gateway can remain available in passthrough during a
-WLOC failure.
+Any WLOC child exit, health failure, or redirect setup failure first calls
+`wloc-redirect-sync.sh stop`, then stops WLOC while leaving the stable Gateway
+available in passthrough. An explicit service stop, SIGTERM, or reload also
+stops the Gateway because that is an operator-requested product shutdown. The
+WLOC table, policy route, DNS marker, socket, and supervisor state are handled
+idempotently. A failed cleanup is reported as `cleanup_unsafe`, never as a
+clean `stopped` state.
 
 procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
 Rust supervisor policy additionally limits the managed child count to two

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -21,7 +21,8 @@ They are not independently enabled in the v2 steady state.
    table; the supervisor does not call Gateway stop during a WLOC fault.
 3. Start WLOC without its legacy redirect side effect and wait for its
    root-only Unix socket.
-4. Check both child processes before enabling the WLOC redirect.
+4. Wait up to the bounded startup timeout for both child processes and the
+   WLOC socket before enabling the WLOC redirect.
 5. Install only the WLOC-owned redirect/table and publish `intercepting`.
 
 The supervisor never edits the stable Gateway nftables table and never
@@ -32,10 +33,15 @@ intercepts UDP 500/4500.
 Any WLOC child exit, health failure, or redirect setup failure first calls
 `wloc-redirect-sync.sh stop`, then stops WLOC while leaving the stable Gateway
 available in passthrough. An explicit service stop, SIGTERM, or reload also
-stops the Gateway because that is an operator-requested product shutdown. The
-WLOC table, policy route, DNS marker, socket, and supervisor state are handled
-idempotently. A failed cleanup is reported as `cleanup_unsafe`, never as a
-clean `stopped` state.
+only withdraws WLOC-owned rules; the stable Gateway remains under its original
+init/firewall owner. The WLOC table, policy route, DNS marker, socket, and
+supervisor state are handled idempotently. A failed cleanup is reported as
+`cleanup_unsafe`, never as a clean `stopped` state.
+
+The WLOC daemon applies its persisted `enabled` state in supervised mode with
+the first redirect installation deferred. The supervisor performs the actual
+redirect install after readiness, so daemon state and firewall transition
+cannot disagree during startup.
 
 procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
 Rust supervisor policy additionally limits the managed child count to two

--- a/docs/operations/V2_UNIFIED_SUPERVISOR.md
+++ b/docs/operations/V2_UNIFIED_SUPERVISOR.md
@@ -1,0 +1,53 @@
+# V2 unified Gateway/WLOC supervisor
+
+## Ownership
+
+`/etc/init.d/wificalling-location-gateway` is the only enabled v2 entry point.
+Its single procd instance runs
+`/usr/libexec/wificalling-location-gateway/unified-supervisor.sh`, which
+coordinates the existing Gateway and WLOC children during the one-release
+migration window.
+
+The legacy `wificalling-gateway` and `wloc-service` init scripts remain
+available for rollback but are disabled by the migration/post-install step.
+They are not independently enabled in the v2 steady state.
+
+## Start ordering
+
+1. Create a root-only volatile runtime directory and acquire the supervisor
+   lock.
+2. Stop any legacy child instances and start the Gateway in passthrough.
+3. Start WLOC and wait for its root-only Unix socket.
+4. Check both child processes before enabling the WLOC redirect.
+5. Install only the WLOC-owned redirect/table and publish `intercepting`.
+
+The supervisor never edits the stable Gateway nftables table and never
+intercepts UDP 500/4500.
+
+## Failure and stop ordering
+
+Any child exit, health failure, redirect setup failure, SIGTERM, or reload
+first calls `wloc-redirect-sync.sh stop`, then stops WLOC and Gateway. The
+WLOC table, policy route, DNS marker, socket, and supervisor state are removed
+idempotently. The stable Gateway can remain available in passthrough during a
+WLOC failure.
+
+procd allows at most three supervisor restarts in one hour (`3600 5 3`). The
+Rust supervisor policy additionally limits the managed child count to two
+long-lived children plus one temporary probe and bounds restart backoff and
+health polling.
+
+## Rollback
+
+```sh
+/etc/init.d/wificalling-location-gateway stop
+/etc/init.d/wificalling-location-gateway disable
+/etc/init.d/wloc-service enable
+/etc/init.d/wificalling-gateway enable
+/etc/init.d/wificalling-gateway start
+/etc/init.d/wloc-service start
+```
+
+Rollback preserves `/etc/config/*`, the WLOC CA, and Gateway node material.
+If unified startup fails, the supervisor leaves the router in passthrough and
+does not delete persistent credentials or configuration.

--- a/docs/releases/V2.0_ISSUE_DRAFTS.md
+++ b/docs/releases/V2.0_ISSUE_DRAFTS.md
@@ -1,0 +1,296 @@
+# v2.0 GitHub Issue drafts
+
+These drafts are local planning material. They do not create or modify GitHub
+Issues. Each draft must be reviewed against the current repository state before
+publication and then leased through the project's agent workflow.
+
+## V2-00 — Freeze unified runtime, profile, API, resource and migration contracts
+
+Labels: `status:ready`, `phase:0`, `role:integration`, `cap:docs`, `cap:test`
+
+### Objective
+
+Approve the v2 architecture and contracts before product implementation: one
+Gateway/WLOC supervisor, one control plane, per-device profiles, resource
+budgets, structured logs, component updates, migration and rollback.
+
+### Owned paths
+
+- `docs/adr/0002-v2-unified-runtime-and-device-profiles.md`
+- `docs/api/WLOC_SERVICE_API_V2_DRAFT.md`
+- `docs/releases/V2.0_TASK_BREAKDOWN.md`
+- `docs/releases/V2.0_ISSUE_DRAFTS.md`
+
+### Acceptance
+
+- Profile schema, lifecycle states, API methods and compatibility policy are
+  reviewed and frozen.
+- AX6S memory, storage, CPU and write-volume measurement plan is explicit.
+- v1 migration and rollback paths are documented.
+- Security and test roles approve the contracts.
+
+### Non-goals
+
+- No product code changes.
+- No change to v1.2.x runtime behavior.
+
+## V2-01 — Implement unified UCI/profile model and migration
+
+Labels: `status:ready`, `phase:1`, `role:integration`, `cap:rust`, `cap:test`
+
+### Objective
+
+Replace the single global WLOC configuration with validated device profiles
+that reference existing Gateway nodes without copying credentials or spawning
+one process per device.
+
+### Owned paths
+
+- `src/config/`
+- `src/service/api.rs`
+- `src/service/dispatch.rs`
+- `openwrt/files/etc/config/`
+- migration helpers and profile contract tests under `tests/`
+
+### Dependencies
+
+- V2-00
+
+### Acceptance
+
+- Create, update, delete, enable and disable profile operations are validated.
+- Existing v1 UCI files migrate deterministically and preserve the CA.
+- Ambiguous or missing node bindings fail closed; no arbitrary-node fallback.
+- Migration failure leaves Wi-Fi Calling passthrough available.
+- v1 control requests map only to an explicitly selected default profile.
+
+### Rollback
+
+- Restore the two v1 UCI files and retain the v1 package/CA backup.
+
+## V2-02 — Implement the unified supervisor and runtime adapter
+
+Labels: `status:ready`, `phase:1`, `role:engine`, `cap:rust`, `cap:openwrt`
+
+### Objective
+
+Replace the production `StubRuntime` path with one supervisor that owns Gateway,
+WLOC, health, redirect, watchdog and passthrough lifecycle.
+
+### Owned paths
+
+- `src/bin/`
+- `src/app.rs`
+- `src/service/`
+- `src/runtime/`
+- `openwrt/files/etc/init.d/`
+- runtime adapter tests under `tests/`
+
+### Dependencies
+
+- V2-00, V2-01
+
+### Acceptance
+
+- One procd entry point is authoritative after migration.
+- Enable installs redirect only after observed engine health and scope checks.
+- Disable, crash recovery and rollback remove redirect before drain/stop.
+- Health reflects actual process, proxy, watchdog and nftables state.
+- Gateway UDP 500/4500 behavior remains unchanged.
+
+### Non-goals
+
+- Do not embed or duplicate sing-box.
+- Do not remove the legacy facade until migration tests pass.
+
+## V2-03 — Add per-profile Gateway/WLOC/redirect runtime
+
+Labels: `status:ready`, `phase:1`, `role:engine`, `role:network`, `cap:rust`, `cap:network`
+
+### Objective
+
+Give every device profile independent node binding, WLOC mode, probe/Geo state,
+patch target, redirect and health state while sharing compatible sing-box
+processes.
+
+### Owned paths
+
+- `src/app.rs`
+- `src/exitprobe/`
+- `src/georesolver/`
+- `openwrt/files/usr/sbin/`
+- `tests/` profile isolation tests
+
+### Dependencies
+
+- V2-01, V2-02
+
+### Acceptance
+
+- Two profiles can use different nodes and locations independently.
+- Two profiles can share one node without duplicate sing-box processes.
+- Disabling one profile never changes another profile's redirect or patch target.
+- A node switch updates only the affected profile.
+- Profile deletion removes only its redirect and runtime state.
+
+## V2-04 — Close network, protocol and fail-open gaps
+
+Labels: `status:ready`, `phase:2`, `role:network`, `role:protocol`, `cap:network`, `cap:security`, `cap:test`
+
+### Objective
+
+Apply the approved audit fixes without widening the intended local-router
+scope: IPv4/IPv6 policy, exact device/host/port matching, proxy correctness,
+timeouts, Geo transport and parser robustness.
+
+### Owned paths
+
+- `src/mitm/`
+- `src/tls_h2.rs`
+- `src/wloc/`
+- `src/georesolver/`
+- `src/exitprobe/`
+- `openwrt/files/usr/sbin/`
+- `tests/fixtures/` and relevant contract tests
+
+### Acceptance
+
+- IPv6 is implemented or the documented AAAA policy is enforced and tested.
+- Proxy preserves required upstream status and headers.
+- Connection, body, response, stream and concurrency limits are enforced.
+- Geo queries use the approved transport and response limits.
+- Malformed chunked/protobuf inputs cannot panic the process.
+- Unknown or invalid evidence never creates a default location.
+
+## V2-05 — Build unified LuCI settings, devices, status and diagnostics
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `cap:ui`, `cap:test`
+
+### Objective
+
+Provide a mature OpenWrt plugin information architecture: Overview, Basic
+Settings, Devices, Nodes, Runtime Status, Logs, Diagnostics, Updates and
+Advanced Settings.
+
+### Owned paths
+
+- `openwrt/luci-app-wificalling-location-gateway/files/www/`
+- `openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/`
+- menu and ACL files
+- LuCI tests and fixtures
+
+### Acceptance
+
+- Every profile has a dedicated detail view.
+- Apply operations report pending, applied, degraded or failed state.
+- Status explains the reason for every non-healthy state.
+- Dangerous actions require confirmation and show their impact.
+- Overview uses one compact status request rather than per-device polling.
+- UI works within the AX6S memory and browser-cache constraints.
+
+## V2-06 — Implement structured logs, bounded storage and diagnostics
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `role:security`, `cap:test`
+
+### Objective
+
+Unify Gateway/WLOC events into a bounded, searchable and supportable logging
+system that helps users determine whether the system is working.
+
+### Owned paths
+
+- `src/` logging/event modules
+- `openwrt/files/usr/libexec/wificalling-gateway/`
+- `openwrt/luci-app-wificalling-location-gateway/files/www/` log/diagnostic views
+- `tests/` log redaction and storage tests
+
+### Acceptance
+
+- One documented JSONL event envelope is used by Gateway and WLOC.
+- Global and per-profile byte/count limits are enforced in the writer.
+- Rotation and clear operations are bounded and atomic.
+- Debug mode is explicit, time-limited and automatically cleaned.
+- Support bundles are allowlist-based and contain no credentials or raw bodies.
+- UI supports filtering by profile, component, level, event and time.
+
+## V2-07 — Implement component update, compatibility and rollback flows
+
+Labels: `status:ready`, `phase:3`, `role:integration`, `role:security`, `cap:ci`, `cap:test`
+
+### Objective
+
+Add a low-resource-safe component update center for architecture-specific
+packages, runtime compatibility and rollback.
+
+### Owned paths
+
+- `scripts/openwrt/`
+- `scripts/ci/`
+- OpenWrt package metadata and post-install scripts
+- update API/UI and tests
+- release documentation
+
+### Acceptance
+
+- Architecture, OpenWrt version, memory and free-space checks run before staging.
+- Manifest/signature/SHA-256 checks are mandatory.
+- At most one staged package and one rollback copy are retained.
+- Configurations and CA are preserved.
+- Interrupted or failed updates return to a verified passthrough state.
+- AX6S update does not duplicate sing-box or exceed storage budget.
+
+## V2-08 — Establish low-resource profiling and AX6S gates
+
+Labels: `status:ready`, `phase:4`, `role:test`, `cap:ci`, `cap:test`, `cap:openwrt`
+
+### Objective
+
+Measure and enforce the resource budget for the unified service, multi-device
+profiles, probing, logs, diagnostics and updates.
+
+### Owned paths
+
+- `tests/harness/`
+- `scripts/ci/`
+- `.github/workflows/ci.yml`
+- `docs/testing/`
+
+### Acceptance
+
+- Idle/active RSS, CPU, file descriptors and peak probe RSS are measured.
+- Per-profile memory growth is measured without spawning per-profile processes.
+- Low-memory and low-storage tests are deterministic.
+- Package payload, update staging and log growth gates are explicit.
+- No raw captures or secrets are uploaded as artifacts.
+
+## V2-09 — Full integration, documentation, migration rehearsal and release
+
+Labels: `status:ready`, `phase:release`, `role:test`, `role:integration`, `cap:ci`, `cap:test`, `cap:openwrt`
+
+### Objective
+
+Perform the final review, test, documentation update, AX6S rehearsal, package
+build, migration, rollback and v2.0 release.
+
+### Owned paths
+
+- `README.md`
+- `docs/`
+- `.github/`
+- release/package metadata
+- final integration tests and reports
+
+### Acceptance
+
+- All v2 issues are merged and reviewed by a different role.
+- `./scripts/ci/verify.sh` passes.
+- OpenWrt Docker and AX6S tests pass.
+- v1.2.x upgrade and rollback are rehearsed.
+- Resource gates pass on the target router class.
+- README, API, deployment, troubleshooting, security and release docs agree.
+- Release artifacts are architecture-correct, signed/hashed and reproducible.
+
+### Rollback
+
+- Publish no release until the previous package and configuration restore path
+  has been demonstrated on the target router class.

--- a/docs/releases/V2.0_TASK_BREAKDOWN.md
+++ b/docs/releases/V2.0_TASK_BREAKDOWN.md
@@ -1,0 +1,73 @@
+# v2.0 task breakdown and ownership
+
+Status: planning; no v2 implementation is authorized by this document alone.
+
+The project lead owns architecture, task sequencing, integration, review,
+verification, documentation, acceptance, and release. Each implementation task
+must be backed by a GitHub Issue, an owned path, an independent `codex/` branch,
+focused commits, a handoff capsule, and a review by a different role.
+
+## Work packages
+
+| ID | Work package | Primary owner | Review owner | Depends on |
+|---|---|---|---|---|
+| V2-00 | ADR, API, profile, resource, migration contracts | integration/project lead | security | — |
+| V2-01 | Unified UCI/profile model and migration | integration | engine + test | V2-00 |
+| V2-02 | Unified supervisor and real runtime adapter | engine | network + security | V2-00, V2-01 |
+| V2-03 | Per-profile Gateway/WLOC/redirect state | engine + network | protocol + test | V2-01, V2-02 |
+| V2-04 | IPv4/IPv6, proxy, Geo, parser, and fail-open fixes | network + protocol | security + test | V2-02, V2-03 |
+| V2-05 | Unified LuCI settings, device pages, status, and diagnostics | integration | engine + test | V2-01, V2-02 |
+| V2-06 | Structured logs, bounded storage, debug mode, support bundle | integration + security | test | V2-02, V2-05 |
+| V2-07 | Component update, compatibility, rollback, and low-space handling | integration | security + test | V2-01, V2-02 |
+| V2-08 | Resource profiling and AX6S gates | test | engine | V2-02, V2-03, V2-06, V2-07 |
+| V2-09 | Full test matrix, docs, migration rehearsal, and release | test + integration | project lead + security | V2-04, V2-05, V2-06, V2-07, V2-08 |
+
+## Ownership boundaries
+
+- `src/`, service state, runtime, proxy, and TLS: `role:engine`.
+- `src/exitprobe/`, `src/georesolver/`, OpenWrt network and lifecycle files:
+  `role:network`.
+- `src/wloc/` and authorized fixtures: `role:protocol`.
+- LuCI, rpcd, UCI migration, API docs, packaging and release docs:
+  `role:integration`.
+- `SECURITY.md`, security ADRs, ACL, and workflow policy: `role:security`.
+- `tests/`, `scripts/ci/`, low-resource, OpenWrt, migration, and release tests:
+  `role:test`.
+
+## Review and verification gates
+
+Every work package must include tests before implementation where product code
+is involved. The project lead will require:
+
+- API contract tests for profile and lifecycle changes;
+- failure-path tests for redirect withdrawal and rollback;
+- multi-device isolation tests;
+- IPv4/IPv6 tests;
+- bounded log/cache/temp-file tests;
+- low-memory and low-storage measurements;
+- OpenWrt Docker verification;
+- AX6S upgrade, restart, and real-device checks;
+- `./scripts/ci/verify.sh` plus the relevant cross-build and package checks.
+
+No v2 release is accepted while a test only verifies an abstract state machine
+but not the corresponding OpenWrt runtime behavior.
+
+## Assistant delegation policy
+
+Code assistants may receive only bounded, disjoint tasks with explicit owned
+paths. They must not modify another role's active lease, change credentials,
+push releases, or self-approve safety-sensitive work. The project lead reviews
+all assistant output, runs the complete verification loop, and owns final
+merge, acceptance, and publication.
+
+## Release sequence
+
+1. Freeze v2 API/profile/migration contracts.
+2. Complete runtime and per-profile integration.
+3. Complete UI, logs, diagnostics, and update center.
+4. Run code review and security review.
+5. Run unit, integration, OpenWrt, low-resource, migration, and AX6S tests.
+6. Build architecture-specific packages and verify checksums.
+7. Rehearse upgrade and rollback from v1.2.x.
+8. Update README, API, deployment, release, troubleshooting, and security docs.
+9. Publish only after the project lead's acceptance checklist is green.

--- a/docs/releases/V2.0_TASK_BREAKDOWN.md
+++ b/docs/releases/V2.0_TASK_BREAKDOWN.md
@@ -1,6 +1,31 @@
 # v2.0 task breakdown and ownership
 
-Status: planning; no v2 implementation is authorized by this document alone.
+Status: active implementation under GitHub Issue #35; the project lead owns
+integration and acceptance. This document is the implementation checklist,
+not a release approval.
+
+## Current implementation checkpoint
+
+Completed on the V2-03 branch and covered by focused tests:
+
+- bounded `ProfileRuntimeManager` with independent enable/disable/degraded
+  state and shared-engine health gating;
+- profile-scoped OpenWrt nftables tables, exact TCP/443 rule shape, approved
+  Apple set refresh, independent cleanup, and package inclusion;
+- redacted per-profile health projection and a unified LuCI device-profile
+  page/status table;
+- bounded WLOC event log (64 KiB), Gateway activity log (configurable default
+  64 KiB), synthesized-client cache, and debug sample files.
+
+Still not accepted for a v2 release:
+
+- the production daemon still consumes one `WlocService` patch/Geo context;
+  multiple profiles must not be enabled against it until per-profile node
+  probing and source-device patch routing are integrated;
+- LuCI profile save/restart is a configuration surface, not proof of live
+  multi-profile interception;
+- component update/rollback, migration rehearsal, AX6S real-device memory and
+  storage measurements, and the full OpenWrt matrix remain release gates.
 
 The project lead owns architecture, task sequencing, integration, review,
 verification, documentation, acceptance, and release. Each implementation task

--- a/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
+++ b/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
@@ -24,7 +24,7 @@ Command:
 ```
 
 Result: PASS. The run included 69 Python tests, Rust all-target tests, Rust
-line coverage of 81.27%, OpenWrt cross-build/resource gates, release package
+line coverage of 81.29%, OpenWrt cross-build/resource gates, release package
 tests, standalone AX6S package tests, JavaScript tests, secret scanning,
 formatting, and dependency audit. Cargo audit reported no advisories; it did
 report the pre-existing duplicate `socket2` and `windows-sys` lock entries.

--- a/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
+++ b/docs/testing/V2_UNIFIED_SUPERVISOR.tdd.md
@@ -1,0 +1,41 @@
+# V2 unified supervisor TDD evidence
+
+## Scope
+
+This evidence covers Issue #33's unified Gateway/WLOC lifecycle slice. The
+device-profile, LuCI, update, migration, and AX6S live-RSS slices remain
+follow-up work from the V2 task breakdown.
+
+## RED/GREEN checkpoints
+
+| Behavior | RED evidence | GREEN evidence |
+|---|---|---|
+| A failed cleanup is not reported as cleanly stopped | `cargo test --test service_supervisor cleanup_failure_is_not_reported_as_stopped` failed to compile because `CleanupUnsafe` was not implemented | The same target passed; the full supervisor integration test passed with 8 tests |
+| Legacy WLOC cannot install redirect before unified health checks | `./tests/scripts/test-unified-supervisor.sh` exited 1 after assertions for `WLOC_SKIP_REDIRECT` and fail-open cleanup were added | `unified supervisor shell tests passed` |
+| Runtime control delegates only the WLOC-owned redirect | `cargo test --bin wloc-service openwrt_runtime_delegates_only_component_redirect_actions` failed to compile because `OpenWrtRuntime` was absent | The test passed and verified `start` then `stop` against a fake helper |
+| Unified mode does not enable independent child respawn | The shell test exited 1 before supervised-mode guards were added | `unified supervisor shell tests passed`; release and standalone package tests passed |
+
+## Full verification
+
+Command:
+
+```sh
+./scripts/ci/verify.sh
+```
+
+Result: PASS. The run included 69 Python tests, Rust all-target tests, Rust
+line coverage of 81.27%, OpenWrt cross-build/resource gates, release package
+tests, standalone AX6S package tests, JavaScript tests, secret scanning,
+formatting, and dependency audit. Cargo audit reported no advisories; it did
+report the pre-existing duplicate `socket2` and `windows-sys` lock entries.
+
+## Guarantees and gaps
+
+| Guarantee | Test or evidence |
+|---|---|
+| Redirect installation is after child start and health check | `tests/scripts/test-unified-supervisor.sh`; `tests/service_supervisor.rs` |
+| WLOC fault withdraws the WLOC redirect and leaves Gateway passthrough alive | `openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh` failure paths plus shell static gate |
+| Cleanup uncertainty is visible as `CleanupUnsafe` | `tests/service_supervisor.rs:cleanup_failure_is_not_reported_as_stopped` |
+| Stable Gateway nftables namespace and UDP 500/4500 are not directly edited by WLOC cleanup | shell static gate and dedicated `wloc_service` stop mock |
+| Release packaging enables the unified entry point | `tests/scripts/test-openwrt-release-packaging.sh` and `tests/scripts/test-standalone-ax6s-package.sh` |
+| No claim is made for live AX6S RSS, procd behavior, or multi-device UI in this slice | Requires hardware/package-install acceptance in the next issue |

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -49,6 +49,7 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-redirect-sync.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-refresh-set.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-redirect.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-status.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-health.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -46,6 +46,10 @@ define Package/wloc-service/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(BIN_DIR)/wloc-service $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/export-mobileconfig.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-redirect-sync.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-refresh-set.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-redirect.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-health.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -48,6 +48,9 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/export-mobileconfig.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/
+	$(INSTALL_DIR) $(1)/usr/libexec/wificalling-location-gateway
+	$(INSTALL_BIN) ./files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh $(1)/usr/libexec/wificalling-location-gateway/
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) ./files/etc/config/wloc-service $(1)/etc/config/
 endef

--- a/openwrt/files/etc/config/wloc-service
+++ b/openwrt/files/etc/config/wloc-service
@@ -36,3 +36,17 @@ config preset 'hong_kong'
 	option label 'Hong Kong'
 	option latitude '22.3193'
 	option longitude '114.1694'
+
+# v2 migration example (disabled by default): one config device section is
+# the future unit for node binding, WLOC mode, service enablement, logs, and
+# monitoring. If any device sections are present, they take precedence over
+# the legacy singleton fields above. Keep addresses and locations local to
+# the router; they are never returned by the redacted status API.
+#
+# config device 'phone'
+# 	option label 'Living room phone'
+# 	option assigned_device '192.168.1.100'
+# 	option node_ref 'default'
+# 	option node_mode 'fixed'
+# 	option geo_source 'auto'
+# 	option enabled '1'

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -98,12 +98,16 @@ start_service() {
 	/usr/libexec/$APP/firewall.sh start "$RUNDIR/clients" || { logger -t "$APP" "firewall setup failed"; /usr/libexec/$APP/firewall.sh stop "$RUNDIR/clients"; return 1; }
 	procd_open_instance sing-box
 	procd_set_param command /usr/bin/sing-box run -c "$RUNDIR/sing-box.json"
-	procd_set_param respawn 3600 5 5
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn 3600 5 5
+	fi
 	procd_set_param limits nofile="65535 65535"
 	procd_close_instance
 	procd_open_instance monitor
 	procd_set_param command /usr/libexec/$APP/monitor-loop.sh "$RUNDIR/clients" "$RUNDIR/status.json" "$RUNDIR/nodes" "$RUNDIR/node-status.json" "$RUNDIR/events.log" "$RUNDIR/monitor.state" "$event_interval" "$max_events_per_device" "$log_enabled"
-	procd_set_param respawn
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn
+	fi
 	procd_close_instance
 }
 

--- a/openwrt/files/etc/init.d/wificalling-location-gateway
+++ b/openwrt/files/etc/init.d/wificalling-location-gateway
@@ -1,0 +1,48 @@
+#!/bin/sh /etc/rc.common
+# Unified v2 Gateway/WLOC lifecycle entry point.
+#
+# The legacy wificalling-gateway and wloc-service init scripts remain in the
+# package as a one-release rollback facade. After migration only this script
+# is enabled; its procd instance owns ordering, health, redirect withdrawal,
+# and crash recovery for the two managed children.
+
+USE_PROCD=1
+START=95
+STOP=10
+
+SUPERVISOR=/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+RUNDIR=/var/run/wificalling-location-gateway
+
+start_service() {
+	[ -x "$SUPERVISOR" ] || return 1
+	mkdir -p "$RUNDIR"
+	chmod 0700 "$RUNDIR"
+
+	procd_open_instance unified
+	procd_set_param command "$SUPERVISOR" start
+	procd_set_param env \
+		WLOC_UNIFIED_RUNDIR="$RUNDIR" \
+		WLOC_SOCKET=/var/run/wloc-service/control.sock
+	# Three crashes in an hour is the hard restart ceiling. The supervisor
+	# withdraws redirects before exiting; procd then provides bounded recovery.
+	procd_set_param respawn 3600 5 3
+	procd_set_param limits nofile="4096 4096"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+stop_service() {
+	[ -x "$SUPERVISOR" ] && "$SUPERVISOR" stop >/dev/null 2>&1 || true
+	# Idempotent defensive cleanup if the procd instance was already gone.
+	[ -x /usr/sbin/wloc-redirect-sync.sh ] && /usr/sbin/wloc-redirect-sync.sh stop >/dev/null 2>&1 || true
+}
+
+reload_service() {
+	[ -x "$SUPERVISOR" ] && "$SUPERVISOR" reload >/dev/null 2>&1 || restart
+}
+
+service_triggers() {
+	procd_add_reload_trigger wificalling-gateway
+	procd_add_reload_trigger wloc-service
+}

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -23,7 +23,8 @@ start_service() {
 		"WLOC_CA_KEY=/etc/wloc-service/ca.key" \
 		"WLOC_PROXY_PORT=8443" \
 		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
-		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
+		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}" \
+		"WLOC_DEFER_REDIRECT=${WLOC_DEFER_REDIRECT:-0}"
 	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
 		procd_set_param respawn
 	fi

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -24,7 +24,9 @@ start_service() {
 		"WLOC_PROXY_PORT=8443" \
 		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
 		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
-	procd_set_param respawn
+	if [ "${WLOC_SUPERVISED:-0}" != 1 ]; then
+		procd_set_param respawn
+	fi
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -22,14 +22,20 @@ start_service() {
 		"WLOC_CA_CERT=/etc/wloc-service/ca.pem" \
 		"WLOC_CA_KEY=/etc/wloc-service/ca.key" \
 		"WLOC_PROXY_PORT=8443" \
-		"WLOC_DUMP_DIR=/tmp/wloc-dump"
+		"WLOC_DUMP_DIR=/tmp/wloc-dump" \
+		"WLOC_SUPERVISED=${WLOC_SUPERVISED:-0}"
 	procd_set_param respawn
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_close_instance
 
 	# Keep the nftables redirect in sync with the gateway device policies.
-	/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
+	# The unified supervisor owns this step and installs the redirect only
+	# after both children pass health checks. Legacy standalone startup keeps
+	# the old behavior for rollback compatibility.
+	if [ "${WLOC_SKIP_REDIRECT:-0}" != 1 ]; then
+		/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
+	fi
 }
 
 stop_service() {

--- a/openwrt/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/files/usr/libexec/rpcd/luci.wloc
@@ -55,6 +55,8 @@ list)
 	json_close_object
 	json_add_object restart_gateway
 	json_close_object
+	json_add_object restart_unified
+	json_close_object
 	json_add_object verify_fingerprint
 	json_close_object
 	json_add_object health
@@ -220,6 +222,14 @@ call)
 		# Regenerate the sing-box config and restart the proxy for the
 		# Wi-Fi Calling Gateway (brief interruption of device proxy).
 		/etc/init.d/wificalling-gateway restart >/dev/null 2>&1
+		sleep 2
+		echo '{"ok":true}'
+		exit 0
+		;;
+	restart_unified)
+		# Apply both Gateway and WLOC configuration through the single v2
+		# supervisor. The legacy component init scripts remain disabled.
+		/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1
 		sleep 2
 		echo '{"ok":true}'
 		exit 0

--- a/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
@@ -11,6 +11,11 @@ events=${5:-$output_dir/events.log}
 event_interval=${6:-60}
 max_events=${7:-20}
 log_enabled=${8:-1}
+max_event_bytes=${WFC_MAX_EVENT_LOG_BYTES:-65536}
+case "$max_event_bytes" in
+	''|*[!0-9]*) max_event_bytes=65536 ;;
+esac
+[ "$max_event_bytes" -gt 0 ] 2>/dev/null || max_event_bytes=65536
 tmp="${output}.tmp.$$"
 state_tmp="${state}.tmp.$$"
 event_tmp="${events}.tmp.$$"
@@ -111,6 +116,17 @@ FNR==NR { count[$2 FS $3]++; next }
 { key=$2 FS $3; seen[key]++; if (seen[key] > count[key]-limit) print }
 ' "$events" "$events" > "$trim_tmp"
 mv "$trim_tmp" "$events"
+
+# A record-count limit alone is not sufficient: labels and future fields can
+# make a small number of records consume the whole flash partition. Keep the
+# newest complete lines under a hard byte cap; never leave a partial first
+# record for the LuCI parser.
+event_bytes=$(wc -c < "$events" | tr -d ' ')
+if [ "$event_bytes" -gt "$max_event_bytes" ]; then
+	tail -c "$max_event_bytes" "$events" \
+		| awk -F '|' 'NR == 1 && NF != 8 { next } { print }' > "$trim_tmp"
+	mv "$trim_tmp" "$events"
+fi
 chmod 644 "$tmp" "$events"
 chmod 600 "$state_tmp"
 mv "$state_tmp" "$state"

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -19,10 +19,14 @@ GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+START_TIMEOUT=${WLOC_SUPERVISOR_START_TIMEOUT:-30}
 case "$CHECK_INTERVAL" in ''|*[!0-9]*) CHECK_INTERVAL=10;; esac
 [ "$CHECK_INTERVAL" -ge 1 ] || CHECK_INTERVAL=1
 [ "$CHECK_INTERVAL" -le 60 ] || CHECK_INTERVAL=60
 case "$MAX_RUNTIME_SECONDS" in ''|*[!0-9]*) MAX_RUNTIME_SECONDS=0;; esac
+case "$START_TIMEOUT" in ''|*[!0-9]*) START_TIMEOUT=30;; esac
+[ "$START_TIMEOUT" -ge 1 ] || START_TIMEOUT=1
+[ "$START_TIMEOUT" -le 120 ] || START_TIMEOUT=120
 gateway_running=0
 wloc_running=0
 redirect_present=0
@@ -67,19 +71,20 @@ withdraw_redirect() {
 
 cleanup_runtime() {
 	reason=$1
-	keep_gateway=${2:-0}
+	keep_gateway=${2:-1}
+	state_phase=${3:-degraded_passthrough}
 	withdraw_redirect
 	stop_child "$WLOC_INIT"
 	wloc_running=0
 	if [ "$keep_gateway" -eq 1 ]; then
-		# WLOC failure is fail-open for Wi-Fi Calling: leave the stable
-		# Gateway data plane alive in passthrough and report degradation.
+		# The stable Gateway is deliberately never stopped here. WLOC failure
+		# is fail-open, and explicit stop/reload only withdraws WLOC-owned
+		# rules; the stable Gateway table remains under its original owner.
 		gateway_running=1
-		write_state degraded_passthrough "$reason"
+		write_state "$state_phase" "$reason"
 	else
-		stop_child "$GATEWAY_INIT"
 		gateway_running=0
-		write_state stopped "$reason"
+		write_state "$state_phase" "$reason"
 	fi
 	rm -f "$PIDFILE"
 }
@@ -91,7 +96,7 @@ stop_supervisor() {
 		# The procd-owned process receives SIGTERM as well; cleanup is also
 		# idempotent here for direct upgrade/rollback invocations.
 	fi
-	cleanup_runtime requested_stop
+	cleanup_runtime requested_stop 1 stopped
 	rmdir "$LOCKDIR" 2>/dev/null || true
 }
 
@@ -108,6 +113,19 @@ health_ok() {
 	[ -S "${WLOC_SOCKET:-/var/run/wloc-service/control.sock}" ] || return 1
 }
 
+gateway_healthy() {
+	command -v pgrep >/dev/null 2>&1 || return 1
+	pgrep -f '/usr/bin/sing-box run' >/dev/null 2>&1
+}
+
+wait_for_health() {
+	deadline=$(( $(now) + START_TIMEOUT ))
+	while ! health_ok; do
+		[ "$(now)" -lt "$deadline" ] || return 1
+		sleep 1
+	done
+}
+
 start_supervisor() {
 	mkdir -p "$RUNDIR"
 	chmod 0700 "$RUNDIR"
@@ -118,7 +136,7 @@ start_supervisor() {
 	if ! mkdir "$LOCKDIR" 2>/dev/null; then
 		return 0
 	fi
-	trap 'cleanup_runtime signal; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
+	trap 'cleanup_runtime signal 1 stopped; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
 	echo "$$" > "$PIDFILE"
 	chmod 0600 "$PIDFILE"
 	gateway_running=0
@@ -132,15 +150,17 @@ start_supervisor() {
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
 
-	if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime gateway_start_failed
-		exit 1
+	if ! gateway_healthy; then
+		if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
+			cleanup_runtime gateway_start_failed 0 stopped
+			exit 1
+		fi
 	fi
 	gateway_running=1
 	write_state starting gateway_ready
 
-	if ! WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime wloc_start_failed keep_gateway
+	if ! WLOC_SUPERVISED=1 WLOC_DEFER_REDIRECT=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed 1
 		exit 1
 	fi
 	wloc_running=1
@@ -148,12 +168,12 @@ start_supervisor() {
 
 	# Redirect installation is the final step. It only edits the dedicated
 	# wloc_service table and policy route; it never touches Gateway tables.
-	if ! health_ok; then
-		cleanup_runtime child_health_failed keep_gateway
+	if ! wait_for_health; then
+		cleanup_runtime child_health_failed 1
 		exit 1
 	fi
 	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
-		cleanup_runtime redirect_install_failed keep_gateway
+		cleanup_runtime redirect_install_failed 1
 		exit 1
 	fi
 	redirect_present=1
@@ -162,12 +182,12 @@ start_supervisor() {
 	started=$(now)
 	while :; do
 		if ! health_ok; then
-			cleanup_runtime health_failed keep_gateway
+			cleanup_runtime health_failed 1
 			exit 1
 		fi
 		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \
 			&& [ "$(($(now) - started))" -ge "$MAX_RUNTIME_SECONDS" ]; then
-			cleanup_runtime test_runtime_limit
+			cleanup_runtime test_runtime_limit 1 stopped
 			exit 0
 		fi
 		sleep "$CHECK_INTERVAL"

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+# Unified Gateway/WLOC lifecycle supervisor.
+#
+# This is intentionally a small, POSIX/busybox-compatible coordinator. The
+# stable Gateway 1.7 service remains available as a rollback facade, but only
+# this supervisor is enabled after migration. It owns ordering and cleanup;
+# the Gateway nftables table and UDP 500/4500 handling remain owned by the
+# stable Gateway init/helper and are never edited here.
+
+set -eu
+
+APP=wificalling-location-gateway
+RUNDIR=${WLOC_UNIFIED_RUNDIR:-/var/run/$APP}
+STATE=$RUNDIR/supervisor.json
+PIDFILE=$RUNDIR/supervisor.pid
+LOCKDIR=$RUNDIR/.lock
+WLOC_INIT=${WLOC_INIT:-/etc/init.d/wloc-service}
+GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
+REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
+CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
+MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+gateway_running=0
+wloc_running=0
+redirect_present=0
+
+now() { date +%s; }
+
+json_escape() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/[[:cntrl:]]/ /g'
+}
+
+write_state() {
+	phase=$1; reason=$2
+	updated=$(now)
+	printf '{"version":1,"phase":"%s","reason":"%s","gateway":%s,"wloc":%s,"redirect":%s,"updated_at":%s}\n' \
+		"$(json_escape "$phase")" "$(json_escape "$reason")" \
+		"$gateway_running" "$wloc_running" "$redirect_present" "$updated" > "$STATE"
+	chmod 0600 "$STATE"
+}
+
+pid_alive() {
+	pid=$1
+	[ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+read_pid() {
+	[ -s "$PIDFILE" ] || return 1
+	pid=$(sed -n '1p' "$PIDFILE")
+	case "$pid" in ''|*[!0-9]*) return 1;; esac
+	pid_alive "$pid"
+}
+
+stop_child() {
+	init=$1
+	[ -x "$init" ] || return 0
+	"$init" stop >/dev/null 2>&1 || true
+}
+
+withdraw_redirect() {
+	redirect_present=0
+	[ -x "$REDIRECT_HELPER" ] && "$REDIRECT_HELPER" stop >/dev/null 2>&1 || true
+}
+
+cleanup_runtime() {
+	withdraw_redirect
+	stop_child "$WLOC_INIT"
+	stop_child "$GATEWAY_INIT"
+	gateway_running=0
+	wloc_running=0
+	write_state stopped "$1"
+	rm -f "$PIDFILE"
+}
+
+stop_supervisor() {
+	if read_pid; then
+		pid=$(sed -n '1p' "$PIDFILE")
+		[ "$$" = "$pid" ] || kill -TERM "$pid" 2>/dev/null || true
+		# The procd-owned process receives SIGTERM as well; cleanup is also
+		# idempotent here for direct upgrade/rollback invocations.
+	fi
+	cleanup_runtime requested_stop
+	rm -rf "$LOCKDIR"
+}
+
+health_ok() {
+	# The supervisor only considers a child healthy when its init action
+	# succeeded, the process is observable, and WLOC's root-only socket exists.
+	# No network probe or unbounded command output is used in this loop.
+	if command -v pgrep >/dev/null 2>&1; then
+		pgrep -f '/usr/bin/sing-box run' >/dev/null 2>&1 || return 1
+		pgrep -f '/usr/sbin/wloc-service' >/dev/null 2>&1 || return 1
+	else
+		return 1
+	fi
+	[ -S "${WLOC_SOCKET:-/var/run/wloc-service/control.sock}" ] || return 1
+}
+
+start_supervisor() {
+	mkdir -p "$RUNDIR"
+	chmod 0700 "$RUNDIR"
+	if read_pid; then
+		return 0
+	fi
+	rm -rf "$LOCKDIR"
+	if ! mkdir "$LOCKDIR" 2>/dev/null; then
+		return 0
+	fi
+	trap 'cleanup_runtime signal; rm -rf "$LOCKDIR"; exit 0' TERM INT
+	echo "$$" > "$PIDFILE"
+	chmod 0600 "$PIDFILE"
+	gateway_running=0
+	wloc_running=0
+	redirect_present=0
+	write_state starting passthrough
+
+	# Legacy children are used only as a one-release adapter. Disable their
+	# independent boot ownership before invoking them under this boundary.
+	[ -x "$WLOC_INIT" ] && "$WLOC_INIT" disable >/dev/null 2>&1 || true
+	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
+	stop_child "$WLOC_INIT"
+	stop_child "$GATEWAY_INIT"
+
+	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime gateway_start_failed
+		exit 1
+	fi
+	gateway_running=1
+	write_state starting gateway_ready
+
+	if ! "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed
+		exit 1
+	fi
+	wloc_running=1
+	write_state passthrough children_started
+
+	# Redirect installation is the final step. It only edits the dedicated
+	# wloc_service table and policy route; it never touches Gateway tables.
+	if ! health_ok; then
+		cleanup_runtime child_health_failed
+		exit 1
+	fi
+	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
+		cleanup_runtime redirect_install_failed
+		exit 1
+	fi
+	redirect_present=1
+	write_state intercepting ready
+
+	started=$(now)
+	while :; do
+		if ! health_ok; then
+			cleanup_runtime health_failed
+			exit 1
+		fi
+		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \
+			&& [ "$(($(now) - started))" -ge "$MAX_RUNTIME_SECONDS" ]; then
+			cleanup_runtime test_runtime_limit
+			exit 0
+		fi
+		sleep "$CHECK_INTERVAL"
+	done
+}
+
+main() {
+	command=${1:-start}
+	case "$command" in
+		start) start_supervisor ;;
+		stop) stop_supervisor ;;
+		reload) stop_supervisor; start_supervisor ;;
+		status) [ -s "$STATE" ] && cat "$STATE" || printf '%s\n' '{"version":1,"phase":"stopped","reason":"not_running"}' ;;
+		*) echo "usage: $0 {start|stop|reload|status}" >&2; exit 2 ;;
+	esac
+}
+
+main "$@"

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -19,6 +19,10 @@ GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
+case "$CHECK_INTERVAL" in ''|*[!0-9]*) CHECK_INTERVAL=10;; esac
+[ "$CHECK_INTERVAL" -ge 1 ] || CHECK_INTERVAL=1
+[ "$CHECK_INTERVAL" -le 60 ] || CHECK_INTERVAL=60
+case "$MAX_RUNTIME_SECONDS" in ''|*[!0-9]*) MAX_RUNTIME_SECONDS=0;; esac
 gateway_running=0
 wloc_running=0
 redirect_present=0
@@ -62,12 +66,21 @@ withdraw_redirect() {
 }
 
 cleanup_runtime() {
+	reason=$1
+	keep_gateway=${2:-0}
 	withdraw_redirect
 	stop_child "$WLOC_INIT"
-	stop_child "$GATEWAY_INIT"
-	gateway_running=0
 	wloc_running=0
-	write_state stopped "$1"
+	if [ "$keep_gateway" -eq 1 ]; then
+		# WLOC failure is fail-open for Wi-Fi Calling: leave the stable
+		# Gateway data plane alive in passthrough and report degradation.
+		gateway_running=1
+		write_state degraded_passthrough "$reason"
+	else
+		stop_child "$GATEWAY_INIT"
+		gateway_running=0
+		write_state stopped "$reason"
+	fi
 	rm -f "$PIDFILE"
 }
 
@@ -79,7 +92,7 @@ stop_supervisor() {
 		# idempotent here for direct upgrade/rollback invocations.
 	fi
 	cleanup_runtime requested_stop
-	rm -rf "$LOCKDIR"
+	rmdir "$LOCKDIR" 2>/dev/null || true
 }
 
 health_ok() {
@@ -101,11 +114,11 @@ start_supervisor() {
 	if read_pid; then
 		return 0
 	fi
-	rm -rf "$LOCKDIR"
+	rmdir "$LOCKDIR" 2>/dev/null || true
 	if ! mkdir "$LOCKDIR" 2>/dev/null; then
 		return 0
 	fi
-	trap 'cleanup_runtime signal; rm -rf "$LOCKDIR"; exit 0' TERM INT
+	trap 'cleanup_runtime signal; rmdir "$LOCKDIR" 2>/dev/null || true; exit 0' TERM INT
 	echo "$$" > "$PIDFILE"
 	chmod 0600 "$PIDFILE"
 	gateway_running=0
@@ -118,7 +131,6 @@ start_supervisor() {
 	[ -x "$WLOC_INIT" ] && "$WLOC_INIT" disable >/dev/null 2>&1 || true
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
-	stop_child "$GATEWAY_INIT"
 
 	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
 		cleanup_runtime gateway_start_failed
@@ -127,8 +139,8 @@ start_supervisor() {
 	gateway_running=1
 	write_state starting gateway_ready
 
-	if ! "$WLOC_INIT" start >/dev/null 2>&1; then
-		cleanup_runtime wloc_start_failed
+	if ! WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start >/dev/null 2>&1; then
+		cleanup_runtime wloc_start_failed keep_gateway
 		exit 1
 	fi
 	wloc_running=1
@@ -137,11 +149,11 @@ start_supervisor() {
 	# Redirect installation is the final step. It only edits the dedicated
 	# wloc_service table and policy route; it never touches Gateway tables.
 	if ! health_ok; then
-		cleanup_runtime child_health_failed
+		cleanup_runtime child_health_failed keep_gateway
 		exit 1
 	fi
 	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
-		cleanup_runtime redirect_install_failed
+		cleanup_runtime redirect_install_failed keep_gateway
 		exit 1
 	fi
 	redirect_present=1
@@ -150,7 +162,7 @@ start_supervisor() {
 	started=$(now)
 	while :; do
 		if ! health_ok; then
-			cleanup_runtime health_failed
+			cleanup_runtime health_failed keep_gateway
 			exit 1
 		fi
 		if [ "$MAX_RUNTIME_SECONDS" -gt 0 ] 2>/dev/null \

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -132,7 +132,7 @@ start_supervisor() {
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
 
-	if ! "$GATEWAY_INIT" start >/dev/null 2>&1; then
+	if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then
 		cleanup_runtime gateway_start_failed
 		exit 1
 	fi

--- a/openwrt/files/usr/sbin/wloc-health.sh
+++ b/openwrt/files/usr/sbin/wloc-health.sh
@@ -111,6 +111,18 @@ if [ -f "$node_status" ]; then
 	[ "$nodes_unknown" -lt 0 ] && nodes_unknown=0
 fi
 
+# --- v2 profile projection ------------------------------------------------
+# Keep profile state separate from the aggregate process checks. The helper
+# returns only bounded, redacted fields; if it is absent the health document
+# remains valid for v1 packages.
+profiles='[]'
+if [ -x /usr/sbin/wloc-profile-status.sh ]; then
+	profile_json=$(/usr/sbin/wloc-profile-status.sh 2>/dev/null || true)
+	profiles=$(printf '%s\n' "$profile_json" \
+		| sed -n 's/^{"profiles":\(.*\)}$/\1/p')
+	[ -n "$profiles" ] || profiles='[]'
+fi
+
 printf '{"generated_at":%s,' "$now"
 printf '"services":{"wloc":{"running":%s,"socket":%s,"status_fresh":%s,"phase":"%s","exit":"%s","geo":"%s","last_error":%s},' \
 	"$wloc_running" "$wloc_socket" "$wloc_status_fresh" "$wloc_phase" "$wloc_exit" "$wloc_geo" "$wloc_error"
@@ -118,5 +130,5 @@ printf '"gateway":{"running":%s,"monitor":%s,"singbox":%s,"config_present":%s,"c
 	"$monitor_running" "$monitor_running" "$sb_running" "$sb_config" "$sb_config_valid" "$sb_config_age" "$sb_config_stale" "$nft_rules" "$devices"
 printf '"patches":{"psk":%s,"handshake":%s,"compact":%s,"device_guard":%s}}},' \
 	"$patch_psk" "$patch_health" "$patch_compact" "$patch_device_guard"
-printf '"nodes":{"total":%s,"ok":%s,"down":%s,"unknown":%s}}\n' \
-	"$nodes_total" "$nodes_ok" "$nodes_down" "$nodes_unknown"
+printf '"nodes":{"total":%s,"ok":%s,"down":%s,"unknown":%s},"profiles":%s}\n' \
+	"$nodes_total" "$nodes_ok" "$nodes_down" "$nodes_unknown" "$profiles"

--- a/openwrt/files/usr/sbin/wloc-profile-redirect.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-redirect.sh
@@ -12,7 +12,6 @@ set -eu
 PROFILE_TABLE_PREFIX=wloc_profile_
 PROXY_PORT=${WLOC_PROFILE_PROXY_PORT:-${WLOC_PROXY_PORT:-8443}}
 FWMARK=1
-NAMES='gs-loc.apple.com gs-loc-cn.apple.com'
 
 fail() {
 	printf 'wloc-profile-redirect: %s\n' "$*" >&2
@@ -47,7 +46,8 @@ valid_private_ipv4() {
 		[ "$octet" -le 255 ] 2>/dev/null || return 1
 	done
 	case "$1" in
-		10|192) return 0 ;;
+		10) return 0 ;;
+		192) [ "$2" -eq 168 ] 2>/dev/null ;;
 		172) [ "$2" -ge 16 ] 2>/dev/null && [ "$2" -le 31 ] 2>/dev/null ;;
 		*) return 1 ;;
 	esac

--- a/openwrt/files/usr/sbin/wloc-profile-redirect.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-redirect.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Manage one device profile's WLOC TPROXY table.
+#
+# The table is intentionally profile-scoped. A profile stop deletes only its
+# own table; the shared policy route and the stable Gateway nftables namespace
+# are owned elsewhere. The only approved destinations are the two exact Apple
+# WLOC hostnames, represented by the per-table apple_hosts set populated by
+# wloc-refresh-set.sh.
+
+set -eu
+
+PROFILE_TABLE_PREFIX=wloc_profile_
+PROXY_PORT=${WLOC_PROFILE_PROXY_PORT:-${WLOC_PROXY_PORT:-8443}}
+FWMARK=1
+NAMES='gs-loc.apple.com gs-loc-cn.apple.com'
+
+fail() {
+	printf 'wloc-profile-redirect: %s\n' "$*" >&2
+	exit 2
+}
+
+valid_profile_id() {
+	case "$1" in
+		''|*[!a-z0-9_-]*) return 1 ;;
+	esac
+	[ "${#1}" -le 32 ]
+}
+
+valid_port() {
+	case "$1" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+	[ "$1" -ge 1 ] 2>/dev/null && [ "$1" -le 65535 ] 2>/dev/null
+}
+
+valid_private_ipv4() {
+	address=$1
+	old_ifs=$IFS
+	IFS=.
+	set -- $address
+	IFS=$old_ifs
+	[ "$#" -eq 4 ] || return 1
+	for octet in "$@"; do
+		case "$octet" in
+			''|*[!0-9]*) return 1 ;;
+		esac
+		[ "$octet" -le 255 ] 2>/dev/null || return 1
+	done
+	case "$1" in
+		10|192) return 0 ;;
+		172) [ "$2" -ge 16 ] 2>/dev/null && [ "$2" -le 31 ] 2>/dev/null ;;
+		*) return 1 ;;
+	esac
+}
+
+action=${1:-}
+profile_id=${2:-}
+nft_binary=${WLOC_NFT_BINARY:-nft}
+
+case "$action" in
+	start)
+		[ "$#" -eq 3 ] || fail 'usage: start PROFILE_ID PRIVATE_IPV4'
+		valid_profile_id "$profile_id" || fail 'invalid profile id'
+		valid_private_ipv4 "$3" || fail 'assigned device must be a private IPv4 address'
+		valid_port "$PROXY_PORT" || fail 'invalid proxy port'
+		table=${PROFILE_TABLE_PREFIX}${profile_id}
+		device_ip=$3
+		"$nft_binary" add table inet "$table" 2>/dev/null || true
+		"$nft_binary" add set inet "$table" apple_hosts '{ type ipv4_addr; }' 2>/dev/null || true
+		"$nft_binary" flush chain inet "$table" prerouting 2>/dev/null || true
+		"$nft_binary" delete chain inet "$table" prerouting 2>/dev/null || true
+		"$nft_binary" "add chain inet $table prerouting { type filter hook prerouting priority mangle; }"
+		"$nft_binary" "add rule inet $table prerouting ip saddr $device_ip tcp dport 443 ip daddr @apple_hosts meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
+		printf 'wloc-profile-redirect: %s -> :%s\n' "$profile_id" "$PROXY_PORT"
+		;;
+	stop)
+		[ "$#" -eq 2 ] || fail 'usage: stop PROFILE_ID'
+		valid_profile_id "$profile_id" || fail 'invalid profile id'
+		"$nft_binary" delete table inet "${PROFILE_TABLE_PREFIX}${profile_id}" 2>/dev/null || true
+		;;
+	status)
+		[ "$#" -eq 2 ] || fail 'usage: status PROFILE_ID'
+		valid_profile_id "$profile_id" || fail 'invalid profile id'
+		"$nft_binary" list table inet "${PROFILE_TABLE_PREFIX}${profile_id}" >/dev/null 2>&1
+		;;
+	*)
+		fail 'action must be start, stop, or status'
+		;;
+esac

--- a/openwrt/files/usr/sbin/wloc-profile-status.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-status.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Emit a bounded, coordinate/device-redacted status list for v2 profiles.
+#
+# This is intentionally a read-only health projection. It does not decide
+# lifecycle state or modify UCI/nftables; the runtime manager remains the
+# authority for enable/disable ordering.
+
+set -eu
+
+MAX_PROFILES=8
+NFT_BINARY=${WLOC_NFT_BINARY:-nft}
+
+json_escape() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/[[:space:]]\+/ /g'
+}
+
+valid_profile_id() {
+	case "$1" in
+		''|*[!a-z0-9_-]*) return 1 ;;
+	esac
+	[ "${#1}" -le 32 ]
+}
+
+uci_get() {
+	uci -q get "$1" 2>/dev/null || true
+}
+
+profile_phase() {
+	profile_id=$1
+	enabled=$2
+	assigned_device=$3
+	if [ "$enabled" != 1 ]; then
+		printf '%s' 'disabled|disabled'
+	elif [ -z "$assigned_device" ]; then
+		printf '%s' 'degraded_passthrough|missing_device_binding'
+	elif "$NFT_BINARY" list table inet "wloc_profile_${profile_id}" >/dev/null 2>&1; then
+		printf '%s' 'intercepting|intercepting'
+	else
+		printf '%s' 'passthrough|redirect_not_installed'
+	fi
+}
+
+sections=$(uci -q show wloc-service 2>/dev/null \
+	| sed -n 's/^wloc-service\.\([a-z0-9_-]*\)=device$/\1/p' \
+	| head -n "$MAX_PROFILES" || true)
+if [ -z "$sections" ]; then
+	# Keep the v1 singleton visible during migration without returning its
+	# address. It is not treated as a v2 device section by the parser.
+	if [ -n "$(uci_get wloc-service.main.enabled)" ]; then
+		sections=default
+	fi
+fi
+
+printf '{"profiles":['
+first=1
+for profile_id in $sections; do
+	valid_profile_id "$profile_id" || continue
+	if [ "$profile_id" = default ]; then
+		prefix=wloc-service.main
+		label='Default device'
+	else
+		prefix="wloc-service.$profile_id"
+		label=$(uci_get "$prefix.label" | cut -c1-48)
+		[ -n "$label" ] || label=$profile_id
+	fi
+	enabled=$(uci_get "$prefix.enabled")
+	[ "$enabled" = 1 ] || enabled=0
+	assigned_device=$(uci_get "$prefix.assigned_device")
+	phase_reason=$(profile_phase "$profile_id" "$enabled" "$assigned_device")
+	phase=${phase_reason%%|*}
+	reason=${phase_reason#*|}
+	[ "$first" -eq 1 ] || printf ','
+	first=0
+	printf '{"id":"%s","label":"%s","enabled":%s,"assigned_device_configured":%s,"phase":"%s","reason_code":"%s"}' \
+		"$(json_escape "$profile_id")" "$(json_escape "$label")" "$([ "$enabled" = 1 ] && printf true || printf false)" \
+		"$([ -n "$assigned_device" ] && printf true || printf false)" "$phase" "$reason"
+done
+printf ']}\n'

--- a/openwrt/files/usr/sbin/wloc-profile-status.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-status.sh
@@ -29,11 +29,13 @@ profile_phase() {
 	profile_id=$1
 	enabled=$2
 	assigned_device=$3
+	table="wloc_profile_${profile_id}"
+	[ "$profile_id" = default ] && table=wloc_service
 	if [ "$enabled" != 1 ]; then
 		printf '%s' 'disabled|disabled'
-	elif [ -z "$assigned_device" ]; then
+	elif [ -z "$assigned_device" ] && [ "$profile_id" != default ]; then
 		printf '%s' 'degraded_passthrough|missing_device_binding'
-	elif "$NFT_BINARY" list table inet "wloc_profile_${profile_id}" >/dev/null 2>&1; then
+	elif "$NFT_BINARY" list table inet "$table" >/dev/null 2>&1; then
 		printf '%s' 'intercepting|intercepting'
 	else
 		printf '%s' 'passthrough|redirect_not_installed'

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -16,6 +16,20 @@ CHAIN=prerouting
 PROXY_PORT="${WLOC_PROXY_PORT:-8443}"
 FWMARK=1
 ROUTE_TABLE=100
+action=${1:-start}
+
+if [ "$action" = stop ]; then
+	# Only remove the WLOC-owned table, policy route, and DNS marker. The
+	# stable Gateway 1.7 nftables table (and UDP 500/4500 handling) is never
+	# touched by this cleanup path.
+	nft delete table inet "$TABLE" 2>/dev/null || true
+	ip rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+	ip route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
+	for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
+		sed -i '/# wloc-service DNS hijack (do not edit)/,/^# wloc-service end/d' "$hosts_file" 2>/dev/null || true
+	done
+	exit 0
+fi
 
 # Collect the LAN IPs of every device in the gateway device policy.
 ips=$(uci -q show wificalling-gateway \
@@ -53,7 +67,7 @@ HOSTS_MARKER='# wloc-service DNS hijack (do not edit)'
 # dnsmasq reads addn-hosts from the /tmp/hosts directory on this build;
 # /etc/hosts is kept as a fallback.
 mkdir -p /tmp/hosts
-for hosts_file in /etc/hosts /tmp/hosts/wloc-hosts; do
+for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
     sed -i "/$HOSTS_MARKER/,/^# wloc-service end/d" "$hosts_file" 2>/dev/null || true
     cat >> "$hosts_file" <<EOF
 $HOSTS_MARKER

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -71,7 +71,7 @@ for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
     sed -i "/$HOSTS_MARKER/,/^# wloc-service end/d" "$hosts_file" 2>/dev/null || true
     cat >> "$hosts_file" <<EOF
 $HOSTS_MARKER
-$ROUTER_IP gs-loc.apple.com gs-loc-cn.apple.com gs-loc-corpa.apple.com gs-loc.apple.com.cn bluedot.is.autonavi.com bluedot.is.autonavi.com.gds.alibabadns.com
+$ROUTER_IP gs-loc.apple.com gs-loc-cn.apple.com
 # wloc-service end
 EOF
 done

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -52,9 +52,11 @@ ips=$(collect | grep -v "^$ROUTER_IP$" | sort -u | tr '
     exit 1
 }
 
-"$NFT_BINARY" flush set inet "$TABLE" "$SET" 2>/dev/null || \
-    "$NFT_BINARY" add set inet "$TABLE" "$SET" '{ type ipv4_addr; }'
-"$NFT_BINARY" add element inet "$TABLE" "$SET" "{ $ips }"
+if "$NFT_BINARY" list table inet "$TABLE" >/dev/null 2>&1; then
+	"$NFT_BINARY" flush set inet "$TABLE" "$SET" 2>/dev/null || \
+		"$NFT_BINARY" add set inet "$TABLE" "$SET" '{ type ipv4_addr; }'
+	"$NFT_BINARY" add element inet "$TABLE" "$SET" "{ $ips }"
+fi
 
 # V2 profiles each have an isolated nft table and set. Refresh the same
 # approved Apple answers into every live profile table without touching the

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -13,7 +13,7 @@ set -eu
 TABLE=wloc_service
 SET=apple_hosts
 
-HOSTS="gs-loc.apple.com gs-loc-cn.apple.com gs-loc-corpa.apple.com gs-loc.apple.com.cn bluedot.is.autonavi.com bluedot.is.autonavi.com.gds.alibabadns.com"
+HOSTS="gs-loc.apple.com gs-loc-cn.apple.com"
 
 # The router's own LAN IPv4 (the DNS hijack maps the WLOC names to it);
 # answers equal to it must not pollute the set.

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -12,6 +12,7 @@ set -eu
 
 TABLE=wloc_service
 SET=apple_hosts
+NFT_BINARY=${WLOC_NFT_BINARY:-nft}
 
 HOSTS="gs-loc.apple.com gs-loc-cn.apple.com"
 
@@ -51,6 +52,33 @@ ips=$(collect | grep -v "^$ROUTER_IP$" | sort -u | tr '
     exit 1
 }
 
-nft flush set inet "$TABLE" "$SET" 2>/dev/null || nft add set inet "$TABLE" "$SET" '{ type ipv4_addr; }'
-nft add element inet "$TABLE" "$SET" "{ $ips }"
+"$NFT_BINARY" flush set inet "$TABLE" "$SET" 2>/dev/null || \
+    "$NFT_BINARY" add set inet "$TABLE" "$SET" '{ type ipv4_addr; }'
+"$NFT_BINARY" add element inet "$TABLE" "$SET" "{ $ips }"
+
+# V2 profiles each have an isolated nft table and set. Refresh the same
+# approved Apple answers into every live profile table without touching the
+# stable Gateway namespace. Table names are validated before being reused as
+# nft arguments even though they originate from the local kernel listing.
+profile_tables=$(
+    "$NFT_BINARY" list tables inet 2>/dev/null \
+        | sed -n 's/^table inet \(wloc_profile_[a-z0-9_-]*\)$/\1/p' \
+        || true
+)
+while IFS= read -r profile_table; do
+    [ -n "$profile_table" ] || continue
+    case "$profile_table" in
+        wloc_profile_*|*[!a-z0-9_-]*)
+            case "$profile_table" in
+                *[!a-z0-9_-]*) continue ;;
+            esac
+            ;;
+        *) continue ;;
+    esac
+    "$NFT_BINARY" flush set inet "$profile_table" "$SET" 2>/dev/null || \
+        "$NFT_BINARY" add set inet "$profile_table" "$SET" '{ type ipv4_addr; }'
+    "$NFT_BINARY" add element inet "$profile_table" "$SET" "{ $ips }"
+done <<EOF
+$profile_tables
+EOF
 echo "wloc-refresh-set: updated $SET = { $ips }"

--- a/openwrt/files/usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/files/usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json
@@ -35,6 +35,14 @@
       "path": "wificalling-location-gateway/wloc"
     }
   },
+  "admin/services/wificalling-location-gateway/wloc-devices": {
+    "title": "WLOC Device Profiles",
+    "order": 35,
+    "action": {
+      "type": "view",
+      "path": "wificalling-location-gateway/wloc-devices"
+    }
+  },
   "admin/services/wificalling-location-gateway/wloc-monitor": {
     "title": "WLOC Monitor & Log",
     "order": 40,

--- a/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -9,6 +9,7 @@
           "cert_info",
           "regen_ca",
           "restart_service",
+          "restart_unified",
           "verify_fingerprint",
           "health",
           "restart_gateway",
@@ -44,6 +45,7 @@
           "cert_info",
           "regen_ca",
           "restart_service",
+          "restart_unified",
           "verify_fingerprint",
           "node_test"
         ],

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js
@@ -1,0 +1,187 @@
+'use strict';
+'require view';
+'require wificalling-location-gateway.i18n as wlocI18n';
+'require uci';
+'require rpc';
+'require poll';
+'require ui';
+
+// v2 device profiles: one stable local id binds one LAN device to one node
+// policy and one WLOC mode. Configuration is UCI-backed; runtime state is
+// read from the bounded redacted health projection.
+
+var getHealth = rpc.declare({ object: 'luci.wloc', method: 'health' });
+var restartUnified = rpc.declare({ object: 'luci.wloc', method: 'restart_unified' });
+
+function notify(title, message, kind) {
+	ui.addNotification(null, E('p', [ E('strong', title + ': '), message ]), kind || 'info');
+}
+
+function statusText(status) {
+	if (!status) return wlocI18n.t('Not observed');
+	return status.phase + ' (' + status.reason_code + ')';
+}
+
+return view.extend({
+	load: function() {
+		return Promise.all([
+			uci.load('wloc-service'),
+			L.resolveDefault(getHealth(), {})
+		]);
+	},
+
+	render: function(data) {
+		wlocI18n.localizeTabs();
+		var body = E('tbody', {});
+		var health = data[1] || {};
+		var profileStatus = {};
+
+		function indexHealth(h) {
+			profileStatus = {};
+			(h.profiles || []).forEach(function(p) { profileStatus[p.id] = p; });
+		}
+		indexHealth(health);
+
+		function input(value, placeholder) {
+			return E('input', {
+				'class': 'cbi-input-text', 'value': value || '',
+				'placeholder': placeholder || ''
+			});
+		}
+
+		function saveProfile(section, fields) {
+			var id = section['.name'];
+			if (!/^[a-z0-9_-]{1,32}$/.test(id)) {
+				notify(wlocI18n.t('Save failed'), wlocI18n.t('Profile id must use lowercase letters, numbers, - or _.') ,'error');
+				return;
+			}
+			var label = fields.label.value.trim();
+			var address = fields.address.value.trim();
+			var node = fields.node.value.trim();
+			if (!label || !address || !node) {
+				notify(wlocI18n.t('Save failed'), wlocI18n.t('Label, device address, and node are required.'), 'error');
+				return;
+			}
+			uci.set('wloc-service', id, 'label', label);
+			uci.set('wloc-service', id, 'assigned_device', address);
+			uci.set('wloc-service', id, 'node_ref', node);
+			uci.set('wloc-service', id, 'node_mode', fields.nodeMode.value);
+			uci.set('wloc-service', id, 'geo_source', fields.geoMode.value);
+			uci.set('wloc-service', id, 'enabled', fields.enabled.checked ? '1' : '0');
+			uci.set('wloc-service', id, 'manual_lat', fields.latitude.value.trim());
+			uci.set('wloc-service', id, 'manual_lon', fields.longitude.value.trim());
+			uci.save('wloc-service').then(function() {
+				return ui.changes.apply(true);
+			}).then(function() {
+				return restartUnified();
+			}).then(function(result) {
+				if (result && result.error) throw new Error(result.error);
+				notify(wlocI18n.t('Saved'), wlocI18n.t('Unified Gateway/WLOC supervisor restarted.'));
+				return getHealth();
+			}).then(function(result) {
+				indexHealth(result || {});
+				renderRows();
+			}).catch(function(error) {
+				notify(wlocI18n.t('Save failed'), String(error), 'error');
+			});
+		}
+
+		function removeProfile(section) {
+			var id = section['.name'];
+			if (!window.confirm(wlocI18n.t('Delete profile %s?').format(id))) return;
+			uci.delete('wloc-service', id);
+			uci.save('wloc-service').then(function() {
+				return ui.changes.apply(true);
+			}).then(function() {
+				return restartUnified();
+			}).then(function() {
+				notify(wlocI18n.t('Deleted'), wlocI18n.t('Profile removed and its redirect was withdrawn.'));
+				return uci.load('wloc-service');
+			}).then(renderRows).catch(function(error) {
+				notify(wlocI18n.t('Delete failed'), String(error), 'error');
+			});
+		}
+
+		function renderRows() {
+			body.innerHTML = '';
+			var profiles = uci.sections('wloc-service', 'device');
+			if (!profiles.length) {
+				body.appendChild(E('tr', {}, [E('td', { 'colspan': 8 }, wlocI18n.t('No v2 device profiles yet.'))]));
+				return;
+			}
+			profiles.forEach(function(section) {
+				var fields = {
+					label: input(section.label, wlocI18n.t('Label')),
+					address: input(section.assigned_device, '192.168.1.100 or MAC'),
+					node: input(section.node_ref || 'default', 'node tag'),
+					latitude: input(section.manual_lat, 'lat'),
+					longitude: input(section.manual_lon, 'lon'),
+					enabled: E('input', { 'type': 'checkbox', 'checked': section.enabled === '1' })
+				};
+				fields.nodeMode = E('select', {});
+				[['fixed', 'Fixed'], ['gateway_default', 'Gateway default']].forEach(function(option) {
+					fields.nodeMode.appendChild(E('option', { value: option[0], selected: (section.node_mode || 'fixed') === option[0] }, option[1]));
+				});
+				fields.geoMode = E('select', {});
+				[['auto', 'Auto follow'], ['manual', 'Manual']].forEach(function(option) {
+					fields.geoMode.appendChild(E('option', { value: option[0], selected: (section.geo_source || 'auto') === option[0] }, option[1]));
+				});
+				var state = profileStatus[section['.name']];
+				var actions = E('span', {}, [
+					E('button', { 'class': 'cbi-button cbi-button-apply', click: function() { saveProfile(section, fields); } }, wlocI18n.t('Save')),
+					' ',
+					E('button', { 'class': 'cbi-button cbi-button-remove', click: function() { removeProfile(section); } }, wlocI18n.t('Delete'))
+				]);
+				body.appendChild(E('tr', { 'class': 'tr' }, [
+					E('td', { 'class': 'td' }, section['.name']),
+					E('td', { 'class': 'td' }, fields.label),
+					E('td', { 'class': 'td' }, fields.address),
+					E('td', { 'class': 'td' }, fields.node),
+					E('td', { 'class': 'td' }, [fields.nodeMode, ' / ', fields.geoMode]),
+					E('td', { 'class': 'td' }, [fields.latitude, ' ', fields.longitude]),
+					E('td', { 'class': 'td' }, [fields.enabled, ' ', statusText(state)]),
+					E('td', { 'class': 'td' }, actions)
+				]));
+			});
+		}
+
+		function addProfile() {
+			var id = window.prompt(wlocI18n.t('New profile id'), 'phone');
+			if (!id || !/^[a-z0-9_-]{1,32}$/.test(id) || uci.get('wloc-service', id)) {
+				notify(wlocI18n.t('Add failed'), wlocI18n.t('Use a unique lowercase profile id.'), 'error');
+				return;
+			}
+			uci.add('wloc-service', 'device', id);
+			uci.set('wloc-service', id, 'label', id);
+			uci.set('wloc-service', id, 'node_ref', 'default');
+			uci.set('wloc-service', id, 'node_mode', 'fixed');
+			uci.set('wloc-service', id, 'geo_source', 'auto');
+			uci.set('wloc-service', id, 'enabled', '0');
+			uci.save('wloc-service').then(function() { return ui.changes.apply(true); }).then(function() {
+				return uci.load('wloc-service');
+			}).then(renderRows).catch(function(error) {
+				notify(wlocI18n.t('Add failed'), String(error), 'error');
+			});
+		}
+
+		renderRows();
+		poll.add(function() {
+			return L.resolveDefault(getHealth(), {}).then(function(result) {
+				indexHealth(result || {});
+				renderRows();
+			});
+		}, 5);
+
+		return E([], [
+			E('h2', {}, wlocI18n.t('Device profiles')),
+			E('p', {}, wlocI18n.t('Each profile owns one device binding, node selection, WLOC auto/manual location mode, enable state, and isolated redirect. Status is redacted in health output; addresses remain local to this settings page.')),
+			E('p', {}, E('button', { 'class': 'cbi-button cbi-button-add', click: addProfile }, wlocI18n.t('Add profile'))),
+			E('div', { 'class': 'cbi-section', style: 'overflow:auto' }, E('table', { 'class': 'table' }, [
+				E('tr', { 'class': 'tr table-titles' }, [
+					'ID', wlocI18n.t('Label'), wlocI18n.t('Device'), wlocI18n.t('Node'), wlocI18n.t('Mode'), wlocI18n.t('Manual location'), wlocI18n.t('Enabled / state'), ''
+				].map(function(title) { return E('th', { 'class': 'th' }, title); })),
+				body
+			]))
+		]);
+	}
+});

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -54,11 +54,13 @@ return view.extend({
 		var wlocBody = E('div', {}, []);
 		var gwBody = E('div', {}, []);
 		var extraBody = E('div', {}, []);
+		var profileBody = E('tbody', {}, []);
 
 		function renderHealth(h) {
 			wlocBody.innerHTML = '';
 			gwBody.innerHTML = '';
 			extraBody.innerHTML = '';
+			profileBody.innerHTML = '';
 
 			var s = h.services || {};
 			var w = s.wloc || {};
@@ -119,6 +121,15 @@ return view.extend({
 			if (h.error) {
 				row(wlocBody, wlocI18n.t('Health check'), E('span', { style: 'color:#dc2626' }, h.error));
 			}
+			(h.profiles || []).forEach(function(profile) {
+				var good = profile.phase === 'intercepting' || profile.phase === 'disabled';
+				profileBody.appendChild(E('tr', { 'class': 'tr' }, [
+					E('td', { 'class': 'td' }, profile.id),
+					E('td', { 'class': 'td' }, profile.label || '-'),
+					E('td', { 'class': 'td' }, statusDot(good, profile.phase || '-')),
+					E('td', { 'class': 'td' }, profile.reason_code || '-')
+				]));
+			});
 		}
 
 		renderHealth(health);
@@ -190,6 +201,13 @@ return view.extend({
 			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
 				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Patches and nodes')),
 				extraBody
+			]),
+			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
+				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Device profiles')),
+				E('table', { 'class': 'table' }, [
+					E('tr', { 'class': 'tr table-titles' }, [wlocI18n.t('ID'), wlocI18n.t('Label'), wlocI18n.t('State'), wlocI18n.t('Reason')].map(function(title) { return E('th', { 'class': 'th' }, title); })),
+					profileBody
+				])
 			]),
 			restartButtons
 		]);

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
@@ -55,6 +55,8 @@ list)
 	json_close_object
 	json_add_object restart_gateway
 	json_close_object
+	json_add_object restart_unified
+	json_close_object
 	json_add_object clear_log
 	json_close_object
 	json_add_object verify_fingerprint
@@ -222,6 +224,12 @@ call)
 		# Regenerate the sing-box config and restart the proxy for the
 		# Wi-Fi Calling Gateway (brief interruption of device proxy).
 		/etc/init.d/wificalling-gateway restart >/dev/null 2>&1
+		sleep 2
+		echo '{"ok":true}'
+		exit 0
+		;;
+	restart_unified)
+		/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1
 		sleep 2
 		echo '{"ok":true}'
 		exit 0

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json
@@ -35,6 +35,14 @@
       "path": "wificalling-location-gateway/wloc"
     }
   },
+  "admin/services/wificalling-location-gateway/wloc-devices": {
+    "title": "WLOC Device Profiles",
+    "order": 35,
+    "action": {
+      "type": "view",
+      "path": "wificalling-location-gateway/wloc-devices"
+    }
+  },
   "admin/services/wificalling-location-gateway/wloc-monitor": {
     "title": "WLOC Monitor & Log",
     "order": 40,

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -12,6 +12,7 @@
           "verify_fingerprint",
           "health",
           "restart_gateway",
+          "restart_unified",
           "node_test",
           "clear_log"
         ],

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js
@@ -1,0 +1,87 @@
+'use strict';
+'require view';
+'require wificalling-location-gateway.i18n as wlocI18n';
+'require uci';
+'require rpc';
+'require poll';
+'require ui';
+
+var health = rpc.declare({ object: 'luci.wloc', method: 'health' });
+var restart = rpc.declare({ object: 'luci.wloc', method: 'restart_unified' });
+
+function note(title, message, kind) {
+	ui.addNotification(null, E('p', [E('strong', title + ': '), message]), kind || 'info');
+}
+
+return view.extend({
+	load: function() {
+		return Promise.all([uci.load('wloc-service'), L.resolveDefault(health(), {})]);
+	},
+	render: function(data) {
+		var body = E('tbody', {}), states = {};
+		function index(value) {
+			states = {};
+			(value.profiles || []).forEach(function(item) { states[item.id] = item; });
+		}
+		index(data[1] || {});
+		function field(value, placeholder) {
+			return E('input', {'class': 'cbi-input-text', value: value || '', placeholder: placeholder || ''});
+		}
+		function apply(section, f) {
+			var id = section['.name'];
+			if (!/^[a-z0-9_-]{1,32}$/.test(id) || !f.label.value.trim() || !f.device.value.trim() || !f.node.value.trim()) {
+				note(wlocI18n.t('Save failed'), wlocI18n.t('Use a valid id, label, device address, and node.'), 'error');
+				return;
+			}
+			uci.set('wloc-service', id, 'label', f.label.value.trim());
+			uci.set('wloc-service', id, 'assigned_device', f.device.value.trim());
+			uci.set('wloc-service', id, 'node_ref', f.node.value.trim());
+			uci.set('wloc-service', id, 'node_mode', f.nodeMode.value);
+			uci.set('wloc-service', id, 'geo_source', f.geo.value);
+			uci.set('wloc-service', id, 'manual_lat', f.lat.value.trim());
+			uci.set('wloc-service', id, 'manual_lon', f.lon.value.trim());
+			uci.set('wloc-service', id, 'enabled', f.enabled.checked ? '1' : '0');
+			uci.save('wloc-service').then(function() { return ui.changes.apply(true); })
+				.then(function() { return restart(); }).then(function() {
+					note(wlocI18n.t('Saved'), wlocI18n.t('Unified supervisor restarted.'));
+					return uci.load('wloc-service');
+				}).then(render).catch(function(error) {
+					note(wlocI18n.t('Save failed'), String(error), 'error');
+				});
+		}
+		function render() {
+			body.innerHTML = '';
+			var sections = uci.sections('wloc-service', 'device');
+			if (!sections.length) {
+				body.appendChild(E('tr', {}, [E('td', {'colspan': 8}, wlocI18n.t('No v2 device profiles yet.'))]));
+				return;
+			}
+			sections.forEach(function(section) {
+				var f = {label: field(section.label, 'label'), device: field(section.assigned_device, '192.168.1.100 or MAC'), node: field(section.node_ref || 'default', 'node'), lat: field(section.manual_lat, 'lat'), lon: field(section.manual_lon, 'lon'), enabled: E('input', {type: 'checkbox', checked: section.enabled === '1'})};
+			f.nodeMode = E('select', {}); [['fixed','fixed'],['gateway_default','gateway_default']].forEach(function(v) { f.nodeMode.appendChild(E('option', {value: v[0], selected: (section.node_mode || 'fixed') === v[0]}, v[1])); });
+			f.geo = E('select', {}); [['auto','auto'],['manual','manual']].forEach(function(v) { f.geo.appendChild(E('option', {value: v[0], selected: (section.geo_source || 'auto') === v[0]}, v[1])); });
+			var state = states[section['.name']];
+			body.appendChild(E('tr', {class: 'tr'}, [
+				E('td', {class: 'td'}, section['.name']), E('td', {class: 'td'}, f.label), E('td', {class: 'td'}, f.device), E('td', {class: 'td'}, f.node),
+				E('td', {class: 'td'}, [f.nodeMode, ' / ', f.geo]), E('td', {class: 'td'}, [f.lat, ' ', f.lon]),
+				E('td', {class: 'td'}, [f.enabled, ' ', state ? state.phase : wlocI18n.t('Not observed')]),
+				E('td', {class: 'td'}, E('button', {class: 'cbi-button cbi-button-apply', click: function() { apply(section, f); }}, wlocI18n.t('Save')))
+			]));
+			});
+		}
+		function add() {
+			var id = window.prompt(wlocI18n.t('New profile id'), 'phone');
+			if (!id || !/^[a-z0-9_-]{1,32}$/.test(id) || uci.get('wloc-service', id)) {
+				note(wlocI18n.t('Add failed'), wlocI18n.t('Use a unique lowercase profile id.'), 'error');
+				return;
+			}
+			uci.add('wloc-service', 'device', id);
+			uci.set('wloc-service', id, 'label', id); uci.set('wloc-service', id, 'node_ref', 'default');
+			uci.set('wloc-service', id, 'node_mode', 'fixed'); uci.set('wloc-service', id, 'geo_source', 'auto'); uci.set('wloc-service', id, 'enabled', '0');
+			uci.save('wloc-service').then(function() { return ui.changes.apply(true); }).then(function() { return uci.load('wloc-service'); }).then(render);
+		}
+		render();
+		poll.add(function() { return L.resolveDefault(health(), {}).then(function(value) { index(value || {}); render(); }); }, 5);
+		return E([], [E('h2', {}, wlocI18n.t('Device profiles')), E('p', {}, wlocI18n.t('One profile owns one device binding, node selection, WLOC auto/manual mode, and isolated redirect.')), E('p', {}, E('button', {class: 'cbi-button cbi-button-add', click: add}, wlocI18n.t('Add profile'))), E('div', {class: 'cbi-section', style: 'overflow:auto'}, E('table', {class: 'table'}, [E('tr', {class: 'tr table-titles'}, ['ID', wlocI18n.t('Label'), wlocI18n.t('Device'), wlocI18n.t('Node'), wlocI18n.t('Mode'), wlocI18n.t('Manual location'), wlocI18n.t('Enabled / state'), ''].map(function(v) { return E('th', {class: 'th'}, v); })), body]))]);
+	}
+});

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -54,11 +54,13 @@ return view.extend({
 		var wlocBody = E('div', {}, []);
 		var gwBody = E('div', {}, []);
 		var extraBody = E('div', {}, []);
+		var profileBody = E('tbody', {}, []);
 
 		function renderHealth(h) {
 			wlocBody.innerHTML = '';
 			gwBody.innerHTML = '';
 			extraBody.innerHTML = '';
+			profileBody.innerHTML = '';
 
 			var s = h.services || {};
 			var w = s.wloc || {};
@@ -125,6 +127,15 @@ return view.extend({
 			if (h.error) {
 				row(wlocBody, wlocI18n.t('Health check'), E('span', { style: 'color:#dc2626' }, h.error));
 			}
+			(h.profiles || []).forEach(function(profile) {
+				var good = profile.phase === 'intercepting' || profile.phase === 'disabled';
+				profileBody.appendChild(E('tr', { 'class': 'tr' }, [
+					E('td', { 'class': 'td' }, profile.id),
+					E('td', { 'class': 'td' }, profile.label || '-'),
+					E('td', { 'class': 'td' }, statusDot(good, profile.phase || '-')),
+					E('td', { 'class': 'td' }, profile.reason_code || '-')
+				]));
+			});
 		}
 
 		renderHealth(health);
@@ -196,6 +207,13 @@ return view.extend({
 			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
 				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Patches and nodes')),
 				extraBody
+			]),
+			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
+				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Device profiles')),
+				E('table', { 'class': 'table' }, [
+					E('tr', { 'class': 'tr table-titles' }, [wlocI18n.t('ID'), wlocI18n.t('Label'), wlocI18n.t('State'), wlocI18n.t('Reason')].map(function(title) { return E('th', { 'class': 'th' }, title); })),
+					profileBody
+				])
 			]),
 			restartButtons
 		]);

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -174,6 +174,7 @@ PY
 			cp "$root/openwrt/files/etc/init.d/wloc-service" "$stage/data/etc/init.d/wloc-service"
 			cp "$root/openwrt/files/usr/sbin/wloc-redirect-sync.sh" "$stage/data/usr/sbin/wloc-redirect-sync.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-refresh-set.sh" "$stage/data/usr/sbin/wloc-refresh-set.sh"
+			cp "$root/openwrt/files/usr/sbin/wloc-profile-redirect.sh" "$stage/data/usr/sbin/wloc-profile-redirect.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
 			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
 			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -175,6 +175,7 @@ PY
 			cp "$root/openwrt/files/usr/sbin/wloc-redirect-sync.sh" "$stage/data/usr/sbin/wloc-redirect-sync.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-refresh-set.sh" "$stage/data/usr/sbin/wloc-refresh-set.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-profile-redirect.sh" "$stage/data/usr/sbin/wloc-profile-redirect.sh"
+			cp "$root/openwrt/files/usr/sbin/wloc-profile-status.sh" "$stage/data/usr/sbin/wloc-profile-status.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
 			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
 			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -175,6 +175,10 @@ PY
 			cp "$root/openwrt/files/usr/sbin/wloc-redirect-sync.sh" "$stage/data/usr/sbin/wloc-redirect-sync.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-refresh-set.sh" "$stage/data/usr/sbin/wloc-refresh-set.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
+			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
+			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"
+			cp "$root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
+				"$stage/data/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 			cp "$service_bin" "$stage/data/usr/sbin/wloc-service"
 			cp "$ctl_bin" "$stage/data/usr/sbin/wloc-ctl"
 			chmod 0755 "$stage/data/etc/init.d/wloc-service" "$stage/data/usr/sbin/"*
@@ -188,14 +192,14 @@ PY
 			cat > "$stage/control/postinst" <<'POSTINST'
 #!/bin/sh
 [ -n "${IPKG_INSTROOT:-}" ] && exit 0
-/etc/init.d/wificalling-gateway enable >/dev/null 2>&1 || true
-/etc/init.d/wloc-service enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-gateway disable >/dev/null 2>&1 || true
+/etc/init.d/wloc-service disable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway enable >/dev/null 2>&1 || true
 killall -q wloc-service >/dev/null 2>&1 || true
 rm -f /var/run/wloc-service/control.sock
 mkdir -p /var/run/wificalling-gateway
 chmod 0700 /var/run/wificalling-gateway
-/etc/init.d/wificalling-gateway restart >/dev/null 2>&1 || true
-/etc/init.d/wloc-service restart >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1 || true
 rm -f /tmp/luci-indexcache.*
 /etc/init.d/rpcd reload >/dev/null 2>&1 || true
 exit 0

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -22,6 +22,7 @@ done
 ./tests/scripts/test-openwrt-release-packaging.sh
 ./tests/scripts/test-standalone-ax6s-package.sh
 ./tests/scripts/test-release-version.sh
+./tests/scripts/test-unified-supervisor.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -141,7 +141,7 @@ mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
 cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
 	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
-for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-health.sh; do
+for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-profile-status.sh wloc-health.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
 chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -141,7 +141,7 @@ mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
 cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
 	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
-for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-health.sh; do
+for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-health.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
 chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -136,11 +136,16 @@ mkdir -p "$package_dir/files/usr/sbin" "$package_dir/files/etc/init.d" "$package
 cp "$service_bin" "$package_dir/files/usr/sbin/wloc-service"
 cp "$ctl_bin" "$package_dir/files/usr/sbin/wloc-ctl"
 cp "$repo_root/openwrt/files/etc/init.d/wloc-service" "$package_dir/files/etc/init.d/wloc-service"
+cp "$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway" "$package_dir/files/etc/init.d/wificalling-location-gateway"
+mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
+cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
+	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
 for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-health.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
-chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"*
+chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \
+	"$package_dir/files/usr/libexec/wificalling-location-gateway/"*
 
 cat > "$package_dir/Makefile" <<EOF
 include \$(TOPDIR)/rules.mk
@@ -174,12 +179,12 @@ define Package/wificalling-location-gateway/postinst
 for required in /usr/bin/sing-box /usr/sbin/nft /usr/sbin/ip /usr/libexec/rpcd; do
   [ -e "\$\$required" ] || echo "wificalling-location-gateway: prerequisite missing: \$\$required" >&2
 done
-/etc/init.d/wificalling-gateway enable >/dev/null 2>&1 || true
-/etc/init.d/wloc-service enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-gateway disable >/dev/null 2>&1 || true
+/etc/init.d/wloc-service disable >/dev/null 2>&1 || true
 mkdir -p /var/run/wificalling-gateway
 chmod 0700 /var/run/wificalling-gateway
-/etc/init.d/wificalling-gateway restart >/dev/null 2>&1 || true
-/etc/init.d/wloc-service restart >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway enable >/dev/null 2>&1 || true
+/etc/init.d/wificalling-location-gateway restart >/dev/null 2>&1 || true
 rm -f /tmp/luci-indexcache.*
 /etc/init.d/rpcd reload >/dev/null 2>&1 || true
 exit 0

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,14 +18,13 @@ use crate::exitprobe::{NodeRef, ProbeLimits};
 use crate::georesolver::runtime::{resolve_geo, GeoProviderRuntime};
 use crate::georesolver::{GeoResolution, ProviderRef};
 use crate::service::api::RequestParams;
-use crate::service::control::{
-    disable as control_disable, enable as control_enable, ControlError, RuntimeControl,
-};
+use crate::service::control::{ControlError, RuntimeControl};
 use crate::service::dispatch::{DispatchError, ServiceDispatch};
 use crate::service::state::{reduce, ServiceEvent, ServicePhase, ServiceState};
 use crate::service::status::{
     encode_status, DesiredState, EngineHealth, ExitState, GeoState, StatusInputs,
 };
+use crate::service::supervisor::{SupervisorError, UnifiedSupervisor};
 use crate::wloc::PatchTarget;
 
 fn current_unix() -> u64 {
@@ -42,6 +41,13 @@ fn map_control_error(error: ControlError) -> DispatchError {
         ControlError::RedirectStillPresent => DispatchError::RedirectPresent,
         ControlError::CleanupUnsafe => DispatchError::CleanupUnsafe,
         ControlError::RuntimeFailure(_) => DispatchError::RuntimeFailure,
+    }
+}
+
+fn map_supervisor_error(error: SupervisorError) -> DispatchError {
+    match error {
+        SupervisorError::Control(control_error) => map_control_error(control_error),
+        SupervisorError::Transition(_) => DispatchError::InvalidConfig,
     }
 }
 
@@ -84,7 +90,7 @@ struct ManualGeoLookup {
 /// and Geo resolver.
 pub struct WlocService<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> {
     state: ServiceState,
-    runtime: R,
+    supervisor: UnifiedSupervisor<R>,
     probe: P,
     geo: G,
     node_ref: NodeRef,
@@ -144,7 +150,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     pub fn new(runtime: R, probe: P, geo: G, config: WlocServiceConfig) -> Self {
         Self {
             state: ServiceState::disabled(),
-            runtime,
+            supervisor: UnifiedSupervisor::new(runtime),
             probe,
             geo,
             node_ref: config.node_ref,
@@ -639,8 +645,9 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
         if self.state.phase() != ServicePhase::Disabled {
             return Err(DispatchError::InvalidConfig);
         }
-        control_enable(&mut self.runtime, self.scope_valid, self.ipv6_ready)
-            .map_err(map_control_error)?;
+        self.supervisor
+            .enable(self.scope_valid, self.ipv6_ready)
+            .map_err(map_supervisor_error)?;
         self.apply_enable_events();
         self.desired_state = DesiredState::Enabled;
         Ok(())
@@ -650,7 +657,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> ServiceDispa
         if self.state.phase() == ServicePhase::Disabled {
             return Ok(());
         }
-        control_disable(&mut self.runtime).map_err(map_control_error)?;
+        self.supervisor.disable().map_err(map_supervisor_error)?;
         for event in [ServiceEvent::BeginDisable, ServiceEvent::EngineStopped] {
             match reduce(&self.state, event) {
                 Ok(next) => self.state = next,

--- a/src/app.rs
+++ b/src/app.rs
@@ -795,7 +795,7 @@ mod probe_needed_tests {
 
 #[cfg(test)]
 mod bounded_log_tests {
-    use super::{append_line, MAX_EVENT_LOG_BYTES, MAX_EVENT_LINE_BYTES};
+    use super::{append_line, MAX_EVENT_LINE_BYTES, MAX_EVENT_LOG_BYTES};
     use serde_json::json;
 
     #[test]
@@ -823,7 +823,10 @@ mod bounded_log_tests {
             super::current_unix()
         ));
         append_line(&path, &json!({"event": "kept"}));
-        append_line(&path, &json!({"payload": "x".repeat(MAX_EVENT_LINE_BYTES * 2)}));
+        append_line(
+            &path,
+            &json!({"payload": "x".repeat(MAX_EVENT_LINE_BYTES * 2)}),
+        );
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.contains("kept"));
         assert!(!text.contains(&"x".repeat(MAX_EVENT_LINE_BYTES * 2)));

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,6 +190,19 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     /// Probe and resolve evidence when the cached observation is missing,
     /// stale, or the last probe failed.
     fn refresh_evidence_at(&mut self, now_unix: u64) {
+        // An invalid or unsupported profile is disabled at startup, but
+        // status and periodic refreshes still run independently of the
+        // enable path. Do not let those paths create an unbound legacy probe
+        // that silently selects the first outbound, and withdraw any stale
+        // evidence/patch target already held by the service.
+        if !self.scope_valid {
+            self.exit_evidence = ExitEvidence::Unavailable;
+            self.geo_resolution = GeoResolution::Unavailable;
+            self.last_probe_fingerprint = None;
+            self.last_probe_error = Some("invalid service scope".to_owned());
+            self.publish_patch_target();
+            return;
+        }
         // Manual mode pins the location to the preset coordinates; exit
         // probing exists only to drive auto-follow, so it is skipped
         // entirely in manual mode (no reverse probe, no misleading IP).
@@ -240,6 +253,14 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
     /// Publish the current patch target: a manual preset when set, otherwise
     /// the freshest Geo record (in Auto mode).
     fn publish_patch_target(&self) {
+        if !self.scope_valid {
+            if let Some(sink) = &self.patch_sink {
+                if let Ok(mut guard) = sink.lock() {
+                    *guard = None;
+                }
+            }
+            return;
+        }
         let target = match self.geo_source {
             GeoSource::Manual {
                 latitude,

--- a/src/app.rs
+++ b/src/app.rs
@@ -761,3 +761,41 @@ mod probe_needed_tests {
         assert!(probe_needed(true, Some(1), None));
     }
 }
+
+#[cfg(test)]
+mod bounded_log_tests {
+    use super::{append_line, MAX_EVENT_LOG_BYTES, MAX_EVENT_LINE_BYTES};
+    use serde_json::json;
+
+    #[test]
+    fn event_log_never_exceeds_storage_bound() {
+        let path = std::env::temp_dir().join(format!(
+            "wloc-bounded-events-{}-{}.jsonl",
+            std::process::id(),
+            super::current_unix()
+        ));
+        let payload = "x".repeat(MAX_EVENT_LINE_BYTES);
+        for index in 0..128 {
+            append_line(&path, &json!({"event": index, "payload": payload}));
+        }
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.len() <= MAX_EVENT_LOG_BYTES);
+        assert!(bytes.ends_with(b"\n"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn oversized_event_is_dropped_without_corrupting_existing_lines() {
+        let path = std::env::temp_dir().join(format!(
+            "wloc-bounded-event-drop-{}-{}.jsonl",
+            std::process::id(),
+            super::current_unix()
+        ));
+        append_line(&path, &json!({"event": "kept"}));
+        append_line(&path, &json!({"payload": "x".repeat(MAX_EVENT_LINE_BYTES * 2)}));
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("kept"));
+        assert!(!text.contains(&"x".repeat(MAX_EVENT_LINE_BYTES * 2)));
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,11 @@ use crate::service::status::{
 use crate::service::supervisor::{SupervisorError, UnifiedSupervisor};
 use crate::wloc::PatchTarget;
 
+/// Upper bounds for the root-local structured event log. These are small
+/// enough for AX6S-class gateways while retaining recent diagnostic history.
+pub(crate) const MAX_EVENT_LOG_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_EVENT_LINE_BYTES: usize = 2048;
+
 fn current_unix() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -718,18 +723,44 @@ fn probe_needed(
 /// Append one JSON line to an append-only log file (bounded to avoid
 /// unbounded growth).
 fn append_line(path: &std::path::Path, value: &serde_json::Value) {
-    use std::io::Write as _;
     let mut line = serde_json::to_string(value).unwrap_or_default();
     line.push('\n');
+    if line.len() > MAX_EVENT_LINE_BYTES {
+        return;
+    }
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    if let Ok(mut file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
-        let _ = file.write_all(line.as_bytes());
+
+    let existing = std::fs::read(path).unwrap_or_default();
+    if existing.len().saturating_add(line.len()) <= MAX_EVENT_LOG_BYTES {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            use std::io::Write as _;
+            let _ = file.write_all(line.as_bytes());
+        }
+        return;
+    }
+
+    let keep_bytes = MAX_EVENT_LOG_BYTES.saturating_sub(line.len());
+    let mut retained = if existing.len() > keep_bytes {
+        let start = existing.len() - keep_bytes;
+        let boundary = existing[start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|offset| start + offset + 1)
+            .unwrap_or(existing.len());
+        existing[boundary..].to_vec()
+    } else {
+        existing
+    };
+    retained.extend_from_slice(line.as_bytes());
+    let temporary = path.with_extension(format!("log.tmp.{}", std::process::id()));
+    if std::fs::write(&temporary, retained).is_ok() {
+        let _ = std::fs::rename(temporary, path);
     }
 }
 
@@ -774,7 +805,7 @@ mod bounded_log_tests {
             std::process::id(),
             super::current_unix()
         ));
-        let payload = "x".repeat(MAX_EVENT_LINE_BYTES);
+        let payload = "x".repeat(MAX_EVENT_LINE_BYTES / 2);
         for index in 0..128 {
             append_line(&path, &json!({"event": index, "payload": payload}));
         }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
-use wificalling_location_gateway::config::{LocationMode, WlocUciConfig};
+use wificalling_location_gateway::config::{LocationMode, RuntimeProfile, WlocUciConfig};
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
 use wificalling_location_gateway::georesolver::http::GeoHttpClient;
@@ -43,6 +43,31 @@ fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs())
         .unwrap_or(0)
+}
+
+fn disabled_runtime_profile() -> RuntimeProfile {
+    RuntimeProfile {
+        id: "invalid".to_owned(),
+        enabled: false,
+        assigned_device: None,
+        node_ref: "default".to_owned(),
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+    }
+}
+
+fn runtime_profile_from_uci(uci: &WlocUciConfig) -> RuntimeProfile {
+    match uci
+        .profile_model()
+        .and_then(|model| model.single_runtime_profile())
+    {
+        Ok(profile) => profile,
+        Err(error) => {
+            eprintln!("wloc-service: profile is not runnable yet: {error}; staying disabled");
+            disabled_runtime_profile()
+        }
+    }
 }
 
 /// No-op runtime control: every adapter step succeeds and the engine is
@@ -213,24 +238,35 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let uci = match WlocUciConfig::load(Path::new(&uci_path)) {
         Ok(config) => config,
         Err(error) => {
-            eprintln!("wloc-service: {error}; using defaults");
-            WlocUciConfig::default()
+            eprintln!("wloc-service: {error}; using disabled defaults");
+            WlocUciConfig {
+                enabled: false,
+                ..WlocUciConfig::default()
+            }
         }
     };
+    let runtime_profile = runtime_profile_from_uci(&uci);
     // The device whose node binding the location follows. It is normally
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
     // instead of a fixed example address.
-    let assigned_device = if uci.assigned_device.trim().is_empty() {
+    let assigned_device = if runtime_profile
+        .assigned_device
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
         gateway_first_device_ip().unwrap_or_default()
     } else {
-        uci.assigned_device.clone()
+        runtime_profile.assigned_device.clone().unwrap_or_default()
     };
     eprintln!(
-        "wloc-service: uci enabled={} geo_source={:?} node={} device={}",
-        uci.enabled,
-        uci.location_mode,
-        uci.node_ref,
+        "wloc-service: profile={} enabled={} geo_source={:?} node={} device={}",
+        runtime_profile.id,
+        runtime_profile.enabled,
+        runtime_profile.location_mode,
+        runtime_profile.node_ref,
         if assigned_device.is_empty() {
             "(none)".to_owned()
         } else {
@@ -257,7 +293,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         build_probe(&assigned_device, uci.probe_port),
         geo,
         WlocServiceConfig {
-            node_ref: NodeRef::new(&uci.node_ref)
+            node_ref: NodeRef::new(&runtime_profile.node_ref)
                 .unwrap_or_else(|_| NodeRef::new("default").expect("static node ref is valid")),
             providers: vec![ProviderRef::new("http").expect("static provider ref is valid")],
             probe_limits: ProbeLimits {
@@ -385,8 +421,11 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // manual location preset first (so a manual target is already fresh), then
     // the desired enabled state. Failures are logged, not fatal: the daemon
     // still serves status and can be steered through the control API.
-    if uci.location_mode == LocationMode::Manual {
-        if let (Some(latitude), Some(longitude)) = (uci.manual_latitude, uci.manual_longitude) {
+    if runtime_profile.location_mode == LocationMode::Manual {
+        if let (Some(latitude), Some(longitude)) = (
+            runtime_profile.manual_latitude,
+            runtime_profile.manual_longitude,
+        ) {
             let params = RequestParams {
                 query: None,
                 latitude: Some(latitude),
@@ -401,7 +440,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             );
         }
     }
-    if uci.enabled {
+    if runtime_profile.enabled {
         if let Err(error) = service.enable() {
             eprintln!("wloc-service: enable failed: {error:?}");
         }
@@ -607,5 +646,29 @@ mod tests {
     fn ignores_non_ip_tokens() {
         let output = "elements = { 59.82.17.33, hostname, 10.0.0.1/8 }\n";
         assert_eq!(parse_apple_ips(output), vec!["59.82.17.33"]);
+    }
+
+    #[test]
+    fn explicit_profile_is_the_single_runtime_source() {
+        let config = WlocUciConfig::parse(
+            "config wloc-service 'main'\n\toption enabled '0'\n\toption node_ref 'legacy'\n\toption assigned_device '192.168.1.200'\nconfig device 'phone'\n\toption label 'Phone'\n\toption assigned_device '192.168.1.100'\n\toption node_ref 'profile-node'\n\toption geo_source 'auto'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert_eq!(profile.id, "phone");
+        assert!(profile.enabled);
+        assert_eq!(profile.assigned_device.as_deref(), Some("192.168.1.100"));
+        assert_eq!(profile.node_ref, "profile-node");
+    }
+
+    #[test]
+    fn multiple_profiles_never_select_one_implicitly() {
+        let config = WlocUciConfig::parse(
+            "config device 'phone'\n\toption assigned_device '192.168.1.100'\nconfig device 'tablet'\n\toption assigned_device '192.168.1.101'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert!(!profile.enabled);
+        assert_eq!(profile.id, "invalid");
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
-use wificalling_location_gateway::config::{LocationMode, RuntimeProfile, WlocUciConfig};
+use wificalling_location_gateway::config::{DeviceProfile, LocationMode, RuntimeProfile, WlocUciConfig};
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
 use wificalling_location_gateway::georesolver::http::GeoHttpClient;
@@ -24,6 +24,9 @@ use wificalling_location_gateway::mitm::CaBundle;
 use wificalling_location_gateway::service::api::RequestParams;
 use wificalling_location_gateway::service::control::{RuntimeControl, RuntimeFailure};
 use wificalling_location_gateway::service::dispatch::ServiceDispatch;
+use wificalling_location_gateway::service::profile_runtime::{
+    ProfileRuntimeControl, ProfileRuntimeError,
+};
 use wificalling_location_gateway::service::server::ControlServer;
 use wificalling_location_gateway::service::GeoRecord;
 use wificalling_location_gateway::wloc::PatchTarget;
@@ -92,6 +95,7 @@ fn runtime_scope_valid(config_valid: bool, profile: &RuntimeProfile) -> bool {
 /// terminate itself.
 struct OpenWrtRuntime {
     redirect_helper: std::path::PathBuf,
+    profile_redirect_helper: std::path::PathBuf,
     nft_binary: std::path::PathBuf,
     defer_first_redirect: bool,
 }
@@ -103,6 +107,9 @@ impl OpenWrtRuntime {
                 .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
             std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
         );
+        runtime.profile_redirect_helper = std::env::var("WLOC_PROFILE_REDIRECT_HELPER")
+            .unwrap_or_else(|_| "/usr/sbin/wloc-profile-redirect.sh".to_owned())
+            .into();
         runtime.defer_first_redirect = std::env::var("WLOC_DEFER_REDIRECT").as_deref() == Ok("1");
         runtime
     }
@@ -111,8 +118,10 @@ impl OpenWrtRuntime {
         redirect_helper: impl Into<std::path::PathBuf>,
         nft_binary: impl Into<std::path::PathBuf>,
     ) -> Self {
+        let redirect_helper = redirect_helper.into();
         Self {
-            redirect_helper: redirect_helper.into(),
+            profile_redirect_helper: redirect_helper.clone(),
+            redirect_helper,
             nft_binary: nft_binary.into(),
             defer_first_redirect: false,
         }
@@ -129,6 +138,28 @@ impl OpenWrtRuntime {
             .status()
             .map_err(|_| RuntimeFailure)
             .and_then(|status| status.success().then_some(()).ok_or(RuntimeFailure))
+    }
+
+    fn run_profile_redirect(
+        &self,
+        action: &str,
+        profile_id: &str,
+        assigned_device: Option<&str>,
+    ) -> Result<(), ProfileRuntimeError> {
+        let mut command = std::process::Command::new(&self.profile_redirect_helper);
+        command.arg(action).arg(profile_id);
+        if let Some(device) = assigned_device {
+            command.arg(device);
+        }
+        command
+            .status()
+            .map_err(|_| ProfileRuntimeError::RedirectInstall)
+            .and_then(|status| {
+                status
+                    .success()
+                    .then_some(())
+                    .ok_or(ProfileRuntimeError::RedirectInstall)
+            })
     }
 }
 
@@ -167,6 +198,47 @@ impl RuntimeControl for OpenWrtRuntime {
     }
     fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
         Ok(())
+    }
+}
+
+impl ProfileRuntimeControl for OpenWrtRuntime {
+    fn ensure_shared_engine(&mut self) -> Result<(), ProfileRuntimeError> {
+        // The unified supervisor owns the single Gateway/WLOC process set.
+        Ok(())
+    }
+
+    fn shared_engine_healthy(&mut self) -> Result<bool, ProfileRuntimeError> {
+        // The supervisor has already admitted the service before profile
+        // redirects are installed. A future health adapter can tighten this
+        // gate without changing the profile state machine.
+        Ok(true)
+    }
+
+    fn install_profile_redirect(
+        &mut self,
+        profile: &DeviceProfile,
+    ) -> Result<(), ProfileRuntimeError> {
+        let address = profile
+            .assigned_device
+            .as_deref()
+            .filter(|address| address.parse::<std::net::Ipv4Addr>().is_ok())
+            .ok_or(ProfileRuntimeError::UnsupportedDevice)?;
+        self.run_profile_redirect("start", &profile.id, Some(address))
+    }
+
+    fn remove_profile_redirect(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError> {
+        self.run_profile_redirect("stop", profile_id, None)
+    }
+
+    fn profile_redirect_present(
+        &mut self,
+        profile_id: &str,
+    ) -> Result<bool, ProfileRuntimeError> {
+        let status = std::process::Command::new(&self.profile_redirect_helper)
+            .args(["status", profile_id])
+            .status()
+            .map_err(|_| ProfileRuntimeError::CleanupUnsafe)?;
+        Ok(status.success())
     }
 }
 
@@ -838,7 +910,7 @@ mod tests {
 
         assert_eq!(
             std::fs::read_to_string(&log).unwrap(),
-            "start phone 192.168.1.100\\nstop phone\\n"
+            "start phone 192.168.1.100\nstop phone\n"
         );
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -49,6 +49,7 @@ fn disabled_runtime_profile() -> RuntimeProfile {
     RuntimeProfile {
         id: "invalid".to_owned(),
         enabled: false,
+        runtime_supported: false,
         assigned_device: None,
         node_ref: "default".to_owned(),
         location_mode: LocationMode::Auto,
@@ -62,12 +63,25 @@ fn runtime_profile_from_uci(uci: &WlocUciConfig) -> RuntimeProfile {
         .profile_model()
         .and_then(|model| model.single_runtime_profile())
     {
-        Ok(profile) => profile,
+        Ok(mut profile) => {
+            if !profile.runtime_supported {
+                eprintln!(
+                    "wloc-service: profile {} has no IP runtime binding; staying disabled",
+                    profile.id
+                );
+                profile.enabled = false;
+            }
+            profile
+        }
         Err(error) => {
             eprintln!("wloc-service: profile is not runnable yet: {error}; staying disabled");
             disabled_runtime_profile()
         }
     }
+}
+
+fn runtime_scope_valid(config_valid: bool, profile: &RuntimeProfile) -> bool {
+    config_valid && profile.runtime_supported
 }
 
 /// No-op runtime control: every adapter step succeeds and the engine is
@@ -235,14 +249,17 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // file falls back to the defaults so the daemon still runs unconfigured.
     let uci_path = std::env::var("WLOC_UCI_CONFIG")
         .unwrap_or_else(|_| wificalling_location_gateway::config::uci::DEFAULT_UCI_PATH.into());
-    let uci = match WlocUciConfig::load(Path::new(&uci_path)) {
-        Ok(config) => config,
+    let (uci, config_valid) = match WlocUciConfig::load(Path::new(&uci_path)) {
+        Ok(config) => (config, true),
         Err(error) => {
             eprintln!("wloc-service: {error}; using disabled defaults");
-            WlocUciConfig {
-                enabled: false,
-                ..WlocUciConfig::default()
-            }
+            (
+                WlocUciConfig {
+                    enabled: false,
+                    ..WlocUciConfig::default()
+                },
+                false,
+            )
         }
     };
     let runtime_profile = runtime_profile_from_uci(&uci);
@@ -250,7 +267,9 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // chosen from LuCI; when unset, fall back to the first device policy of
     // the Gateway config so a fresh install follows something on any subnet
     // instead of a fixed example address.
-    let assigned_device = if runtime_profile
+    let assigned_device = if !runtime_profile.runtime_supported {
+        String::new()
+    } else if runtime_profile
         .assigned_device
         .as_deref()
         .unwrap_or_default()
@@ -299,7 +318,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             probe_limits: ProbeLimits {
                 max_observation_age: Duration::from_secs(uci.probe_interval_secs),
             },
-            scope_valid: true,
+            scope_valid: runtime_scope_valid(config_valid, &runtime_profile),
             ipv6_ready: true,
             assigned_device_configured: !assigned_device.is_empty(),
             assigned_device: if assigned_device.is_empty() {
@@ -670,5 +689,22 @@ mod tests {
         let profile = runtime_profile_from_uci(&config);
         assert!(!profile.enabled);
         assert_eq!(profile.id, "invalid");
+    }
+
+    #[test]
+    fn mac_profile_is_not_enabled_until_runtime_resolution_exists() {
+        let config = WlocUciConfig::parse(
+            "config device 'phone'\n\toption assigned_device 'aa:bb:cc:dd:ee:ff'\n",
+        )
+        .unwrap();
+        let profile = runtime_profile_from_uci(&config);
+        assert!(!profile.enabled);
+        assert!(!profile.runtime_supported);
+    }
+
+    #[test]
+    fn invalid_uci_cannot_be_enabled_from_the_control_socket() {
+        let profile = disabled_runtime_profile();
+        assert!(!runtime_scope_valid(false, &profile));
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -93,15 +93,18 @@ fn runtime_scope_valid(config_valid: bool, profile: &RuntimeProfile) -> bool {
 struct OpenWrtRuntime {
     redirect_helper: std::path::PathBuf,
     nft_binary: std::path::PathBuf,
+    defer_first_redirect: bool,
 }
 
 impl OpenWrtRuntime {
     fn from_env() -> Self {
-        Self::new(
+        let mut runtime = Self::new(
             std::env::var("WLOC_REDIRECT_HELPER")
                 .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
             std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
-        )
+        );
+        runtime.defer_first_redirect = std::env::var("WLOC_DEFER_REDIRECT").as_deref() == Ok("1");
+        runtime
     }
 
     fn new(
@@ -111,7 +114,13 @@ impl OpenWrtRuntime {
         Self {
             redirect_helper: redirect_helper.into(),
             nft_binary: nft_binary.into(),
+            defer_first_redirect: false,
         }
+    }
+
+    #[cfg(test)]
+    fn defer_first_redirect(&mut self) {
+        self.defer_first_redirect = true;
     }
 
     fn run_redirect(&self, action: &str) -> Result<(), RuntimeFailure> {
@@ -134,6 +143,10 @@ impl RuntimeControl for OpenWrtRuntime {
         Ok(())
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        if self.defer_first_redirect {
+            self.defer_first_redirect = false;
+            return Ok(());
+        }
         self.run_redirect("start")
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
@@ -714,7 +727,6 @@ mod tests {
         assert_eq!(parse_apple_ips(output), vec!["59.82.17.33"]);
     }
 
-<<<<<<< HEAD
     #[test]
     fn explicit_profile_is_the_single_runtime_source() {
         let config = WlocUciConfig::parse(
@@ -774,10 +786,12 @@ mod tests {
         std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
 
         let mut runtime = OpenWrtRuntime::new(&helper, &helper);
+        runtime.defer_first_redirect();
         runtime.install_exact_redirect().unwrap();
         runtime.remove_redirect().unwrap();
+        runtime.install_exact_redirect().unwrap();
 
-        assert_eq!(std::fs::read_to_string(&log).unwrap(), "start\nstop\n");
+        assert_eq!(std::fs::read_to_string(&log).unwrap(), "stop\nstart\n");
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -153,17 +153,20 @@ fn build_probe(assigned_device: &str, probe_port: u16) -> Box<dyn ExitProbeRunti
             .unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
     );
     let probe_port: u16 = env_or("WLOC_PROBE_PORT", probe_port);
-    Box::new(
-        wificalling_location_gateway::exitprobe::singbox::SingBoxProbe::new(
-            std::path::PathBuf::from(
-                std::env::var("WLOC_SINGBOX_CONFIG")
-                    .unwrap_or_else(|_| "/var/run/wificalling-gateway/sing-box.json".into()),
-            ),
-            device_ip,
-            probe_port,
-            std::path::PathBuf::from("/tmp/wloc-probe"),
+    let probe = wificalling_location_gateway::exitprobe::singbox::SingBoxProbe::new(
+        std::path::PathBuf::from(
+            std::env::var("WLOC_SINGBOX_CONFIG")
+                .unwrap_or_else(|_| "/var/run/wificalling-gateway/sing-box.json".into()),
         ),
-    )
+        device_ip,
+        probe_port,
+        std::path::PathBuf::from("/tmp/wloc-probe"),
+    );
+    if assigned_device.trim().is_empty() {
+        Box::new(probe)
+    } else {
+        Box::new(probe.with_required_device_binding())
+    }
 }
 
 /// Stub Geo provider: returns a fixed, valid record for the queried exit.
@@ -246,11 +249,16 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .unwrap_or_else(|_| "/var/run/wloc-service/control.sock".into());
 
     // Persisted configuration from /etc/config/wloc-service (UCI). A missing
-    // file falls back to the defaults so the daemon still runs unconfigured.
+    // file preserves the v1 unconfigured-default behavior; an existing but
+    // invalid file is fail-closed and cannot later be enabled over the socket.
     let uci_path = std::env::var("WLOC_UCI_CONFIG")
         .unwrap_or_else(|_| wificalling_location_gateway::config::uci::DEFAULT_UCI_PATH.into());
     let (uci, config_valid) = match WlocUciConfig::load(Path::new(&uci_path)) {
         Ok(config) => (config, true),
+        Err(error) if !Path::new(&uci_path).exists() => {
+            eprintln!("wloc-service: {error}; using unconfigured defaults");
+            (WlocUciConfig::default(), true)
+        }
         Err(error) => {
             eprintln!("wloc-service: {error}; using disabled defaults");
             (

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -794,4 +794,52 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&log).unwrap(), "stop\nstart\n");
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn openwrt_runtime_delegates_profile_scoped_redirect_actions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "wloc-profile-runtime-test-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("actions.log");
+        let helper = root.join("profile-redirect-helper.sh");
+        let script = format!("#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\n", log.display());
+        std::fs::write(&helper, script).unwrap();
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut runtime = OpenWrtRuntime::new(&helper, &helper);
+        let profile = wificalling_location_gateway::config::DeviceProfile {
+            id: "phone".to_owned(),
+            label: "Phone".to_owned(),
+            assigned_device: Some("192.168.1.100".to_owned()),
+            node_ref: "default".to_owned(),
+            node_mode: wificalling_location_gateway::config::NodeSelectionMode::Fixed,
+            location_mode: LocationMode::Auto,
+            manual_latitude: None,
+            manual_longitude: None,
+            manual_location_ref: None,
+            enabled: true,
+        };
+        wificalling_location_gateway::service::profile_runtime::ProfileRuntimeControl::install_profile_redirect(
+            &mut runtime,
+            &profile,
+        )
+        .unwrap();
+        wificalling_location_gateway::service::profile_runtime::ProfileRuntimeControl::remove_profile_redirect(
+            &mut runtime,
+            "phone",
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&log).unwrap(),
+            "start phone 192.168.1.100\\nstop phone\\n"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -13,7 +13,9 @@ use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
-use wificalling_location_gateway::config::{DeviceProfile, LocationMode, RuntimeProfile, WlocUciConfig};
+use wificalling_location_gateway::config::{
+    DeviceProfile, LocationMode, RuntimeProfile, WlocUciConfig,
+};
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
 use wificalling_location_gateway::georesolver::http::GeoHttpClient;
@@ -230,10 +232,7 @@ impl ProfileRuntimeControl for OpenWrtRuntime {
         self.run_profile_redirect("stop", profile_id, None)
     }
 
-    fn profile_redirect_present(
-        &mut self,
-        profile_id: &str,
-    ) -> Result<bool, ProfileRuntimeError> {
+    fn profile_redirect_present(&mut self, profile_id: &str) -> Result<bool, ProfileRuntimeError> {
         let status = std::process::Command::new(&self.profile_redirect_helper)
             .args(["status", profile_id])
             .status()

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -769,10 +769,7 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         let log = root.join("actions.log");
         let helper = root.join("redirect-helper.sh");
-        let script = format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n",
-            log.display()
-        );
+        let script = format!("#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n", log.display());
         std::fs::write(&helper, script).unwrap();
         std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
 

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -1,9 +1,9 @@
 //! Run the WLOC service control daemon over a root-owned Unix socket.
 //!
-//! The daemon serves the frozen control API on a local Unix socket. Runtime
-//! adapters are stubs until the OpenWrt sing-box/nftables/Geo adapters land;
-//! their behavior is configurable through the `WLOC_STUB_*` environment
-//! variables so the control plane can be exercised end to end on any host.
+//! The daemon serves the frozen control API on a local Unix socket. Its
+//! OpenWrt runtime adapter delegates only the component-owned WLOC redirect;
+//! process ownership and the Gateway data plane remain with the unified
+//! supervisor.
 //!
 //! Socket path: `WLOC_SOCKET` (default `/var/run/wloc-service/control.sock`).
 
@@ -84,11 +84,46 @@ fn runtime_scope_valid(config_valid: bool, profile: &RuntimeProfile) -> bool {
     config_valid && profile.runtime_supported
 }
 
-/// No-op runtime control: every adapter step succeeds and the engine is
-/// healthy. Replaced by the nftables/procd adapter on OpenWrt.
-struct StubRuntime;
+/// Runtime control for the daemon's OpenWrt boundary.
+///
+/// The outer unified supervisor owns process start/stop and watchdogs. This
+/// daemon delegates the component-owned redirect and queries its presence;
+/// self-stop/drain operations are no-ops because the control server must not
+/// terminate itself.
+struct OpenWrtRuntime {
+    redirect_helper: std::path::PathBuf,
+    nft_binary: std::path::PathBuf,
+}
 
-impl RuntimeControl for StubRuntime {
+impl OpenWrtRuntime {
+    fn from_env() -> Self {
+        Self::new(
+            std::env::var("WLOC_REDIRECT_HELPER")
+                .unwrap_or_else(|_| "/usr/sbin/wloc-redirect-sync.sh".to_owned()),
+            std::env::var("WLOC_NFT_BINARY").unwrap_or_else(|_| "nft".to_owned()),
+        )
+    }
+
+    fn new(
+        redirect_helper: impl Into<std::path::PathBuf>,
+        nft_binary: impl Into<std::path::PathBuf>,
+    ) -> Self {
+        Self {
+            redirect_helper: redirect_helper.into(),
+            nft_binary: nft_binary.into(),
+        }
+    }
+
+    fn run_redirect(&self, action: &str) -> Result<(), RuntimeFailure> {
+        std::process::Command::new(&self.redirect_helper)
+            .arg(action)
+            .status()
+            .map_err(|_| RuntimeFailure)
+            .and_then(|status| status.success().then_some(()).ok_or(RuntimeFailure))
+    }
+}
+
+impl RuntimeControl for OpenWrtRuntime {
     fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
         Ok(())
     }
@@ -99,13 +134,17 @@ impl RuntimeControl for StubRuntime {
         Ok(())
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
-        Ok(())
+        self.run_redirect("start")
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
-        Ok(())
+        self.run_redirect("stop")
     }
     fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
-        Ok(false)
+        std::process::Command::new(&self.nft_binary)
+            .args(["list", "table", "inet", "wloc_service"])
+            .status()
+            .map(|status| status.success())
+            .map_err(|_| RuntimeFailure)
     }
     fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         Ok(())
@@ -316,7 +355,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     };
 
     let service = WlocService::new(
-        StubRuntime,
+        OpenWrtRuntime::from_env(),
         build_probe(&assigned_device, uci.probe_port),
         geo,
         WlocServiceConfig {
@@ -675,6 +714,7 @@ mod tests {
         assert_eq!(parse_apple_ips(output), vec!["59.82.17.33"]);
     }
 
+<<<<<<< HEAD
     #[test]
     fn explicit_profile_is_the_single_runtime_source() {
         let config = WlocUciConfig::parse(
@@ -714,5 +754,33 @@ mod tests {
     fn invalid_uci_cannot_be_enabled_from_the_control_socket() {
         let profile = disabled_runtime_profile();
         assert!(!runtime_scope_valid(false, &profile));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn openwrt_runtime_delegates_only_component_redirect_actions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "wloc-runtime-test-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("actions.log");
+        let helper = root.join("redirect-helper.sh");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$1\" >> '{}'\n",
+            log.display()
+        );
+        std::fs::write(&helper, script).unwrap();
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut runtime = OpenWrtRuntime::new(&helper, &helper);
+        runtime.install_exact_redirect().unwrap();
+        runtime.remove_redirect().unwrap();
+
+        assert_eq!(std::fs::read_to_string(&log).unwrap(), "start\nstop\n");
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,5 +12,6 @@ pub mod uci;
 pub use profile::{
     validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
     validate_profile_label, DeviceProfile, NodeSelectionMode, ProfileError, ProfileModel,
+    RuntimeProfile,
 };
 pub use uci::{LocationMode, Preset, UciError, WlocUciConfig};

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,11 @@
 //! only writer; keeping the parser inside the daemon means the root-only
 //! control API stays the single runtime write path.
 
+pub mod profile;
 pub mod uci;
 
+pub use profile::{
+    validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
+    validate_profile_label, DeviceProfile, NodeSelectionMode, ProfileError, ProfileModel,
+};
 pub use uci::{LocationMode, Preset, UciError, WlocUciConfig};

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -320,6 +320,9 @@ fn is_valid_device_address(value: &str) -> bool {
                     || ip.is_multicast()
                     || ip == std::net::Ipv4Addr::BROADCAST
                     || (octets[0] == 169 && octets[1] == 254))
+                    && (octets[0] == 10
+                        || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                        || (octets[0] == 192 && octets[1] == 168))
             }
             IpAddr::V6(ip) => {
                 let first = ip.segments()[0];
@@ -327,6 +330,7 @@ fn is_valid_device_address(value: &str) -> bool {
                     && !ip.is_loopback()
                     && !ip.is_multicast()
                     && (first & 0xffc0) != 0xfe80
+                    && (first & 0xfe00) == 0xfc00
             }
         };
     }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,282 @@
+//! Bounded v2 device profiles.
+//!
+//! A profile is the unit that will eventually connect one LAN device to one
+//! node, one WLOC location policy, and one service lifecycle.  This module is
+//! deliberately independent from runtime control: validation happens before
+//! any UCI write, nftables operation, or child-process change.
+
+use std::fmt;
+use std::net::IpAddr;
+
+use serde::Serialize;
+
+use super::uci::{LocationMode, WlocUciConfig};
+
+pub const MAX_PROFILES: usize = 8;
+pub const MAX_PROFILE_ID_BYTES: usize = 32;
+pub const MAX_PROFILE_LABEL_BYTES: usize = 48;
+pub const MAX_NODE_REF_BYTES: usize = 96;
+pub const MAX_LOCATION_REF_BYTES: usize = 64;
+pub const MAX_SERIALIZED_PROFILES_BYTES: usize = 8 * 1024;
+pub const MAX_REDACTED_STATUS_BYTES: usize = 4 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeSelectionMode {
+    Fixed,
+    GatewayDefault,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DeviceProfile {
+    pub id: String,
+    pub label: String,
+    pub assigned_device: Option<String>,
+    pub node_ref: String,
+    pub node_mode: NodeSelectionMode,
+    pub location_mode: LocationMode,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
+    pub manual_location_ref: Option<String>,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProfileError {
+    TooManyProfiles,
+    DuplicateId(String),
+    MissingAssignedDevice,
+    EmptyField(&'static str),
+    FieldTooLong { field: &'static str, max: usize },
+    InvalidProfileId(String),
+    InvalidDeviceAddress(String),
+    InvalidNodeRef,
+    IncompleteLocation,
+    InvalidLocation,
+    SerializedTooLarge,
+}
+
+impl fmt::Display for ProfileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooManyProfiles => write!(formatter, "too many device profiles"),
+            Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
+            Self::MissingAssignedDevice => {
+                formatter.write_str("assigned device address is required")
+            }
+            Self::EmptyField(field) => write!(formatter, "profile field is empty: {field}"),
+            Self::FieldTooLong { field, max } => {
+                write!(
+                    formatter,
+                    "profile field is too long: {field} (max {max} bytes)"
+                )
+            }
+            Self::InvalidProfileId(id) => write!(formatter, "invalid device profile id: {id}"),
+            Self::InvalidDeviceAddress(address) => {
+                write!(formatter, "invalid assigned device address: {address}")
+            }
+            Self::InvalidNodeRef => formatter.write_str("invalid node reference"),
+            Self::IncompleteLocation => formatter.write_str("manual location is incomplete"),
+            Self::InvalidLocation => formatter.write_str("manual location is invalid"),
+            Self::SerializedTooLarge => formatter.write_str("device profiles exceed storage bound"),
+        }
+    }
+}
+
+impl std::error::Error for ProfileError {}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProfileModel {
+    profiles: Vec<DeviceProfile>,
+}
+
+#[derive(Serialize)]
+struct RedactedProfileStatus<'a> {
+    profile_id: &'a str,
+    label: &'a str,
+    enabled: bool,
+    node_mode: NodeSelectionMode,
+    location_mode: LocationMode,
+    assigned_device_configured: bool,
+    manual_location_configured: bool,
+}
+
+impl ProfileModel {
+    pub fn new(profiles: Vec<DeviceProfile>) -> Result<Self, ProfileError> {
+        let model = Self { profiles };
+        model.validate()?;
+        Ok(model)
+    }
+
+    /// Convert the v1 singleton configuration without changing its effective
+    /// behavior. Re-running this function produces the same model.
+    pub fn from_legacy(config: &WlocUciConfig) -> Result<Self, ProfileError> {
+        let has_manual_coordinates =
+            config.manual_latitude.is_some() || config.manual_longitude.is_some();
+        Self::new(vec![DeviceProfile {
+            id: "default".to_owned(),
+            label: "Default device".to_owned(),
+            assigned_device: (!config.assigned_device.trim().is_empty())
+                .then(|| config.assigned_device.clone()),
+            node_ref: config.node_ref.clone(),
+            node_mode: NodeSelectionMode::Fixed,
+            location_mode: config.location_mode,
+            manual_latitude: config.manual_latitude,
+            manual_longitude: config.manual_longitude,
+            manual_location_ref: has_manual_coordinates.then(|| "legacy-manual".to_owned()),
+            enabled: config.enabled,
+        }])
+    }
+
+    pub fn profiles(&self) -> &[DeviceProfile] {
+        &self.profiles
+    }
+
+    /// Validate a candidate before replacing the current model. The existing
+    /// value is left untouched on every error.
+    pub fn replace(&mut self, profiles: Vec<DeviceProfile>) -> Result<(), ProfileError> {
+        let candidate = Self::new(profiles)?;
+        self.profiles = candidate.profiles;
+        Ok(())
+    }
+
+    pub fn redacted_status(&self) -> Result<Vec<serde_json::Value>, ProfileError> {
+        let status: Vec<_> = self
+            .profiles
+            .iter()
+            .map(|profile| {
+                serde_json::to_value(RedactedProfileStatus {
+                    profile_id: &profile.id,
+                    label: &profile.label,
+                    enabled: profile.enabled,
+                    node_mode: profile.node_mode,
+                    location_mode: profile.location_mode,
+                    assigned_device_configured: profile.assigned_device.is_some(),
+                    manual_location_configured: profile.manual_latitude.is_some()
+                        && profile.manual_longitude.is_some(),
+                })
+                .map_err(|_| ProfileError::SerializedTooLarge)
+            })
+            .collect::<Result<_, _>>()?;
+        let encoded = serde_json::to_vec(&status).map_err(|_| ProfileError::SerializedTooLarge)?;
+        if encoded.len() > MAX_REDACTED_STATUS_BYTES {
+            return Err(ProfileError::SerializedTooLarge);
+        }
+        Ok(status)
+    }
+
+    fn validate(&self) -> Result<(), ProfileError> {
+        if self.profiles.len() > MAX_PROFILES {
+            return Err(ProfileError::TooManyProfiles);
+        }
+        let mut ids = Vec::with_capacity(self.profiles.len());
+        for profile in &self.profiles {
+            validate_profile_id(&profile.id)?;
+            if !ids.iter().any(|id: &String| id == &profile.id) {
+                ids.push(profile.id.clone());
+            } else {
+                return Err(ProfileError::DuplicateId(profile.id.clone()));
+            }
+            validate_bounded_text("label", &profile.label, MAX_PROFILE_LABEL_BYTES)?;
+            if let Some(address) = profile.assigned_device.as_deref() {
+                validate_device_address(address)?;
+            }
+            validate_node_ref(&profile.node_ref)?;
+            if let Some(reference) = profile.manual_location_ref.as_deref() {
+                validate_location_ref(reference)?;
+            }
+            let has_latitude = profile.manual_latitude.is_some();
+            let has_longitude = profile.manual_longitude.is_some();
+            if has_latitude != has_longitude {
+                return Err(ProfileError::IncompleteLocation);
+            }
+            if let (Some(latitude), Some(longitude)) =
+                (profile.manual_latitude, profile.manual_longitude)
+            {
+                if !latitude.is_finite()
+                    || !longitude.is_finite()
+                    || !(-90.0..=90.0).contains(&latitude)
+                    || !(-180.0..=180.0).contains(&longitude)
+                {
+                    return Err(ProfileError::InvalidLocation);
+                }
+            }
+            if profile.location_mode == LocationMode::Manual && !(has_latitude && has_longitude) {
+                return Err(ProfileError::IncompleteLocation);
+            }
+        }
+        let encoded =
+            serde_json::to_vec(&self.profiles).map_err(|_| ProfileError::SerializedTooLarge)?;
+        if encoded.len() > MAX_SERIALIZED_PROFILES_BYTES {
+            return Err(ProfileError::SerializedTooLarge);
+        }
+        Ok(())
+    }
+}
+
+pub fn validate_profile_id(value: &str) -> Result<(), ProfileError> {
+    if value.is_empty() {
+        return Err(ProfileError::EmptyField("id"));
+    }
+    if value.len() > MAX_PROFILE_ID_BYTES
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_')
+        })
+    {
+        return Err(ProfileError::InvalidProfileId(value.to_owned()));
+    }
+    Ok(())
+}
+
+pub fn validate_device_address(value: &str) -> Result<(), ProfileError> {
+    if !is_valid_device_address(value) {
+        return Err(ProfileError::InvalidDeviceAddress(value.to_owned()));
+    }
+    Ok(())
+}
+
+pub fn validate_node_ref(value: &str) -> Result<(), ProfileError> {
+    if value.is_empty()
+        || value.len() > MAX_NODE_REF_BYTES
+        || value.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || character == '/'
+                || character == '\\'
+        })
+    {
+        return Err(ProfileError::InvalidNodeRef);
+    }
+    Ok(())
+}
+
+pub fn validate_profile_label(value: &str) -> Result<(), ProfileError> {
+    validate_bounded_text("label", value, MAX_PROFILE_LABEL_BYTES)
+}
+
+pub fn validate_location_ref(value: &str) -> Result<(), ProfileError> {
+    validate_bounded_text("manual_location_ref", value, MAX_LOCATION_REF_BYTES)
+}
+
+fn validate_bounded_text(field: &'static str, value: &str, max: usize) -> Result<(), ProfileError> {
+    if value.is_empty() {
+        return Err(ProfileError::EmptyField(field));
+    }
+    if value.len() > max {
+        return Err(ProfileError::FieldTooLong { field, max });
+    }
+    Ok(())
+}
+
+fn is_valid_device_address(value: &str) -> bool {
+    value.parse::<IpAddr>().is_ok() || is_valid_mac(value)
+}
+
+fn is_valid_mac(value: &str) -> bool {
+    let separator = if value.contains(':') { ':' } else { '-' };
+    let parts: Vec<_> = value.split(separator).collect();
+    parts.len() == 6
+        && parts
+            .iter()
+            .all(|part| part.len() == 2 && part.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -19,6 +19,7 @@ pub const MAX_NODE_REF_BYTES: usize = 96;
 pub const MAX_LOCATION_REF_BYTES: usize = 64;
 pub const MAX_SERIALIZED_PROFILES_BYTES: usize = 8 * 1024;
 pub const MAX_REDACTED_STATUS_BYTES: usize = 4 * 1024;
+pub const MAX_UCI_TEXT_BYTES: usize = 32 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +47,7 @@ pub enum ProfileError {
     TooManyProfiles,
     DuplicateId(String),
     MissingAssignedDevice,
+    MultipleProfilesRequireUnifiedRuntime,
     EmptyField(&'static str),
     FieldTooLong { field: &'static str, max: usize },
     InvalidProfileId(String),
@@ -63,6 +65,9 @@ impl fmt::Display for ProfileError {
             Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
             Self::MissingAssignedDevice => {
                 formatter.write_str("assigned device address is required")
+            }
+            Self::MultipleProfilesRequireUnifiedRuntime => {
+                formatter.write_str("multiple profiles require the unified runtime")
             }
             Self::EmptyField(field) => write!(formatter, "profile field is empty: {field}"),
             Self::FieldTooLong { field, max } => {
@@ -88,6 +93,17 @@ impl std::error::Error for ProfileError {}
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProfileModel {
     profiles: Vec<DeviceProfile>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RuntimeProfile {
+    pub id: String,
+    pub enabled: bool,
+    pub assigned_device: Option<String>,
+    pub node_ref: String,
+    pub location_mode: LocationMode,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -130,6 +146,26 @@ impl ProfileModel {
 
     pub fn profiles(&self) -> &[DeviceProfile] {
         &self.profiles
+    }
+
+    /// The current daemon is still a single-runtime process. It may consume
+    /// exactly one profile, but must refuse to guess when multiple profiles
+    /// are configured before unified multi-device routing lands.
+    pub fn single_runtime_profile(&self) -> Result<RuntimeProfile, ProfileError> {
+        let profile = self
+            .profiles
+            .first()
+            .filter(|_| self.profiles.len() == 1)
+            .ok_or(ProfileError::MultipleProfilesRequireUnifiedRuntime)?;
+        Ok(RuntimeProfile {
+            id: profile.id.clone(),
+            enabled: profile.enabled,
+            assigned_device: profile.assigned_device.clone(),
+            node_ref: profile.node_ref.clone(),
+            location_mode: profile.location_mode,
+            manual_latitude: profile.manual_latitude,
+            manual_longitude: profile.manual_longitude,
+        })
     }
 
     /// Validate a candidate before replacing the current model. The existing
@@ -269,14 +305,40 @@ fn validate_bounded_text(field: &'static str, value: &str, max: usize) -> Result
 }
 
 fn is_valid_device_address(value: &str) -> bool {
-    value.parse::<IpAddr>().is_ok() || is_valid_mac(value)
+    if let Ok(address) = value.parse::<IpAddr>() {
+        return match address {
+            IpAddr::V4(ip) => {
+                let octets = ip.octets();
+                !ip.is_unspecified()
+                    && !ip.is_loopback()
+                    && !ip.is_multicast()
+                    && ip != std::net::Ipv4Addr::BROADCAST
+                    && !(octets[0] == 169 && octets[1] == 254)
+            }
+            IpAddr::V6(ip) => {
+                let first = ip.segments()[0];
+                !ip.is_unspecified()
+                    && !ip.is_loopback()
+                    && !ip.is_multicast()
+                    && (first & 0xffc0) != 0xfe80
+            }
+        };
+    }
+    is_valid_mac(value)
 }
 
 fn is_valid_mac(value: &str) -> bool {
     let separator = if value.contains(':') { ':' } else { '-' };
     let parts: Vec<_> = value.split(separator).collect();
+    let first = parts
+        .first()
+        .and_then(|part| u8::from_str_radix(part, 16).ok());
     parts.len() == 6
         && parts
             .iter()
             .all(|part| part.len() == 2 && part.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        && parts
+            .iter()
+            .any(|part| part.bytes().any(|byte| byte != b'0'))
+        && first.is_some_and(|byte| byte & 1 == 0)
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -99,6 +99,7 @@ pub struct ProfileModel {
 pub struct RuntimeProfile {
     pub id: String,
     pub enabled: bool,
+    pub runtime_supported: bool,
     pub assigned_device: Option<String>,
     pub node_ref: String,
     pub location_mode: LocationMode,
@@ -160,6 +161,11 @@ impl ProfileModel {
         Ok(RuntimeProfile {
             id: profile.id.clone(),
             enabled: profile.enabled,
+            runtime_supported: profile
+                .assigned_device
+                .as_deref()
+                .map(|address| address.parse::<IpAddr>().is_ok())
+                .unwrap_or(true),
             assigned_device: profile.assigned_device.clone(),
             node_ref: profile.node_ref.clone(),
             location_mode: profile.location_mode,

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -65,7 +65,10 @@ impl fmt::Display for ProfileError {
             Self::TooManyProfiles => write!(formatter, "too many device profiles"),
             Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
             Self::DuplicateAssignedDevice(address) => {
-                write!(formatter, "device is assigned to multiple profiles: {address}")
+                write!(
+                    formatter,
+                    "device is assigned to multiple profiles: {address}"
+                )
             }
             Self::MissingAssignedDevice => {
                 formatter.write_str("assigned device address is required")

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -309,11 +309,11 @@ fn is_valid_device_address(value: &str) -> bool {
         return match address {
             IpAddr::V4(ip) => {
                 let octets = ip.octets();
-                !ip.is_unspecified()
-                    && !ip.is_loopback()
-                    && !ip.is_multicast()
-                    && ip != std::net::Ipv4Addr::BROADCAST
-                    && !(octets[0] == 169 && octets[1] == 254)
+                !(ip.is_unspecified()
+                    || ip.is_loopback()
+                    || ip.is_multicast()
+                    || ip == std::net::Ipv4Addr::BROADCAST
+                    || (octets[0] == 169 && octets[1] == 254))
             }
             IpAddr::V6(ip) => {
                 let first = ip.segments()[0];

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -46,6 +46,7 @@ pub struct DeviceProfile {
 pub enum ProfileError {
     TooManyProfiles,
     DuplicateId(String),
+    DuplicateAssignedDevice(String),
     MissingAssignedDevice,
     MultipleProfilesRequireUnifiedRuntime,
     EmptyField(&'static str),
@@ -63,6 +64,9 @@ impl fmt::Display for ProfileError {
         match self {
             Self::TooManyProfiles => write!(formatter, "too many device profiles"),
             Self::DuplicateId(id) => write!(formatter, "duplicate device profile id: {id}"),
+            Self::DuplicateAssignedDevice(address) => {
+                write!(formatter, "device is assigned to multiple profiles: {address}")
+            }
             Self::MissingAssignedDevice => {
                 formatter.write_str("assigned device address is required")
             }
@@ -212,6 +216,7 @@ impl ProfileModel {
             return Err(ProfileError::TooManyProfiles);
         }
         let mut ids = Vec::with_capacity(self.profiles.len());
+        let mut assigned_devices = Vec::with_capacity(self.profiles.len());
         for profile in &self.profiles {
             validate_profile_id(&profile.id)?;
             if !ids.iter().any(|id: &String| id == &profile.id) {
@@ -222,6 +227,11 @@ impl ProfileModel {
             validate_bounded_text("label", &profile.label, MAX_PROFILE_LABEL_BYTES)?;
             if let Some(address) = profile.assigned_device.as_deref() {
                 validate_device_address(address)?;
+                let normalized = normalize_device_address(address);
+                if assigned_devices.contains(&normalized) {
+                    return Err(ProfileError::DuplicateAssignedDevice(address.to_owned()));
+                }
+                assigned_devices.push(normalized);
             }
             validate_node_ref(&profile.node_ref)?;
             if let Some(reference) = profile.manual_location_ref.as_deref() {
@@ -335,6 +345,17 @@ fn is_valid_device_address(value: &str) -> bool {
         };
     }
     is_valid_mac(value)
+}
+
+fn normalize_device_address(value: &str) -> String {
+    if let Ok(address) = value.parse::<IpAddr>() {
+        return address.to_string();
+    }
+    value
+        .bytes()
+        .filter(|byte| *byte != b':' && *byte != b'-')
+        .map(|byte| byte.to_ascii_lowercase() as char)
+        .collect()
 }
 
 fn is_valid_mac(value: &str) -> bool {

--- a/src/config/uci.rs
+++ b/src/config/uci.rs
@@ -81,6 +81,8 @@ pub enum UciError {
     Coordinate { option: String, value: String },
     /// A device profile section failed v2 validation.
     Profile(String),
+    /// The complete UCI input exceeds the small-gateway parser bound.
+    ConfigTooLarge,
 }
 
 impl fmt::Display for UciError {
@@ -94,6 +96,7 @@ impl fmt::Display for UciError {
                 write!(f, "invalid {option} coordinate: {value}")
             }
             UciError::Profile(message) => write!(f, "invalid device profile: {message}"),
+            UciError::ConfigTooLarge => write!(f, "UCI configuration exceeds the size limit"),
         }
     }
 }
@@ -123,6 +126,11 @@ impl PresetBuilder {
 impl WlocUciConfig {
     /// Read and parse the daemon configuration file.
     pub fn load(path: &Path) -> Result<Self, UciError> {
+        let metadata =
+            std::fs::metadata(path).map_err(|_| UciError::Io(path.display().to_string()))?;
+        if metadata.len() > super::profile::MAX_UCI_TEXT_BYTES as u64 {
+            return Err(UciError::ConfigTooLarge);
+        }
         let text =
             std::fs::read_to_string(path).map_err(|_| UciError::Io(path.display().to_string()))?;
         Self::parse(&text)
@@ -142,6 +150,9 @@ impl WlocUciConfig {
 
     /// Parse UCI text. A missing `main` section yields the defaults.
     pub fn parse(text: &str) -> Result<Self, UciError> {
+        if text.len() > super::profile::MAX_UCI_TEXT_BYTES {
+            return Err(UciError::ConfigTooLarge);
+        }
         let mut config = Self::default();
         let mut section_type: Option<String> = None;
         let mut section_name: Option<String> = None;

--- a/src/config/uci.rs
+++ b/src/config/uci.rs
@@ -10,6 +10,8 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 
+use serde::Serialize;
+
 pub const DEFAULT_UCI_PATH: &str = "/etc/config/wloc-service";
 pub const DEFAULT_PROBE_PORT: u16 = 18080;
 pub const DEFAULT_PROBE_INTERVAL_SECS: u64 = 300;
@@ -17,7 +19,8 @@ const DEFAULT_NODE_REF: &str = "default";
 
 /// Where the location target comes from: follow the bound node's exit, or
 /// use the manually configured coordinates.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LocationMode {
     Auto,
     Manual,
@@ -45,6 +48,9 @@ pub struct WlocUciConfig {
     pub geo_provider: String,
     pub probe_port: u16,
     pub presets: Vec<Preset>,
+    /// Explicit v2 device sections. An empty list means the legacy singleton
+    /// fields above are still the source and can be migrated by `profile_model`.
+    pub profiles: Vec<super::profile::DeviceProfile>,
 }
 
 impl Default for WlocUciConfig {
@@ -60,6 +66,7 @@ impl Default for WlocUciConfig {
             geo_provider: "http".to_owned(),
             probe_port: DEFAULT_PROBE_PORT,
             presets: Vec::new(),
+            profiles: Vec::new(),
         }
     }
 }
@@ -72,6 +79,8 @@ pub enum UciError {
     Syntax { line: usize, text: String },
     /// A coordinate value is not a valid f64.
     Coordinate { option: String, value: String },
+    /// A device profile section failed v2 validation.
+    Profile(String),
 }
 
 impl fmt::Display for UciError {
@@ -84,6 +93,7 @@ impl fmt::Display for UciError {
             UciError::Coordinate { option, value } => {
                 write!(f, "invalid {option} coordinate: {value}")
             }
+            UciError::Profile(message) => write!(f, "invalid device profile: {message}"),
         }
     }
 }
@@ -118,12 +128,25 @@ impl WlocUciConfig {
         Self::parse(&text)
     }
 
+    /// Return the explicit v2 profiles, or a deterministic singleton model
+    /// synthesized from the v1 fields when no device sections exist.
+    pub fn profile_model(
+        &self,
+    ) -> Result<super::profile::ProfileModel, super::profile::ProfileError> {
+        if self.profiles.is_empty() {
+            super::profile::ProfileModel::from_legacy(self)
+        } else {
+            super::profile::ProfileModel::new(self.profiles.clone())
+        }
+    }
+
     /// Parse UCI text. A missing `main` section yields the defaults.
     pub fn parse(text: &str) -> Result<Self, UciError> {
         let mut config = Self::default();
         let mut section_type: Option<String> = None;
         let mut section_name: Option<String> = None;
         let mut preset: Option<PresetBuilder> = None;
+        let mut device: Option<DeviceBuilder> = None;
 
         for (index, raw_line) in text.lines().enumerate() {
             let line = raw_line.trim();
@@ -139,14 +162,25 @@ impl WlocUciConfig {
                     if let Some(builder) = preset.take() {
                         config.presets.push(builder.finish());
                     }
+                    if let Some(builder) = device.take() {
+                        config
+                            .profiles
+                            .push(builder.finish().map_err(profile_error)?);
+                    }
                     match tokens.as_slice() {
                         [_keyword, type_name, name, ..] => {
                             section_type = Some(type_name.clone());
                             section_name = Some(name.clone());
+                            if type_name == "device" {
+                                device = Some(DeviceBuilder::new(name.clone()));
+                            }
                         }
                         [_keyword, type_name] => {
                             section_type = Some(type_name.clone());
                             section_name = None;
+                            if type_name == "device" {
+                                device = Some(DeviceBuilder::new("default".to_owned()));
+                            }
                         }
                         _ => {
                             return Err(UciError::Syntax {
@@ -169,6 +203,7 @@ impl WlocUciConfig {
                     apply_option(
                         &mut config,
                         &mut preset,
+                        &mut device,
                         section_type.as_deref(),
                         section_name.as_deref(),
                         name,
@@ -186,6 +221,14 @@ impl WlocUciConfig {
         }
         if let Some(builder) = preset.take() {
             config.presets.push(builder.finish());
+        }
+        if let Some(builder) = device.take() {
+            config
+                .profiles
+                .push(builder.finish().map_err(profile_error)?);
+        }
+        if !config.profiles.is_empty() {
+            super::profile::ProfileModel::new(config.profiles.clone()).map_err(profile_error)?;
         }
         Ok(config)
     }
@@ -224,6 +267,7 @@ fn split_uci_tokens(line: &str) -> Option<Vec<String>> {
 fn apply_option(
     config: &mut WlocUciConfig,
     preset: &mut Option<PresetBuilder>,
+    device: &mut Option<DeviceBuilder>,
     section_type: Option<&str>,
     section_name: Option<&str>,
     name: &str,
@@ -239,6 +283,35 @@ fn apply_option(
                 "label" => builder.label = value.to_owned(),
                 "latitude" => builder.latitude = parse_coord(name, value)?,
                 "longitude" => builder.longitude = parse_coord(name, value)?,
+                _ => {}
+            }
+        }
+        Some("device") => {
+            let builder = device.as_mut().ok_or_else(|| {
+                UciError::Profile("device option outside a device section".to_owned())
+            })?;
+            match name {
+                "label" | "name" => builder.label = value.to_owned(),
+                "assigned_device" => builder.assigned_device = Some(value.to_owned()),
+                "node_ref" => builder.node_ref = value.to_owned(),
+                "node_mode" => {
+                    builder.node_mode = match value {
+                        "fixed" => super::profile::NodeSelectionMode::Fixed,
+                        "gateway_default" => super::profile::NodeSelectionMode::GatewayDefault,
+                        _ => return Err(UciError::Profile("unknown node_mode".to_owned())),
+                    }
+                }
+                "geo_source" => {
+                    builder.location_mode = match value {
+                        "auto" => LocationMode::Auto,
+                        "manual" => LocationMode::Manual,
+                        _ => return Err(UciError::Profile("unknown geo_source".to_owned())),
+                    }
+                }
+                "manual_lat" => builder.manual_latitude = Some(parse_coord(name, value)?),
+                "manual_lon" => builder.manual_longitude = Some(parse_coord(name, value)?),
+                "manual_location_ref" => builder.manual_location_ref = Some(value.to_owned()),
+                "enabled" => builder.enabled = matches!(value, "1" | "true" | "on"),
                 _ => {}
             }
         }
@@ -266,6 +339,59 @@ fn apply_option(
         _ => {}
     }
     Ok(())
+}
+
+fn profile_error(error: super::profile::ProfileError) -> UciError {
+    UciError::Profile(error.to_string())
+}
+
+struct DeviceBuilder {
+    id: String,
+    label: String,
+    assigned_device: Option<String>,
+    node_ref: String,
+    node_mode: super::profile::NodeSelectionMode,
+    location_mode: LocationMode,
+    manual_latitude: Option<f64>,
+    manual_longitude: Option<f64>,
+    manual_location_ref: Option<String>,
+    enabled: bool,
+}
+
+impl DeviceBuilder {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            label: "Default device".to_owned(),
+            assigned_device: None,
+            node_ref: DEFAULT_NODE_REF.to_owned(),
+            node_mode: super::profile::NodeSelectionMode::Fixed,
+            location_mode: LocationMode::Auto,
+            manual_latitude: None,
+            manual_longitude: None,
+            manual_location_ref: None,
+            enabled: true,
+        }
+    }
+
+    fn finish(self) -> Result<super::profile::DeviceProfile, super::profile::ProfileError> {
+        if self.assigned_device.is_none() {
+            return Err(super::profile::ProfileError::MissingAssignedDevice);
+        }
+        let profile = super::profile::DeviceProfile {
+            id: self.id,
+            label: self.label,
+            assigned_device: self.assigned_device,
+            node_ref: self.node_ref,
+            node_mode: self.node_mode,
+            location_mode: self.location_mode,
+            manual_latitude: self.manual_latitude,
+            manual_longitude: self.manual_longitude,
+            manual_location_ref: self.manual_location_ref,
+            enabled: self.enabled,
+        };
+        super::profile::ProfileModel::new(vec![profile.clone()]).map(|_| profile)
+    }
 }
 
 fn parse_coord(option: &str, value: &str) -> Result<f64, UciError> {

--- a/src/exitprobe/singbox.rs
+++ b/src/exitprobe/singbox.rs
@@ -289,6 +289,9 @@ pub struct SingBoxProbe {
     /// the bound node for devices that have no route rule (e.g. disabled
     /// Wi-Fi Calling policies), so follow-device still probes their node.
     uci_config_path: PathBuf,
+    /// When true, an explicit device binding is required. A missing binding
+    /// must not silently fall back to an unrelated outbound.
+    require_device_binding: bool,
 }
 
 impl SingBoxProbe {
@@ -306,7 +309,16 @@ impl SingBoxProbe {
             timeout: Duration::from_secs(15),
             singbox_bin: "/usr/bin/sing-box".to_owned(),
             uci_config_path: PathBuf::from("/etc/config/wificalling-gateway"),
+            require_device_binding: false,
         }
+    }
+
+    /// Require a matching Gateway policy for this probe target. This is used
+    /// by the profile-driven daemon; legacy callers may retain the historical
+    /// fallback behavior unless they opt in.
+    pub fn with_required_device_binding(mut self) -> Self {
+        self.require_device_binding = true;
+        self
     }
 
     /// Read the Gateway config and select the outbound for the test device.
@@ -336,6 +348,9 @@ impl SingBoxProbe {
             if config.endpoints.iter().any(|e| e.tag == tag) {
                 return Ok(tag);
             }
+        }
+        if self.require_device_binding {
+            return Err(ProbeFailure::Unreachable);
         }
         // 2. Fall back to the first non-direct outbound, then the first
         //    wireguard endpoint (a gateway with only wg nodes has no usable
@@ -646,6 +661,35 @@ mod tests {
         let _ = probe.probe_exit_ip();
         std::fs::remove_file(&config_path).unwrap();
         let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-fallback-work"));
+    }
+
+    #[test]
+    fn required_device_binding_never_falls_back_to_another_outbound() {
+        let doc = json!({"outbounds": [
+            {"type": "hysteria2", "tag": "node-a"},
+            {"type": "direct", "tag": "direct"}
+        ]});
+        let dir = std::env::temp_dir();
+        let config_path = dir.join("wloc-singbox-required-binding.json");
+        let uci_path = dir.join("wloc-singbox-required-binding-uci");
+        std::fs::write(&config_path, doc.to_string()).unwrap();
+        std::fs::write(
+            &uci_path,
+            "config device\n\tlist source_ip '192.168.31.177'\n",
+        )
+        .unwrap();
+        let mut probe = SingBoxProbe::new(
+            config_path.clone(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 31, 176)),
+            18080,
+            dir.join("wloc-singbox-required-binding-work"),
+        )
+        .with_required_device_binding();
+        probe.uci_config_path = uci_path.clone();
+        assert_eq!(probe.load_outbound_tag(), Err(ProbeFailure::Unreachable));
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::remove_file(&uci_path).unwrap();
+        let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-binding-work"));
     }
 
     #[test]

--- a/src/exitprobe/singbox.rs
+++ b/src/exitprobe/singbox.rs
@@ -335,7 +335,19 @@ impl SingBoxProbe {
         //    which the Gateway compiler names `wg-<section>` (sing-box
         //    1.11+), while the UCI binding resolves to `node-<section>`.
         let uci_text = std::fs::read_to_string(&self.uci_config_path).ok();
-        if let Some(tag) = select_node_tag(&document, uci_text.as_deref(), self.device_ip) {
+        let selected_tag = if self.require_device_binding {
+            // A profile-bound probe must never trust a generated route rule
+            // as a substitute for the Gateway's device policy. Route rules
+            // can be stale or orphaned after a node switch; accepting one
+            // here would let the probe follow a different device/node than
+            // the profile explicitly selected.
+            uci_text
+                .as_deref()
+                .and_then(|text| device_bound_node_tag(text, self.device_ip))
+        } else {
+            select_node_tag(&document, uci_text.as_deref(), self.device_ip)
+        };
+        if let Some(tag) = selected_tag {
             if config.outbounds.iter().any(|o| o.tag == tag) {
                 return Ok(tag);
             }
@@ -690,6 +702,43 @@ mod tests {
         std::fs::remove_file(&config_path).unwrap();
         std::fs::remove_file(&uci_path).unwrap();
         let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-binding-work"));
+    }
+
+    #[test]
+    fn required_device_binding_rejects_route_only_match() {
+        // A stale generated route rule can still point this device at an
+        // outbound even when Gateway UCI has no matching device policy. A
+        // profile-bound probe must reject that route-only match.
+        let doc = json!({
+            "outbounds": [
+                {"type": "hysteria2", "tag": "node-a"},
+                {"type": "direct", "tag": "direct"}
+            ],
+            "route": {"rules": [
+                {"source_ip_cidr": ["192.168.31.176/32"], "action": "route", "outbound": "node-a"}
+            ]}
+        });
+        let dir = std::env::temp_dir();
+        let config_path = dir.join("wloc-singbox-required-route-only.json");
+        let uci_path = dir.join("wloc-singbox-required-route-only-uci");
+        std::fs::write(&config_path, doc.to_string()).unwrap();
+        std::fs::write(
+            &uci_path,
+            "config device\n\tlist source_ip '192.168.31.177'\n",
+        )
+        .unwrap();
+        let mut probe = SingBoxProbe::new(
+            config_path.clone(),
+            IpAddr::V4(Ipv4Addr::new(192, 168, 31, 176)),
+            18080,
+            dir.join("wloc-singbox-required-route-only-work"),
+        )
+        .with_required_device_binding();
+        probe.uci_config_path = uci_path.clone();
+        assert_eq!(probe.load_outbound_tag(), Err(ProbeFailure::Unreachable));
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::remove_file(&uci_path).unwrap();
+        let _ = std::fs::remove_dir_all(dir.join("wloc-singbox-required-route-only-work"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,7 @@ pub mod wloc;
 /// deliberately limited to the two exact Apple names required by the
 /// OpenWrt traffic-isolation contract; DNS CNAME targets are not interception
 /// hostnames.
-pub const APPROVED_WLOC_HOSTS: [&str; 2] = [
-    "gs-loc.apple.com",
-    "gs-loc-cn.apple.com",
-];
+pub const APPROVED_WLOC_HOSTS: [&str; 2] = ["gs-loc.apple.com", "gs-loc-cn.apple.com"];
 pub const MAX_WLOC_BODY_BYTES: u64 = 512 * 1024;
 const MIN_H2_FRAME_SIZE: u32 = 16 * 1024;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,14 +15,13 @@ pub mod service;
 pub mod tls_h2;
 pub mod wloc;
 
-/// Approved WLOC hostnames whose traffic may be intercepted. The Apple names
-/// CNAME to the autonavi bluedot service, so a real request can arrive with
-/// either the Apple or the bluedot hostname as its SNI/Host.
-pub const APPROVED_WLOC_HOSTS: [&str; 4] = [
+/// Approved WLOC hostnames whose traffic may be intercepted. The scope is
+/// deliberately limited to the two exact Apple names required by the
+/// OpenWrt traffic-isolation contract; DNS CNAME targets are not interception
+/// hostnames.
+pub const APPROVED_WLOC_HOSTS: [&str; 2] = [
     "gs-loc.apple.com",
     "gs-loc-cn.apple.com",
-    "bluedot.is.autonavi.com",
-    "bluedot.is.autonavi.com.gds.alibabadns.com",
 ];
 pub const MAX_WLOC_BODY_BYTES: u64 = 512 * 1024;
 const MIN_H2_FRAME_SIZE: u32 = 16 * 1024;

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -411,6 +411,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn synthesized_client_cache_has_entry_and_byte_bounds() {
+        let mut cache = HashMap::new();
+        for index in 0..(MAX_SYNTHESIZED_CLIENTS * 2) {
+            cache_synthesized_payload(
+                &mut cache,
+                &format!("192.0.2.{index}"),
+                vec![0_u8; MAX_SYNTHESIZED_PAYLOAD_BYTES / 2],
+            );
+        }
+        assert!(cache.len() <= MAX_SYNTHESIZED_CLIENTS);
+        assert!(cache.values().map(Vec::len).sum::<usize>() <= MAX_SYNTHESIZED_CACHE_BYTES);
+
+        cache_synthesized_payload(
+            &mut cache,
+            "oversized",
+            vec![0_u8; MAX_SYNTHESIZED_PAYLOAD_BYTES + 1],
+        );
+        assert!(!cache.contains_key("oversized"));
+    }
+
+    #[test]
     fn dump_wloc_samples_writes_three_files() {
         let dir = std::env::temp_dir().join(format!("wloc-dump-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -28,6 +28,7 @@ const MAX_STREAMS: usize = 8;
 const MAX_SYNTHESIZED_CLIENTS: usize = 16;
 const MAX_SYNTHESIZED_CACHE_BYTES: usize = 64 * 1024;
 const MAX_SYNTHESIZED_PAYLOAD_BYTES: usize = 16 * 1024;
+const MAX_DEBUG_SAMPLE_BYTES: usize = 16 * 1024;
 
 /// HTTP/2 MITM proxy bound to one approved hostname's traffic.
 #[derive(Clone)]
@@ -369,18 +370,23 @@ pub(crate) fn dump_wloc_samples(
         .unwrap_or(0);
     let _ = std::fs::create_dir_all(dir);
     let safe = hostname.replace(['/', ':', '.'], "_");
-    let _ = std::fs::write(
-        format!("{dir}/{stamp}_{client_addr}_{safe}_req.bin"),
+    write_bounded_sample(
+        &format!("{dir}/{stamp}_{client_addr}_{safe}_req.bin"),
         request,
     );
-    let _ = std::fs::write(
-        format!("{dir}/{stamp}_{client_addr}_{safe}_resp.bin"),
+    write_bounded_sample(
+        &format!("{dir}/{stamp}_{client_addr}_{safe}_resp.bin"),
         response,
     );
-    let _ = std::fs::write(
-        format!("{dir}/{stamp}_{client_addr}_{safe}_patched.bin"),
+    write_bounded_sample(
+        &format!("{dir}/{stamp}_{client_addr}_{safe}_patched.bin"),
         patched,
     );
+}
+
+fn write_bounded_sample(path: &str, bytes: &[u8]) {
+    let end = bytes.len().min(MAX_DEBUG_SAMPLE_BYTES);
+    let _ = std::fs::write(path, &bytes[..end]);
 }
 
 fn maybe_patch_body(body: &[u8], is_wloc: bool, patch: Option<&PatchTarget>) -> Vec<u8> {

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -211,11 +211,7 @@ impl MitmProxy {
                                 return Ok((request_body.len(), out));
                             }
                         } else if let Ok(mut cache) = self.synthesized_payloads.lock() {
-                            cache_synthesized_payload(
-                                &mut cache,
-                                client_addr,
-                                payload.to_vec(),
-                            );
+                            cache_synthesized_payload(&mut cache, client_addr, payload.to_vec());
                         }
                         eprintln!(
                             "wloc proxy: synthesized {} -> {} bytes (is_wloc={is_wloc})",
@@ -406,7 +402,10 @@ fn cache_synthesized_payload(
     }
     cache.remove(client_addr);
     while cache.len() >= MAX_SYNTHESIZED_CLIENTS
-        || cache.values().map(Vec::len).sum::<usize>()
+        || cache
+            .values()
+            .map(Vec::len)
+            .sum::<usize>()
             .saturating_add(payload.len())
             > MAX_SYNTHESIZED_CACHE_BYTES
     {

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -487,4 +487,23 @@ mod tests {
         assert!(names.iter().any(|n| n.ends_with("_patched.bin")));
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn debug_samples_are_bounded() {
+        let dir = std::env::temp_dir().join(format!("wloc-dump-bound-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let large = vec![b'x'; MAX_DEBUG_SAMPLE_BYTES * 2];
+        dump_wloc_samples(
+            dir.to_str().unwrap(),
+            "gs-loc.apple.com",
+            "192.168.31.175",
+            &large,
+            &large,
+            &large,
+        );
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            assert!(entry.unwrap().metadata().unwrap().len() <= MAX_DEBUG_SAMPLE_BYTES as u64);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -24,6 +24,10 @@ pub const WLOC_PATH: &str = "/clls/wloc";
 const MAX_FORWARD_BODY_BYTES: usize = 512 * 1024;
 /// Concurrent upstream streams per client connection.
 const MAX_STREAMS: usize = 8;
+/// Resource bounds for the per-client synthesis cache on small gateways.
+const MAX_SYNTHESIZED_CLIENTS: usize = 16;
+const MAX_SYNTHESIZED_CACHE_BYTES: usize = 64 * 1024;
+const MAX_SYNTHESIZED_PAYLOAD_BYTES: usize = 16 * 1024;
 
 /// HTTP/2 MITM proxy bound to one approved hostname's traffic.
 #[derive(Clone)]
@@ -206,7 +210,11 @@ impl MitmProxy {
                                 return Ok((request_body.len(), out));
                             }
                         } else if let Ok(mut cache) = self.synthesized_payloads.lock() {
-                            cache.insert(client_addr.to_string(), payload.to_vec());
+                            cache_synthesized_payload(
+                                &mut cache,
+                                client_addr,
+                                payload.to_vec(),
+                            );
                         }
                         eprintln!(
                             "wloc proxy: synthesized {} -> {} bytes (is_wloc={is_wloc})",
@@ -380,6 +388,28 @@ fn maybe_patch_body(body: &[u8], is_wloc: bool, patch: Option<&PatchTarget>) -> 
         Some(patch) if is_wloc => patch_wloc_response(body, patch),
         _ => body.to_vec(),
     }
+}
+
+fn cache_synthesized_payload(
+    cache: &mut HashMap<String, Vec<u8>>,
+    client_addr: &str,
+    payload: Vec<u8>,
+) {
+    if payload.is_empty() || payload.len() > MAX_SYNTHESIZED_PAYLOAD_BYTES {
+        return;
+    }
+    cache.remove(client_addr);
+    while cache.len() >= MAX_SYNTHESIZED_CLIENTS
+        || cache.values().map(Vec::len).sum::<usize>()
+            .saturating_add(payload.len())
+            > MAX_SYNTHESIZED_CACHE_BYTES
+    {
+        let Some(oldest) = cache.keys().next().cloned() else {
+            break;
+        };
+        cache.remove(&oldest);
+    }
+    cache.insert(client_addr.to_owned(), payload);
 }
 
 /// Proxy-level failure; the caller treats any error as "close this

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -7,11 +7,224 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::{
+    validate_device_address, validate_location_ref, validate_node_ref, validate_profile_id,
+    validate_profile_label,
+};
+
 pub const SERVICE_API_ID: &str = "wloc.service/v1";
+pub const SERVICE_API_V2_ID: &str = "wloc.service/v2";
 /// Single source of truth for the control-frame size bound. Re-exported from
 /// the transport codec so the API decoder and the frame layer cannot drift.
 pub use crate::runtime::uds::MAX_CONTROL_FRAME_BYTES;
 const MAX_REQUEST_ID_BYTES: usize = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileApiMethod {
+    List,
+    Get,
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApiV2ErrorCode {
+    FrameTooLarge,
+    MalformedRequest,
+    IncompatibleVersion,
+    InvalidRequestId,
+    UnknownMethod,
+    InvalidParams,
+}
+
+impl ApiV2ErrorCode {
+    pub const fn wire_code(self) -> &'static str {
+        match self {
+            Self::FrameTooLarge => "frame_too_large",
+            Self::MalformedRequest => "malformed_request",
+            Self::IncompatibleVersion => "incompatible_version",
+            Self::InvalidRequestId => "invalid_request_id",
+            Self::UnknownMethod => "unknown_method",
+            Self::InvalidParams => "invalid_params",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ProfileRequestParams {
+    pub profile_id: Option<String>,
+    pub label: Option<String>,
+    pub assigned_device: Option<String>,
+    pub node_ref: Option<String>,
+    pub node_mode: Option<String>,
+    pub geo_source: Option<String>,
+    pub manual_latitude: Option<f64>,
+    pub manual_longitude: Option<f64>,
+    pub manual_location_ref: Option<String>,
+    pub enabled: Option<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ApiV2ProfileRequest {
+    api_version: String,
+    request_id: String,
+    method: ProfileApiMethod,
+    params: ProfileRequestParams,
+}
+
+impl ApiV2ProfileRequest {
+    pub fn api_version(&self) -> &str {
+        &self.api_version
+    }
+
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
+    pub const fn method(&self) -> ProfileApiMethod {
+        self.method
+    }
+
+    pub fn params(&self) -> &ProfileRequestParams {
+        &self.params
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WireV2ProfileRequest {
+    api_version: String,
+    request_id: String,
+    method: String,
+    #[serde(default)]
+    params: WireV2ProfileParams,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct WireV2ProfileParams {
+    #[serde(default)]
+    profile_id: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    assigned_device: Option<String>,
+    #[serde(default)]
+    node_ref: Option<String>,
+    #[serde(default)]
+    node_mode: Option<String>,
+    #[serde(default)]
+    geo_source: Option<String>,
+    #[serde(default)]
+    manual_lat: Option<f64>,
+    #[serde(default)]
+    manual_lon: Option<f64>,
+    #[serde(default)]
+    manual_location_ref: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+impl From<WireV2ProfileParams> for ProfileRequestParams {
+    fn from(params: WireV2ProfileParams) -> Self {
+        Self {
+            profile_id: params.profile_id,
+            label: params.label,
+            assigned_device: params.assigned_device,
+            node_ref: params.node_ref,
+            node_mode: params.node_mode,
+            geo_source: params.geo_source,
+            manual_latitude: params.manual_lat,
+            manual_longitude: params.manual_lon,
+            manual_location_ref: params.manual_location_ref,
+            enabled: params.enabled,
+        }
+    }
+}
+
+/// Decode profile-management requests for the additive v2 API. Runtime
+/// dispatch is intentionally a later issue; decoding and validation are
+/// complete before any handler can receive the request.
+pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, ApiV2ErrorCode> {
+    if frame.is_empty() {
+        return Err(ApiV2ErrorCode::MalformedRequest);
+    }
+    if frame.len() > MAX_CONTROL_FRAME_BYTES {
+        return Err(ApiV2ErrorCode::FrameTooLarge);
+    }
+    let wire: WireV2ProfileRequest =
+        serde_json::from_slice(frame).map_err(|_| ApiV2ErrorCode::MalformedRequest)?;
+    if wire.api_version != SERVICE_API_V2_ID {
+        return Err(ApiV2ErrorCode::IncompatibleVersion);
+    }
+    if !valid_request_id(&wire.request_id) {
+        return Err(ApiV2ErrorCode::InvalidRequestId);
+    }
+    let method = match wire.method.as_str() {
+        "profile.list" => ProfileApiMethod::List,
+        "profile.get" => ProfileApiMethod::Get,
+        "profile.create" => ProfileApiMethod::Create,
+        "profile.update" => ProfileApiMethod::Update,
+        "profile.delete" => ProfileApiMethod::Delete,
+        _ => return Err(ApiV2ErrorCode::UnknownMethod),
+    };
+    if let Some(profile_id) = wire.params.profile_id.as_deref() {
+        validate_profile_id(profile_id).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if matches!(
+        method,
+        ProfileApiMethod::Get | ProfileApiMethod::Update | ProfileApiMethod::Delete
+    ) && wire.params.profile_id.is_none()
+    {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
+    validate_v2_profile_params(&wire.params)?;
+    Ok(ApiV2ProfileRequest {
+        api_version: wire.api_version,
+        request_id: wire.request_id,
+        method,
+        params: wire.params.into(),
+    })
+}
+
+fn validate_v2_profile_params(params: &WireV2ProfileParams) -> Result<(), ApiV2ErrorCode> {
+    if let Some(label) = params.label.as_deref() {
+        validate_profile_label(label).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(address) = params.assigned_device.as_deref() {
+        validate_device_address(address).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(node_ref) = params.node_ref.as_deref() {
+        validate_node_ref(node_ref).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if let Some(node_mode) = params.node_mode.as_deref() {
+        if !matches!(node_mode, "fixed" | "gateway_default") {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    if let Some(geo_source) = params.geo_source.as_deref() {
+        if !matches!(geo_source, "auto" | "manual") {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    if let Some(reference) = params.manual_location_ref.as_deref() {
+        validate_location_ref(reference).map_err(|_| ApiV2ErrorCode::InvalidParams)?;
+    }
+    if params.manual_lat.is_some() != params.manual_lon.is_some() {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
+    if let (Some(latitude), Some(longitude)) = (params.manual_lat, params.manual_lon) {
+        if !latitude.is_finite()
+            || !longitude.is_finite()
+            || !(-90.0..=90.0).contains(&latitude)
+            || !(-180.0..=180.0).contains(&longitude)
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
+    Ok(())
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ApiMethod {
@@ -204,8 +417,8 @@ struct ErrorResponse<'a> {
 }
 
 #[derive(Serialize)]
-struct ResultResponse {
-    api_version: &'static str,
+struct VersionedResultResponse<'a> {
+    api_version: &'a str,
     request_id: String,
     result: serde_json::Value,
 }
@@ -257,8 +470,25 @@ pub fn encode_result_response(
     request_id: &str,
     result: &serde_json::Value,
 ) -> Result<Vec<u8>, ResponseEncodeError> {
-    let response = ResultResponse {
-        api_version: SERVICE_API_ID,
+    encode_versioned_result_response(SERVICE_API_ID, request_id, result)
+}
+
+/// Encode a bounded v2 profile response. Runtime dispatch remains a later
+/// issue, but UI clients can share the reviewed v1/v2 envelope shape.
+pub fn encode_v2_result_response(
+    request_id: &str,
+    result: &serde_json::Value,
+) -> Result<Vec<u8>, ResponseEncodeError> {
+    encode_versioned_result_response(SERVICE_API_V2_ID, request_id, result)
+}
+
+fn encode_versioned_result_response(
+    api_version: &str,
+    request_id: &str,
+    result: &serde_json::Value,
+) -> Result<Vec<u8>, ResponseEncodeError> {
+    let response = VersionedResultResponse {
+        api_version,
         request_id: request_id.to_owned(),
         result: result.clone(),
     };

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -186,6 +186,23 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
     {
         return Err(ApiV2ErrorCode::InvalidParams);
     }
+    if method == ProfileApiMethod::Create {
+        if wire.params.profile_id.is_none()
+            || wire.params.label.is_none()
+            || wire.params.assigned_device.is_none()
+            || wire.params.node_ref.is_none()
+            || wire.params.node_mode.is_none()
+            || wire.params.geo_source.is_none()
+            || wire.params.enabled.is_none()
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+        if wire.params.geo_source.as_deref() == Some("manual")
+            && (wire.params.manual_lat.is_none() || wire.params.manual_lon.is_none())
+        {
+            return Err(ApiV2ErrorCode::InvalidParams);
+        }
+    }
     validate_v2_profile_params(&wire.params)?;
     Ok(ApiV2ProfileRequest {
         api_version: wire.api_version,

--- a/src/service/api.rs
+++ b/src/service/api.rs
@@ -179,6 +179,13 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
     {
         return Err(ApiV2ErrorCode::InvalidParams);
     }
+    if matches!(
+        method,
+        ProfileApiMethod::List | ProfileApiMethod::Get | ProfileApiMethod::Delete
+    ) && has_non_identity_profile_params(&wire.params)
+    {
+        return Err(ApiV2ErrorCode::InvalidParams);
+    }
     validate_v2_profile_params(&wire.params)?;
     Ok(ApiV2ProfileRequest {
         api_version: wire.api_version,
@@ -186,6 +193,18 @@ pub fn decode_v2_profile_request(frame: &[u8]) -> Result<ApiV2ProfileRequest, Ap
         method,
         params: wire.params.into(),
     })
+}
+
+fn has_non_identity_profile_params(params: &WireV2ProfileParams) -> bool {
+    params.label.is_some()
+        || params.assigned_device.is_some()
+        || params.node_ref.is_some()
+        || params.node_mode.is_some()
+        || params.geo_source.is_some()
+        || params.manual_lat.is_some()
+        || params.manual_lon.is_some()
+        || params.manual_location_ref.is_some()
+        || params.enabled.is_some()
 }
 
 fn validate_v2_profile_params(params: &WireV2ProfileParams) -> Result<(), ApiV2ErrorCode> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -16,6 +16,7 @@ pub mod dispatch;
 pub mod server;
 pub mod state;
 pub mod status;
+pub mod supervisor;
 
 pub const SERVICE_API_VERSION: u16 = 1;
 const MAX_CONNECTIONS: u16 = 32;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -12,6 +12,7 @@ use crate::APPROVED_WLOC_HOSTS;
 pub mod api;
 pub mod control;
 pub mod dispatch;
+pub mod profile_runtime;
 #[cfg(unix)]
 pub mod server;
 pub mod state;

--- a/src/service/profile_runtime.rs
+++ b/src/service/profile_runtime.rs
@@ -50,10 +50,7 @@ pub trait ProfileRuntimeControl {
         profile: &DeviceProfile,
     ) -> Result<(), ProfileRuntimeError>;
     fn remove_profile_redirect(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError>;
-    fn profile_redirect_present(
-        &mut self,
-        profile_id: &str,
-    ) -> Result<bool, ProfileRuntimeError>;
+    fn profile_redirect_present(&mut self, profile_id: &str) -> Result<bool, ProfileRuntimeError>;
 }
 
 pub struct ProfileRuntimeManager<R: ProfileRuntimeControl> {
@@ -125,15 +122,13 @@ impl<R: ProfileRuntimeControl> ProfileRuntimeManager<R> {
         }
 
         self.set_status(index, ProfileRuntimePhase::Preparing, "preparing");
-        if !self.shared_engine_ready {
-            if self.runtime.ensure_shared_engine().is_err() {
-                self.set_status(
-                    index,
-                    ProfileRuntimePhase::DegradedPassthrough,
-                    "engine_start_failed",
-                );
-                return Err(ProfileRuntimeError::EngineStart);
-            }
+        if !self.shared_engine_ready && self.runtime.ensure_shared_engine().is_err() {
+            self.set_status(
+                index,
+                ProfileRuntimePhase::DegradedPassthrough,
+                "engine_start_failed",
+            );
+            return Err(ProfileRuntimeError::EngineStart);
         }
         // Health is sampled for every new profile admission. The shared
         // process may have degraded after an earlier profile was enabled.
@@ -163,11 +158,9 @@ impl<R: ProfileRuntimeControl> ProfileRuntimeManager<R> {
                 ProfileRuntimeError::RedirectStillPresent,
                 profile_id,
             ),
-            Err(_) => self.fail_profile_redirect(
-                index,
-                ProfileRuntimeError::CleanupUnsafe,
-                profile_id,
-            ),
+            Err(_) => {
+                self.fail_profile_redirect(index, ProfileRuntimeError::CleanupUnsafe, profile_id)
+            }
         }
     }
 
@@ -231,10 +224,18 @@ impl<R: ProfileRuntimeControl> ProfileRuntimeManager<R> {
         profile_id: &str,
     ) -> Result<(), ProfileRuntimeError> {
         if self.runtime.remove_profile_redirect(profile_id).is_err() {
-            self.set_status(index, ProfileRuntimePhase::DegradedPassthrough, "cleanup_unsafe");
+            self.set_status(
+                index,
+                ProfileRuntimePhase::DegradedPassthrough,
+                "cleanup_unsafe",
+            );
             return Err(ProfileRuntimeError::CleanupUnsafe);
         }
-        self.set_status(index, ProfileRuntimePhase::DegradedPassthrough, reason_for(error));
+        self.set_status(
+            index,
+            ProfileRuntimePhase::DegradedPassthrough,
+            reason_for(error),
+        );
         Err(error)
     }
 }

--- a/src/service/profile_runtime.rs
+++ b/src/service/profile_runtime.rs
@@ -1,0 +1,254 @@
+//! Runtime ownership for independent v2 device profiles.
+//!
+//! A profile owns only its own WLOC redirect and status. Gateway/sing-box is a
+//! shared resource: it is prepared and health-checked once, then profiles are
+//! admitted independently. The manager never selects an arbitrary profile or
+//! node and never stops the shared Gateway when one profile fails.
+
+use std::net::IpAddr;
+
+use crate::config::{DeviceProfile, ProfileModel};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileRuntimePhase {
+    Disabled,
+    Preparing,
+    Passthrough,
+    Intercepting,
+    DegradedPassthrough,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProfileRuntimeStatus {
+    pub profile_id: String,
+    pub phase: ProfileRuntimePhase,
+    pub reason_code: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfileRuntimeError {
+    UnknownProfile,
+    ProfileDisabled,
+    UnsupportedDevice,
+    EngineStart,
+    EngineUnhealthy,
+    RedirectInstall,
+    RedirectStillPresent,
+    CleanupUnsafe,
+}
+
+/// OpenWrt adapter implemented by the product runtime.
+///
+/// Methods are profile-scoped for redirect operations. Engine operations are
+/// deliberately shared so adding a profile cannot create another sing-box or
+/// WLOC process on a small gateway.
+pub trait ProfileRuntimeControl {
+    fn ensure_shared_engine(&mut self) -> Result<(), ProfileRuntimeError>;
+    fn shared_engine_healthy(&mut self) -> Result<bool, ProfileRuntimeError>;
+    fn install_profile_redirect(
+        &mut self,
+        profile: &DeviceProfile,
+    ) -> Result<(), ProfileRuntimeError>;
+    fn remove_profile_redirect(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError>;
+    fn profile_redirect_present(
+        &mut self,
+        profile_id: &str,
+    ) -> Result<bool, ProfileRuntimeError>;
+}
+
+pub struct ProfileRuntimeManager<R: ProfileRuntimeControl> {
+    model: ProfileModel,
+    runtime: R,
+    statuses: Vec<ProfileRuntimeStatus>,
+    shared_engine_ready: bool,
+}
+
+impl<R: ProfileRuntimeControl> ProfileRuntimeManager<R> {
+    pub fn new(model: ProfileModel, runtime: R) -> Self {
+        let statuses = model
+            .profiles()
+            .iter()
+            .map(|profile| ProfileRuntimeStatus {
+                profile_id: profile.id.clone(),
+                phase: ProfileRuntimePhase::Disabled,
+                reason_code: "disabled",
+            })
+            .collect();
+        Self {
+            model,
+            runtime,
+            statuses,
+            shared_engine_ready: false,
+        }
+    }
+
+    pub fn model(&self) -> &ProfileModel {
+        &self.model
+    }
+
+    pub fn runtime(&self) -> &R {
+        &self.runtime
+    }
+
+    pub fn runtime_mut(&mut self) -> &mut R {
+        &mut self.runtime
+    }
+
+    pub fn statuses(&self) -> &[ProfileRuntimeStatus] {
+        &self.statuses
+    }
+
+    pub fn status(&self, profile_id: &str) -> Result<&ProfileRuntimeStatus, ProfileRuntimeError> {
+        self.statuses
+            .iter()
+            .find(|status| status.profile_id == profile_id)
+            .ok_or(ProfileRuntimeError::UnknownProfile)
+    }
+
+    pub fn enable(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError> {
+        let index = self.profile_index(profile_id)?;
+        let profile = self.model.profiles()[index].clone();
+        if !profile.enabled {
+            self.set_status(index, ProfileRuntimePhase::Disabled, "profile_disabled");
+            return Err(ProfileRuntimeError::ProfileDisabled);
+        }
+        if !runtime_device_supported(&profile) {
+            self.set_status(
+                index,
+                ProfileRuntimePhase::DegradedPassthrough,
+                "unsupported_device_binding",
+            );
+            return Err(ProfileRuntimeError::UnsupportedDevice);
+        }
+        if self.statuses[index].phase == ProfileRuntimePhase::Intercepting {
+            return Ok(());
+        }
+
+        self.set_status(index, ProfileRuntimePhase::Preparing, "preparing");
+        if !self.shared_engine_ready {
+            if self.runtime.ensure_shared_engine().is_err() {
+                self.set_status(
+                    index,
+                    ProfileRuntimePhase::DegradedPassthrough,
+                    "engine_start_failed",
+                );
+                return Err(ProfileRuntimeError::EngineStart);
+            }
+            match self.runtime.shared_engine_healthy() {
+                Ok(true) => self.shared_engine_ready = true,
+                Ok(false) | Err(_) => {
+                    self.set_status(
+                        index,
+                        ProfileRuntimePhase::DegradedPassthrough,
+                        "engine_unhealthy",
+                    );
+                    return Err(ProfileRuntimeError::EngineUnhealthy);
+                }
+            }
+        }
+
+        if let Err(error) = self.runtime.install_profile_redirect(&profile) {
+            return self.fail_profile_redirect(index, error, profile_id);
+        }
+        match self.runtime.profile_redirect_present(profile_id) {
+            Ok(true) => {
+                self.set_status(index, ProfileRuntimePhase::Intercepting, "intercepting");
+                Ok(())
+            }
+            Ok(false) => self.fail_profile_redirect(
+                index,
+                ProfileRuntimeError::RedirectStillPresent,
+                profile_id,
+            ),
+            Err(_) => self.fail_profile_redirect(
+                index,
+                ProfileRuntimeError::CleanupUnsafe,
+                profile_id,
+            ),
+        }
+    }
+
+    pub fn disable(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError> {
+        let index = self.profile_index(profile_id)?;
+        if self.statuses[index].phase == ProfileRuntimePhase::Disabled {
+            return Ok(());
+        }
+        if self.runtime.remove_profile_redirect(profile_id).is_err() {
+            self.set_status(
+                index,
+                ProfileRuntimePhase::DegradedPassthrough,
+                "cleanup_unsafe",
+            );
+            return Err(ProfileRuntimeError::CleanupUnsafe);
+        }
+        match self.runtime.profile_redirect_present(profile_id) {
+            Ok(false) => {
+                self.set_status(index, ProfileRuntimePhase::Disabled, "disabled");
+                Ok(())
+            }
+            Ok(true) | Err(_) => {
+                self.set_status(
+                    index,
+                    ProfileRuntimePhase::DegradedPassthrough,
+                    "cleanup_unsafe",
+                );
+                Err(ProfileRuntimeError::CleanupUnsafe)
+            }
+        }
+    }
+
+    pub fn reload(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError> {
+        let phase = self.status(profile_id)?.phase;
+        if phase != ProfileRuntimePhase::Disabled {
+            self.disable(profile_id)?;
+        }
+        self.enable(profile_id)
+    }
+
+    fn profile_index(&self, profile_id: &str) -> Result<usize, ProfileRuntimeError> {
+        self.model
+            .profiles()
+            .iter()
+            .position(|profile| profile.id == profile_id)
+            .ok_or(ProfileRuntimeError::UnknownProfile)
+    }
+
+    fn set_status(&mut self, index: usize, phase: ProfileRuntimePhase, reason_code: &'static str) {
+        self.statuses[index] = ProfileRuntimeStatus {
+            profile_id: self.statuses[index].profile_id.clone(),
+            phase,
+            reason_code,
+        };
+    }
+
+    fn fail_profile_redirect(
+        &mut self,
+        index: usize,
+        error: ProfileRuntimeError,
+        profile_id: &str,
+    ) -> Result<(), ProfileRuntimeError> {
+        if self.runtime.remove_profile_redirect(profile_id).is_err() {
+            self.set_status(index, ProfileRuntimePhase::DegradedPassthrough, "cleanup_unsafe");
+            return Err(ProfileRuntimeError::CleanupUnsafe);
+        }
+        self.set_status(index, ProfileRuntimePhase::DegradedPassthrough, reason_for(error));
+        Err(error)
+    }
+}
+
+fn runtime_device_supported(profile: &DeviceProfile) -> bool {
+    profile
+        .assigned_device
+        .as_deref()
+        .and_then(|address| address.parse::<IpAddr>().ok())
+        .is_some()
+}
+
+fn reason_for(error: ProfileRuntimeError) -> &'static str {
+    match error {
+        ProfileRuntimeError::RedirectInstall => "redirect_install_failed",
+        ProfileRuntimeError::RedirectStillPresent => "redirect_not_confirmed",
+        ProfileRuntimeError::CleanupUnsafe => "cleanup_unsafe",
+        _ => "profile_runtime_failed",
+    }
+}

--- a/src/service/profile_runtime.rs
+++ b/src/service/profile_runtime.rs
@@ -134,16 +134,19 @@ impl<R: ProfileRuntimeControl> ProfileRuntimeManager<R> {
                 );
                 return Err(ProfileRuntimeError::EngineStart);
             }
-            match self.runtime.shared_engine_healthy() {
-                Ok(true) => self.shared_engine_ready = true,
-                Ok(false) | Err(_) => {
-                    self.set_status(
-                        index,
-                        ProfileRuntimePhase::DegradedPassthrough,
-                        "engine_unhealthy",
-                    );
-                    return Err(ProfileRuntimeError::EngineUnhealthy);
-                }
+        }
+        // Health is sampled for every new profile admission. The shared
+        // process may have degraded after an earlier profile was enabled.
+        match self.runtime.shared_engine_healthy() {
+            Ok(true) => self.shared_engine_ready = true,
+            Ok(false) | Err(_) => {
+                self.shared_engine_ready = false;
+                self.set_status(
+                    index,
+                    ProfileRuntimePhase::DegradedPassthrough,
+                    "engine_unhealthy",
+                );
+                return Err(ProfileRuntimeError::EngineUnhealthy);
             }
         }
 

--- a/src/service/supervisor.rs
+++ b/src/service/supervisor.rs
@@ -73,6 +73,10 @@ pub enum SupervisorPhase {
     Intercepting,
     DegradedPassthrough,
     Draining,
+    /// Cleanup could not prove that the component-owned redirect is absent.
+    /// The state is deliberately conservative so callers never mistake an
+    /// uncertain firewall state for a cleanly stopped service.
+    CleanupUnsafe,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -356,7 +360,11 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         .map_err(SupervisorError::Transition)?;
 
         if let Err(error) = control::enable(&mut self.runtime, scope_valid, ipv6_ready) {
-            self.fail_and_stop();
+            if matches!(error, ControlError::CleanupUnsafe) {
+                self.enter_cleanup_unsafe();
+            } else {
+                self.state = SupervisorState::stopped();
+            }
             return Err(SupervisorError::Control(error));
         }
         self.state = reduce(&self.state, SupervisorEvent::ChildrenReady, self.limits)
@@ -372,7 +380,7 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         self.state = reduce(&self.state, SupervisorEvent::StopRequested, self.limits)
             .map_err(SupervisorError::Transition)?;
         if let Err(error) = control::disable(&mut self.runtime) {
-            self.state = SupervisorState::stopped();
+            self.enter_cleanup_unsafe();
             return Err(SupervisorError::Control(error));
         }
         self.state = reduce(&self.state, SupervisorEvent::ChildrenStopped, self.limits)
@@ -381,8 +389,9 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
     }
 
     pub fn record_crash(&mut self, now_unix: u64) -> RestartDecision {
-        self.state = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits)
-            .unwrap_or_else(|_| SupervisorState::stopped());
+        if let Ok(next) = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits) {
+            self.state = next;
+        }
         let decision = self.restart_budget.decide(now_unix, self.limits);
         if matches!(decision, RestartDecision::Allowed { .. }) {
             self.restart_budget.record_attempt(now_unix, self.limits);
@@ -390,8 +399,16 @@ impl<R: RuntimeControl> UnifiedSupervisor<R> {
         decision
     }
 
-    fn fail_and_stop(&mut self) {
-        self.state = SupervisorState::stopped();
+    fn enter_cleanup_unsafe(&mut self) {
+        self.state = SupervisorState {
+            phase: SupervisorPhase::CleanupUnsafe,
+            child_count: self.state.child_count.max(MANAGED_CHILDREN),
+            // A failed cleanup must be treated as possibly still installed.
+            redirect_present: true,
+            watchdog_armed: true,
+            scope_valid: self.state.scope_valid,
+            ipv6_ready: self.state.ipv6_ready,
+        };
     }
 }
 

--- a/src/service/supervisor.rs
+++ b/src/service/supervisor.rs
@@ -1,0 +1,402 @@
+//! Unified Gateway/WLOC lifecycle ownership.
+//!
+//! The supervisor is deliberately independent of procd and shell commands.
+//! It owns the ordering contract used by both the Rust control plane and the
+//! OpenWrt entry point: children start in passthrough, health is observed,
+//! the watchdog is armed, and only then may the component-owned redirect be
+//! installed. Failure and stop paths withdraw the redirect before children
+//! are drained or stopped.
+
+use std::time::Duration;
+
+use super::control::{self, ControlError, RuntimeControl};
+
+pub const MANAGED_CHILDREN: u8 = 2; // Gateway/sing-box + WLOC control/proxy
+pub const MAX_MANAGED_CHILDREN: u8 = 3; // includes one bounded probe child
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SupervisorLimits {
+    pub max_children: u8,
+    pub max_restart_attempts: u8,
+    pub restart_window: Duration,
+    pub initial_restart_backoff: Duration,
+    pub max_restart_backoff: Duration,
+    pub health_poll_interval: Duration,
+}
+
+impl Default for SupervisorLimits {
+    fn default() -> Self {
+        Self {
+            max_children: MAX_MANAGED_CHILDREN,
+            max_restart_attempts: 3,
+            restart_window: Duration::from_secs(300),
+            initial_restart_backoff: Duration::from_secs(5),
+            max_restart_backoff: Duration::from_secs(120),
+            health_poll_interval: Duration::from_secs(10),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorConfigError {
+    TooManyChildren,
+    InvalidRestartBudget,
+    InvalidHealthPollInterval,
+}
+
+impl SupervisorLimits {
+    pub fn validate(self) -> Result<(), SupervisorConfigError> {
+        if self.max_children == 0 || self.max_children > MAX_MANAGED_CHILDREN {
+            return Err(SupervisorConfigError::TooManyChildren);
+        }
+        if self.max_restart_attempts == 0
+            || self.restart_window.is_zero()
+            || self.initial_restart_backoff.is_zero()
+            || self.max_restart_backoff < self.initial_restart_backoff
+        {
+            return Err(SupervisorConfigError::InvalidRestartBudget);
+        }
+        if self.health_poll_interval.is_zero()
+            || self.health_poll_interval > Duration::from_secs(60)
+        {
+            return Err(SupervisorConfigError::InvalidHealthPollInterval);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorPhase {
+    Stopped,
+    StartingPassthrough,
+    ReadyPassthrough,
+    Intercepting,
+    DegradedPassthrough,
+    Draining,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SupervisorState {
+    phase: SupervisorPhase,
+    child_count: u8,
+    redirect_present: bool,
+    watchdog_armed: bool,
+    scope_valid: bool,
+    ipv6_ready: bool,
+}
+
+impl SupervisorState {
+    pub const fn stopped() -> Self {
+        Self {
+            phase: SupervisorPhase::Stopped,
+            child_count: 0,
+            redirect_present: false,
+            watchdog_armed: false,
+            scope_valid: false,
+            ipv6_ready: false,
+        }
+    }
+
+    pub const fn phase(self) -> SupervisorPhase {
+        self.phase
+    }
+
+    pub const fn child_count(self) -> u8 {
+        self.child_count
+    }
+
+    pub const fn redirect_present(self) -> bool {
+        self.redirect_present
+    }
+
+    pub const fn watchdog_armed(self) -> bool {
+        self.watchdog_armed
+    }
+
+    pub const fn scope_valid(self) -> bool {
+        self.scope_valid
+    }
+
+    pub const fn ipv6_ready(self) -> bool {
+        self.ipv6_ready
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorEvent {
+    StartRequested {
+        scope_valid: bool,
+        ipv6_ready: bool,
+        child_count: u8,
+    },
+    ChildrenReady,
+    WatchdogArmed,
+    RedirectInstalled,
+    HealthFailed,
+    StopRequested,
+    ChildrenStopped,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorTransitionError {
+    InvalidSafetyScope,
+    TooManyChildren,
+    SafetyPrerequisiteMissing,
+    InvalidTransition,
+}
+
+pub fn reduce(
+    current: &SupervisorState,
+    event: SupervisorEvent,
+    limits: SupervisorLimits,
+) -> Result<SupervisorState, SupervisorTransitionError> {
+    let mut next = *current;
+    match event {
+        SupervisorEvent::StartRequested {
+            scope_valid,
+            ipv6_ready,
+            child_count,
+        } => {
+            if current.phase != SupervisorPhase::Stopped {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            if !scope_valid || !ipv6_ready {
+                return Err(SupervisorTransitionError::InvalidSafetyScope);
+            }
+            if child_count == 0 || child_count > limits.max_children {
+                return Err(SupervisorTransitionError::TooManyChildren);
+            }
+            next.phase = SupervisorPhase::StartingPassthrough;
+            next.child_count = child_count;
+            next.scope_valid = true;
+            next.ipv6_ready = true;
+        }
+        SupervisorEvent::ChildrenReady => {
+            if current.phase != SupervisorPhase::StartingPassthrough {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.phase = SupervisorPhase::ReadyPassthrough;
+        }
+        SupervisorEvent::WatchdogArmed => {
+            if current.phase != SupervisorPhase::ReadyPassthrough {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.watchdog_armed = true;
+        }
+        SupervisorEvent::RedirectInstalled => {
+            if current.phase != SupervisorPhase::ReadyPassthrough
+                || !current.watchdog_armed
+                || !current.scope_valid
+                || !current.ipv6_ready
+            {
+                return Err(SupervisorTransitionError::SafetyPrerequisiteMissing);
+            }
+            next.phase = SupervisorPhase::Intercepting;
+            next.redirect_present = true;
+        }
+        SupervisorEvent::HealthFailed => {
+            if !matches!(
+                current.phase,
+                SupervisorPhase::StartingPassthrough
+                    | SupervisorPhase::ReadyPassthrough
+                    | SupervisorPhase::Intercepting
+            ) {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next.phase = SupervisorPhase::DegradedPassthrough;
+            next.redirect_present = false;
+            next.watchdog_armed = false;
+        }
+        SupervisorEvent::StopRequested => {
+            if current.phase == SupervisorPhase::Stopped {
+                return Ok(*current);
+            }
+            next.phase = SupervisorPhase::Draining;
+            next.redirect_present = false;
+            next.watchdog_armed = false;
+        }
+        SupervisorEvent::ChildrenStopped => {
+            if !matches!(
+                current.phase,
+                SupervisorPhase::Draining | SupervisorPhase::DegradedPassthrough
+            ) {
+                return Err(SupervisorTransitionError::InvalidTransition);
+            }
+            next = SupervisorState::stopped();
+        }
+    }
+    Ok(next)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RestartDecision {
+    Allowed { delay: Duration },
+    Backoff { retry_at_unix: u64 },
+    Exhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RestartBudget {
+    window_started_at: Option<u64>,
+    attempts: u8,
+    next_allowed_at: u64,
+}
+
+impl RestartBudget {
+    pub const fn new() -> Self {
+        Self {
+            window_started_at: None,
+            attempts: 0,
+            next_allowed_at: 0,
+        }
+    }
+
+    pub fn decide(&self, now_unix: u64, limits: SupervisorLimits) -> RestartDecision {
+        let Some(window_started_at) = self.window_started_at else {
+            return RestartDecision::Allowed {
+                delay: Duration::ZERO,
+            };
+        };
+        if now_unix.saturating_sub(window_started_at) >= limits.restart_window.as_secs() {
+            return RestartDecision::Allowed {
+                delay: Duration::ZERO,
+            };
+        }
+        if self.attempts >= limits.max_restart_attempts {
+            return RestartDecision::Exhausted;
+        }
+        if now_unix < self.next_allowed_at {
+            return RestartDecision::Backoff {
+                retry_at_unix: self.next_allowed_at,
+            };
+        }
+        RestartDecision::Allowed {
+            delay: Duration::from_secs(
+                limits
+                    .initial_restart_backoff
+                    .as_secs()
+                    .saturating_mul(1_u64 << self.attempts.min(6)),
+            ),
+        }
+    }
+
+    pub fn record_attempt(&mut self, now_unix: u64, limits: SupervisorLimits) {
+        if self
+            .window_started_at
+            .map(|started| now_unix.saturating_sub(started) >= limits.restart_window.as_secs())
+            .unwrap_or(true)
+        {
+            self.window_started_at = Some(now_unix);
+            self.attempts = 0;
+        }
+        self.attempts = self.attempts.saturating_add(1);
+        let backoff = limits
+            .initial_restart_backoff
+            .as_secs()
+            .saturating_mul(1_u64 << self.attempts.saturating_sub(1).min(6));
+        self.next_allowed_at =
+            now_unix.saturating_add(backoff.min(limits.max_restart_backoff.as_secs()));
+    }
+}
+
+impl Default for RestartBudget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Runtime adapter owned by the unified service boundary.
+pub struct UnifiedSupervisor<R: RuntimeControl> {
+    runtime: R,
+    state: SupervisorState,
+    limits: SupervisorLimits,
+    restart_budget: RestartBudget,
+}
+
+impl<R: RuntimeControl> UnifiedSupervisor<R> {
+    pub fn new(runtime: R) -> Self {
+        Self::with_limits(runtime, SupervisorLimits::default())
+    }
+
+    pub fn with_limits(runtime: R, limits: SupervisorLimits) -> Self {
+        assert!(
+            limits.validate().is_ok(),
+            "invalid unified supervisor limits"
+        );
+        Self {
+            runtime,
+            state: SupervisorState::stopped(),
+            limits,
+            restart_budget: RestartBudget::new(),
+        }
+    }
+
+    pub fn state(&self) -> SupervisorState {
+        self.state
+    }
+
+    pub fn limits(&self) -> SupervisorLimits {
+        self.limits
+    }
+
+    pub fn restart_budget(&self) -> RestartBudget {
+        self.restart_budget
+    }
+
+    pub fn enable(&mut self, scope_valid: bool, ipv6_ready: bool) -> Result<(), SupervisorError> {
+        self.state = reduce(
+            &self.state,
+            SupervisorEvent::StartRequested {
+                scope_valid,
+                ipv6_ready,
+                child_count: MANAGED_CHILDREN,
+            },
+            self.limits,
+        )
+        .map_err(SupervisorError::Transition)?;
+
+        if let Err(error) = control::enable(&mut self.runtime, scope_valid, ipv6_ready) {
+            self.fail_and_stop();
+            return Err(SupervisorError::Control(error));
+        }
+        self.state = reduce(&self.state, SupervisorEvent::ChildrenReady, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        self.state = reduce(&self.state, SupervisorEvent::WatchdogArmed, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        self.state = reduce(&self.state, SupervisorEvent::RedirectInstalled, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        Ok(())
+    }
+
+    pub fn disable(&mut self) -> Result<(), SupervisorError> {
+        self.state = reduce(&self.state, SupervisorEvent::StopRequested, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        if let Err(error) = control::disable(&mut self.runtime) {
+            self.state = SupervisorState::stopped();
+            return Err(SupervisorError::Control(error));
+        }
+        self.state = reduce(&self.state, SupervisorEvent::ChildrenStopped, self.limits)
+            .map_err(SupervisorError::Transition)?;
+        Ok(())
+    }
+
+    pub fn record_crash(&mut self, now_unix: u64) -> RestartDecision {
+        self.state = reduce(&self.state, SupervisorEvent::HealthFailed, self.limits)
+            .unwrap_or_else(|_| SupervisorState::stopped());
+        let decision = self.restart_budget.decide(now_unix, self.limits);
+        if matches!(decision, RestartDecision::Allowed { .. }) {
+            self.restart_budget.record_attempt(now_unix, self.limits);
+        }
+        decision
+    }
+
+    fn fail_and_stop(&mut self) {
+        self.state = SupervisorState::stopped();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SupervisorError {
+    Transition(SupervisorTransitionError),
+    Control(ControlError),
+}

--- a/tests/app_service.rs
+++ b/tests/app_service.rs
@@ -438,6 +438,44 @@ fn status_reports_unavailable_when_probe_fails() {
 }
 
 #[test]
+fn invalid_scope_never_runs_an_unbound_probe_or_publishes_target() {
+    // An unsupported/malformed profile must fail closed in status and
+    // periodic refresh too, not only in control_enable. An empty probe
+    // sequence makes any accidental fallback probe panic this test.
+    let sink = Arc::new(Mutex::new(None));
+    let mut service = WlocService::new(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        SequenceProbe {
+            results: vec![],
+            index: 0,
+        },
+        SequenceGeo {
+            results: vec![],
+            index: 0,
+        },
+        WlocServiceConfig {
+            node_ref: NodeRef::new("node-1").unwrap(),
+            providers: vec![ProviderRef::new("geo-a").unwrap()],
+            probe_limits: limits(),
+            scope_valid: false,
+            ipv6_ready: true,
+            assigned_device_configured: false,
+            assigned_device: None,
+            reverse_geo_lookup: None,
+        },
+    )
+    .with_patch_sink(Arc::clone(&sink));
+
+    let status = service.status_at(1_000_000).unwrap();
+    assert_eq!(status["exit"]["state"], "unavailable");
+    assert_eq!(status["geo"]["state"], "unavailable");
+    assert!(sink.lock().unwrap().is_none());
+}
+
+#[test]
 fn status_reports_uncertain_when_geo_conflicts() {
     let now = 1_000_000;
     let mut service = WlocService::new(

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -1,0 +1,191 @@
+use std::net::IpAddr;
+
+use wificalling_location_gateway::config::{
+    DeviceProfile, LocationMode, NodeSelectionMode, ProfileError, ProfileModel, WlocUciConfig,
+};
+
+fn profile(id: &str, address: &str) -> DeviceProfile {
+    DeviceProfile {
+        id: id.to_owned(),
+        label: "Living room phone".to_owned(),
+        assigned_device: Some(address.to_owned()),
+        node_ref: "node-a".to_owned(),
+        node_mode: NodeSelectionMode::Fixed,
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+        manual_location_ref: None,
+        enabled: true,
+    }
+}
+
+#[test]
+fn legacy_single_device_configuration_migrates_idempotently() {
+    let config = WlocUciConfig {
+        enabled: true,
+        location_mode: LocationMode::Manual,
+        manual_latitude: Some(22.3193),
+        manual_longitude: Some(114.1694),
+        node_ref: "node-a".to_owned(),
+        assigned_device: "192.168.1.100".to_owned(),
+        ..WlocUciConfig::default()
+    };
+
+    let first = ProfileModel::from_legacy(&config).expect("legacy config is valid");
+    let second = ProfileModel::from_legacy(&config).expect("legacy config is valid");
+    assert_eq!(first, second);
+    assert_eq!(first.profiles().len(), 1);
+    assert_eq!(first.profiles()[0].id, "default");
+    assert_eq!(
+        first.profiles()[0].assigned_device.as_deref(),
+        Some("192.168.1.100")
+    );
+    assert_eq!(first.profiles()[0].location_mode, LocationMode::Manual);
+    assert_eq!(first.profiles()[0].manual_latitude, Some(22.3193));
+}
+
+#[test]
+fn explicit_profiles_reject_duplicates_and_invalid_addresses() {
+    let duplicate = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("phone", "192.168.1.11"),
+    ]);
+    assert!(matches!(duplicate, Err(ProfileError::DuplicateId(_))));
+
+    let invalid = ProfileModel::new(vec![profile("phone", "not-an-address")]);
+    assert!(matches!(
+        invalid,
+        Err(ProfileError::InvalidDeviceAddress(_))
+    ));
+}
+
+#[test]
+fn validation_accepts_ip_and_mac_device_addresses() {
+    let ipv6 = ProfileModel::new(vec![profile("phone", "2001:db8::10")]).unwrap();
+    assert_eq!(
+        ipv6.profiles()[0].assigned_device.as_deref(),
+        Some("2001:db8::10")
+    );
+    let mac = ProfileModel::new(vec![profile("tablet", "aa:bb:cc:dd:ee:ff")]).unwrap();
+    assert_eq!(
+        mac.profiles()[0].assigned_device.as_deref(),
+        Some("aa:bb:cc:dd:ee:ff")
+    );
+}
+
+#[test]
+fn manual_location_requires_a_complete_finite_in_range_pair() {
+    let mut value = profile("phone", "192.168.1.10");
+    value.location_mode = LocationMode::Manual;
+    value.manual_latitude = Some(1.0);
+    assert!(matches!(
+        ProfileModel::new(vec![value.clone()]),
+        Err(ProfileError::IncompleteLocation)
+    ));
+
+    value.manual_longitude = Some(181.0);
+    assert!(matches!(
+        ProfileModel::new(vec![value.clone()]),
+        Err(ProfileError::InvalidLocation)
+    ));
+
+    value.manual_longitude = Some(2.0);
+    value.manual_latitude = Some(f64::NAN);
+    assert!(matches!(
+        ProfileModel::new(vec![value]),
+        Err(ProfileError::InvalidLocation)
+    ));
+}
+
+#[test]
+fn transactional_update_does_not_partially_replace_model() {
+    let original = ProfileModel::new(vec![profile("phone", "192.168.1.10")]).unwrap();
+    let mut model = original.clone();
+    let result = model.replace(vec![profile("phone", "bad")]);
+    assert!(result.is_err());
+    assert_eq!(model, original);
+}
+
+#[test]
+fn profile_status_is_redacted_and_bounded() {
+    let model = ProfileModel::new(vec![profile("phone", "192.168.1.10")]).unwrap();
+    let status = model.redacted_status().unwrap();
+    let text = serde_json::to_string(&status).unwrap();
+    assert!(text.contains("phone"));
+    assert!(!text.contains("192.168.1.10"));
+    assert!(!text.contains("node-a"));
+    assert!(text.len() <= 4096);
+}
+
+#[test]
+fn profile_count_and_serialized_size_are_bounded() {
+    let too_many = (0..=8)
+        .map(|index| {
+            profile(
+                &format!("phone-{index}"),
+                &format!("192.168.1.{}", index + 10),
+            )
+        })
+        .collect();
+    assert!(matches!(
+        ProfileModel::new(too_many),
+        Err(ProfileError::TooManyProfiles)
+    ));
+
+    let mut oversized = profile("phone", "192.168.1.10");
+    oversized.label = "x".repeat(10_000);
+    assert!(matches!(
+        ProfileModel::new(vec![oversized]),
+        Err(ProfileError::FieldTooLong { .. })
+    ));
+}
+
+#[test]
+fn explicit_device_sections_parse_and_profile_model_prefers_them() {
+    let text = r#"
+config wloc-service 'main'
+    option enabled '0'
+config device 'phone'
+    option label 'Living room phone'
+    option assigned_device 'aa:bb:cc:dd:ee:ff'
+    option node_ref 'node-a'
+    option node_mode 'fixed'
+    option geo_source 'manual'
+    option manual_lat '22.3'
+    option manual_lon '114.1'
+    option manual_location_ref 'hong-kong'
+    option enabled '1'
+"#;
+    let config = WlocUciConfig::parse(text).expect("explicit profile parses");
+    assert!(!config.profiles.is_empty());
+    let model = config.profile_model().unwrap();
+    assert_eq!(model.profiles().len(), 1);
+    assert_eq!(model.profiles()[0].id, "phone");
+    assert_eq!(
+        model.profiles()[0].manual_location_ref.as_deref(),
+        Some("hong-kong")
+    );
+}
+
+#[test]
+fn explicit_device_section_rejects_unknown_modes() {
+    let text = "config device 'phone'\n\toption node_mode 'random'\n";
+    assert!(matches!(
+        WlocUciConfig::parse(text),
+        Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn explicit_device_section_requires_an_assigned_address() {
+    let text = "config device 'phone'\n\toption node_ref 'node-a'\n";
+    assert!(matches!(
+        WlocUciConfig::parse(text),
+        Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn unused_import_guard_keeps_the_test_explicit_about_ip_support() {
+    let _: IpAddr = "192.168.1.10".parse().unwrap();
+}

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -74,6 +74,27 @@ fn validation_accepts_ip_and_mac_device_addresses() {
 }
 
 #[test]
+fn unusable_ip_and_mac_addresses_are_rejected() {
+    for address in [
+        "0.0.0.0",
+        "127.0.0.1",
+        "169.254.1.2",
+        "224.0.0.1",
+        "::",
+        "::1",
+        "ff02::1",
+        "00:00:00:00:00:00",
+        "01:00:00:00:00:01",
+    ] {
+        let rejected = matches!(
+            ProfileModel::new(vec![profile("phone", address)]),
+            Err(ProfileError::InvalidDeviceAddress(_))
+        );
+        assert!(rejected, "address should not be accepted: {address}");
+    }
+}
+
+#[test]
 fn manual_location_requires_a_complete_finite_in_range_pair() {
     let mut value = profile("phone", "192.168.1.10");
     value.location_mode = LocationMode::Manual;
@@ -104,6 +125,19 @@ fn transactional_update_does_not_partially_replace_model() {
     let result = model.replace(vec![profile("phone", "bad")]);
     assert!(result.is_err());
     assert_eq!(model, original);
+}
+
+#[test]
+fn multiple_profiles_cannot_be_selected_by_the_single_runtime() {
+    let model = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("tablet", "192.168.1.11"),
+    ])
+    .unwrap();
+    assert!(matches!(
+        model.single_runtime_profile(),
+        Err(ProfileError::MultipleProfilesRequireUnifiedRuntime)
+    ));
 }
 
 #[test]
@@ -182,6 +216,18 @@ fn explicit_device_section_requires_an_assigned_address() {
     assert!(matches!(
         WlocUciConfig::parse(text),
         Err(wificalling_location_gateway::config::UciError::Profile(_))
+    ));
+}
+
+#[test]
+fn oversized_uci_text_is_rejected_before_profile_accumulation() {
+    let text = format!(
+        "config device 'phone'\n\toption label '{}'\n",
+        "x".repeat(33_000)
+    );
+    assert!(matches!(
+        WlocUciConfig::parse(&text),
+        Err(wificalling_location_gateway::config::UciError::ConfigTooLarge)
     ));
 }
 

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -61,10 +61,10 @@ fn explicit_profiles_reject_duplicates_and_invalid_addresses() {
 
 #[test]
 fn validation_accepts_ip_and_mac_device_addresses() {
-    let ipv6 = ProfileModel::new(vec![profile("phone", "2001:db8::10")]).unwrap();
+    let ipv6 = ProfileModel::new(vec![profile("phone", "fd00::10")]).unwrap();
     assert_eq!(
         ipv6.profiles()[0].assigned_device.as_deref(),
-        Some("2001:db8::10")
+        Some("fd00::10")
     );
     let mac = ProfileModel::new(vec![profile("tablet", "aa:bb:cc:dd:ee:ff")]).unwrap();
     assert_eq!(
@@ -77,12 +77,15 @@ fn validation_accepts_ip_and_mac_device_addresses() {
 fn unusable_ip_and_mac_addresses_are_rejected() {
     for address in [
         "0.0.0.0",
+        "0.0.0.1",
         "127.0.0.1",
+        "192.0.2.10",
         "169.254.1.2",
         "224.0.0.1",
         "::",
         "::1",
         "ff02::1",
+        "2001:db8::10",
         "00:00:00:00:00:00",
         "01:00:00:00:00:01",
     ] {

--- a/tests/profile_model.rs
+++ b/tests/profile_model.rs
@@ -57,6 +57,15 @@ fn explicit_profiles_reject_duplicates_and_invalid_addresses() {
         invalid,
         Err(ProfileError::InvalidDeviceAddress(_))
     ));
+
+    let duplicate_device = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("tablet", "192.168.1.10"),
+    ]);
+    assert!(matches!(
+        duplicate_device,
+        Err(ProfileError::DuplicateAssignedDevice(_))
+    ));
 }
 
 #[test]

--- a/tests/profile_runtime.rs
+++ b/tests/profile_runtime.rs
@@ -1,0 +1,192 @@
+use wificalling_location_gateway::config::{
+    DeviceProfile, LocationMode, NodeSelectionMode, ProfileModel,
+};
+use wificalling_location_gateway::service::profile_runtime::{
+    ProfileRuntimeControl, ProfileRuntimeError, ProfileRuntimeManager, ProfileRuntimePhase,
+};
+
+fn profile(id: &str, address: &str) -> DeviceProfile {
+    DeviceProfile {
+        id: id.to_owned(),
+        label: id.to_owned(),
+        assigned_device: Some(address.to_owned()),
+        node_ref: format!("node-{id}"),
+        node_mode: NodeSelectionMode::Fixed,
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+        manual_location_ref: None,
+        enabled: true,
+    }
+}
+
+#[derive(Default, Debug)]
+struct FakeRuntime {
+    operations: Vec<String>,
+    healthy: bool,
+    fail_install_for: Option<String>,
+    redirects: Vec<String>,
+}
+
+impl ProfileRuntimeControl for FakeRuntime {
+    fn ensure_shared_engine(&mut self) -> Result<(), ProfileRuntimeError> {
+        self.operations.push("engine.start".to_owned());
+        Ok(())
+    }
+
+    fn shared_engine_healthy(&mut self) -> Result<bool, ProfileRuntimeError> {
+        self.operations.push("engine.health".to_owned());
+        Ok(self.healthy)
+    }
+
+    fn install_profile_redirect(
+        &mut self,
+        profile: &DeviceProfile,
+    ) -> Result<(), ProfileRuntimeError> {
+        self.operations.push(format!("redirect.add:{}", profile.id));
+        if self.fail_install_for.as_deref() == Some(profile.id.as_str()) {
+            return Err(ProfileRuntimeError::RedirectInstall);
+        }
+        self.redirects.push(profile.id.clone());
+        Ok(())
+    }
+
+    fn remove_profile_redirect(&mut self, profile_id: &str) -> Result<(), ProfileRuntimeError> {
+        self.operations
+            .push(format!("redirect.remove:{profile_id}"));
+        self.redirects.retain(|id| id != profile_id);
+        Ok(())
+    }
+
+    fn profile_redirect_present(
+        &mut self,
+        profile_id: &str,
+    ) -> Result<bool, ProfileRuntimeError> {
+        self.operations
+            .push(format!("redirect.present:{profile_id}"));
+        Ok(self.redirects.iter().any(|id| id == profile_id))
+    }
+}
+
+fn manager(runtime: FakeRuntime) -> ProfileRuntimeManager<FakeRuntime> {
+    let model = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10"),
+        profile("tablet", "192.168.1.11"),
+    ])
+    .unwrap();
+    ProfileRuntimeManager::new(model, runtime)
+}
+
+#[test]
+fn profiles_share_one_engine_but_install_independent_redirects() {
+    let mut manager = manager(FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    });
+
+    manager.enable("phone").unwrap();
+    manager.enable("tablet").unwrap();
+
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(
+        manager
+            .runtime()
+            .operations
+            .iter()
+            .filter(|operation| operation.as_str() == "engine.start")
+            .count(),
+        1
+    );
+    assert!(manager.runtime().redirects.contains(&"phone".to_owned()));
+    assert!(manager.runtime().redirects.contains(&"tablet".to_owned()));
+}
+
+#[test]
+fn disabling_one_profile_does_not_touch_the_other_redirect() {
+    let mut manager = manager(FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    });
+    manager.enable("phone").unwrap();
+    manager.enable("tablet").unwrap();
+
+    manager.disable("phone").unwrap();
+
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Disabled);
+    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(manager.runtime().redirects, vec!["tablet".to_owned()]);
+    assert!(manager
+        .runtime()
+        .operations
+        .contains(&"redirect.remove:phone".to_owned()));
+    assert!(!manager
+        .runtime()
+        .operations
+        .contains(&"redirect.remove:tablet".to_owned()));
+}
+
+#[test]
+fn failed_profile_install_degrades_only_that_profile() {
+    let mut manager = manager(FakeRuntime {
+        healthy: true,
+        fail_install_for: Some("tablet".to_owned()),
+        ..FakeRuntime::default()
+    });
+    manager.enable("phone").unwrap();
+
+    assert_eq!(
+        manager.enable("tablet"),
+        Err(ProfileRuntimeError::RedirectInstall)
+    );
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(manager.runtime().redirects, vec!["phone".to_owned()]);
+    assert!(manager
+        .runtime()
+        .operations
+        .contains(&"redirect.remove:tablet".to_owned()));
+}
+
+#[test]
+fn unhealthy_shared_engine_never_installs_any_profile_redirect() {
+    let mut manager = manager(FakeRuntime::default());
+    assert_eq!(
+        manager.enable("phone"),
+        Err(ProfileRuntimeError::EngineUnhealthy)
+    );
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert!(manager.runtime().redirects.is_empty());
+}
+
+#[test]
+fn unsupported_mac_profile_is_rejected_without_runtime_operation() {
+    let model = ProfileModel::new(vec![profile("phone", "aa:bb:cc:dd:ee:ff")]).unwrap();
+    let mut manager = ProfileRuntimeManager::new(
+        model,
+        FakeRuntime {
+            healthy: true,
+            ..FakeRuntime::default()
+        },
+    );
+
+    assert_eq!(
+        manager.enable("phone"),
+        Err(ProfileRuntimeError::UnsupportedDevice)
+    );
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert!(manager.runtime().operations.is_empty());
+}
+
+#[test]
+fn unknown_profile_is_rejected_without_runtime_operation() {
+    let mut manager = manager(FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    });
+    assert_eq!(
+        manager.enable("missing"),
+        Err(ProfileRuntimeError::UnknownProfile)
+    );
+    assert!(manager.runtime().operations.is_empty());
+}

--- a/tests/profile_runtime.rs
+++ b/tests/profile_runtime.rs
@@ -58,10 +58,7 @@ impl ProfileRuntimeControl for FakeRuntime {
         Ok(())
     }
 
-    fn profile_redirect_present(
-        &mut self,
-        profile_id: &str,
-    ) -> Result<bool, ProfileRuntimeError> {
+    fn profile_redirect_present(&mut self, profile_id: &str) -> Result<bool, ProfileRuntimeError> {
         self.operations
             .push(format!("redirect.present:{profile_id}"));
         Ok(self.redirects.iter().any(|id| id == profile_id))
@@ -87,8 +84,14 @@ fn profiles_share_one_engine_but_install_independent_redirects() {
     manager.enable("phone").unwrap();
     manager.enable("tablet").unwrap();
 
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
-    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::Intercepting
+    );
+    assert_eq!(
+        manager.status("tablet").unwrap().phase,
+        ProfileRuntimePhase::Intercepting
+    );
     assert_eq!(
         manager
             .runtime()
@@ -113,8 +116,14 @@ fn disabling_one_profile_does_not_touch_the_other_redirect() {
 
     manager.disable("phone").unwrap();
 
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Disabled);
-    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::Disabled
+    );
+    assert_eq!(
+        manager.status("tablet").unwrap().phase,
+        ProfileRuntimePhase::Intercepting
+    );
     assert_eq!(manager.runtime().redirects, vec!["tablet".to_owned()]);
     assert!(manager
         .runtime()
@@ -139,8 +148,14 @@ fn failed_profile_install_degrades_only_that_profile() {
         manager.enable("tablet"),
         Err(ProfileRuntimeError::RedirectInstall)
     );
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
-    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::Intercepting
+    );
+    assert_eq!(
+        manager.status("tablet").unwrap().phase,
+        ProfileRuntimePhase::DegradedPassthrough
+    );
     assert_eq!(manager.runtime().redirects, vec!["phone".to_owned()]);
     assert!(manager
         .runtime()
@@ -155,7 +170,10 @@ fn unhealthy_shared_engine_never_installs_any_profile_redirect() {
         manager.enable("phone"),
         Err(ProfileRuntimeError::EngineUnhealthy)
     );
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::DegradedPassthrough
+    );
     assert!(manager.runtime().redirects.is_empty());
 }
 
@@ -172,8 +190,14 @@ fn every_new_profile_enable_rechecks_shared_engine_health() {
         manager.enable("tablet"),
         Err(ProfileRuntimeError::EngineUnhealthy)
     );
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
-    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::Intercepting
+    );
+    assert_eq!(
+        manager.status("tablet").unwrap().phase,
+        ProfileRuntimePhase::DegradedPassthrough
+    );
     assert_eq!(manager.runtime().redirects, vec!["phone".to_owned()]);
 }
 
@@ -192,7 +216,10 @@ fn unsupported_mac_profile_is_rejected_without_runtime_operation() {
         manager.enable("phone"),
         Err(ProfileRuntimeError::UnsupportedDevice)
     );
-    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(
+        manager.status("phone").unwrap().phase,
+        ProfileRuntimePhase::DegradedPassthrough
+    );
     assert!(manager.runtime().operations.is_empty());
 }
 

--- a/tests/profile_runtime.rs
+++ b/tests/profile_runtime.rs
@@ -160,6 +160,24 @@ fn unhealthy_shared_engine_never_installs_any_profile_redirect() {
 }
 
 #[test]
+fn every_new_profile_enable_rechecks_shared_engine_health() {
+    let mut manager = manager(FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    });
+    manager.enable("phone").unwrap();
+    manager.runtime_mut().healthy = false;
+
+    assert_eq!(
+        manager.enable("tablet"),
+        Err(ProfileRuntimeError::EngineUnhealthy)
+    );
+    assert_eq!(manager.status("phone").unwrap().phase, ProfileRuntimePhase::Intercepting);
+    assert_eq!(manager.status("tablet").unwrap().phase, ProfileRuntimePhase::DegradedPassthrough);
+    assert_eq!(manager.runtime().redirects, vec!["phone".to_owned()]);
+}
+
+#[test]
 fn unsupported_mac_profile_is_rejected_without_runtime_operation() {
     let model = ProfileModel::new(vec![profile("phone", "aa:bb:cc:dd:ee:ff")]).unwrap();
     let mut manager = ProfileRuntimeManager::new(

--- a/tests/scripts/test-gateway-log-bound.sh
+++ b/tests/scripts/test-gateway-log-bound.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+monitor="$repo_root/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-gateway-log.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+sh -n "$monitor"
+printf '%s\n' 'phone|192.168.1.10|node-phone' > "$tmp/clients"
+: > "$tmp/conntrack"
+: > "$tmp/status.json"
+: > "$tmp/state"
+i=0
+while [ "$i" -lt 40 ]; do
+  printf '%s|phone|192.168.1.10|handshake_failed|0|0|call_or_sms_unknown|not_detected\n' "$i" >> "$tmp/events.log"
+  i=$((i + 1))
+done
+
+WFC_NOW=100 WFC_MAX_EVENT_LOG_BYTES=512 "$monitor" \
+  "$tmp/clients" "$tmp/conntrack" "$tmp/status.json" "$tmp/state" "$tmp/events.log" 60 20 1
+
+bytes=$(wc -c < "$tmp/events.log" | tr -d ' ')
+[ "$bytes" -le 512 ] || {
+  printf 'event log exceeds byte bound: %s\n' "$bytes" >&2
+  exit 1
+}
+awk -F '|' 'NF != 8 { exit 1 }' "$tmp/events.log"
+
+printf '%s\n' 'gateway log bound tests passed'

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -23,6 +23,14 @@ grep -F 'mkdir -p /var/run/wificalling-gateway' "$builder" >/dev/null ||
 	fail 'release post-install must create the volatile Gateway runtime directory before restart'
 grep -F 'chmod 0700 /var/run/wificalling-gateway' "$builder" >/dev/null ||
 	fail 'release post-install must restrict the Gateway runtime directory'
+grep -F 'wificalling-location-gateway/unified-supervisor.sh' "$builder" >/dev/null ||
+	fail 'release builder must package the unified supervisor'
+grep -F '/etc/init.d/wificalling-gateway disable' "$builder" >/dev/null ||
+	fail 'release post-install must disable the legacy Gateway owner'
+grep -F '/etc/init.d/wloc-service disable' "$builder" >/dev/null ||
+	fail 'release post-install must disable the legacy WLOC owner'
+grep -F '/etc/init.d/wificalling-location-gateway restart' "$builder" >/dev/null ||
+	fail 'release post-install must restart the unified owner'
 grep -F 'rm -f /tmp/luci-indexcache.*' "$builder" >/dev/null ||
 	fail 'release post-install must invalidate every LuCI menu cache variant'
 if grep -F 'wloc-docker-smoke-deps' "$matrix" >/dev/null; then

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -15,6 +15,9 @@ printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
 if [ "$*" = 'list tables inet' ]; then
   printf '%s\n' 'table inet wloc_profile_phone' 'table inet wloc_profile_tablet'
 fi
+if [ "$*" = 'list table inet wloc_service' ]; then
+  exit 1
+fi
 exit 0
 EOF
 cat > "$tmp/bin/uci" <<'EOF'

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -3,17 +3,29 @@ set -eu
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 helper="$repo_root/openwrt/files/usr/sbin/wloc-profile-redirect.sh"
+refresh="$repo_root/openwrt/files/usr/sbin/wloc-refresh-set.sh"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-profile-redirect.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
-sh -n "$helper"
+sh -n "$helper" "$refresh"
 mkdir -p "$tmp/bin"
 cat > "$tmp/bin/nft" <<'EOF'
 #!/bin/sh
 printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
+if [ "$*" = 'list tables inet' ]; then
+  printf '%s\n' 'table inet wloc_profile_phone' 'table inet wloc_profile_tablet'
+fi
 exit 0
 EOF
-chmod 0755 "$tmp/bin/nft"
+cat > "$tmp/bin/uci" <<'EOF'
+#!/bin/sh
+printf '%s\n' '192.168.1.1'
+EOF
+cat > "$tmp/bin/nslookup" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'Address: 59.82.17.33'
+EOF
+chmod 0755 "$tmp/bin/nft" "$tmp/bin/uci" "$tmp/bin/nslookup"
 : > "$tmp/commands.log"
 
 PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
@@ -32,6 +44,10 @@ if grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev
 fi
 grep -F 'ip saddr 192.168.1.10 tcp dport 443' "$tmp/commands.log" >/dev/null
 grep -F 'ip daddr @apple_hosts' "$tmp/commands.log" >/dev/null
+
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" "$refresh"
+grep -F 'nft flush set inet wloc_profile_phone apple_hosts' "$tmp/commands.log" >/dev/null
+grep -F 'nft flush set inet wloc_profile_tablet apple_hosts' "$tmp/commands.log" >/dev/null
 
 if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
   "$helper" start '../phone' 192.168.1.12; then

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+helper="$repo_root/openwrt/files/usr/sbin/wloc-profile-redirect.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-profile-redirect.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+sh -n "$helper"
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/nft" <<'EOF'
+#!/bin/sh
+printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
+exit 0
+EOF
+chmod 0755 "$tmp/bin/nft"
+: > "$tmp/commands.log"
+
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" start phone 192.168.1.10
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" start tablet 192.168.1.11
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" stop phone
+
+grep -F 'nft add table inet wloc_profile_phone' "$tmp/commands.log" >/dev/null
+grep -F 'nft add table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null
+grep -F 'nft delete table inet wloc_profile_phone' "$tmp/commands.log" >/dev/null
+if grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null; then
+  printf '%s\n' 'stopping one profile must not delete another profile table' >&2
+  exit 1
+fi
+grep -F 'ip saddr 192.168.1.10 tcp dport 443' "$tmp/commands.log" >/dev/null
+grep -F 'ip daddr @apple_hosts' "$tmp/commands.log" >/dev/null
+
+if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" start '../phone' 192.168.1.12; then
+  printf '%s\n' 'path traversal profile id must be rejected' >&2
+  exit 1
+fi
+if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" start bad-mac aa:bb:cc:dd:ee:ff; then
+  printf '%s\n' 'MAC binding must remain unsupported by the IP-only runtime' >&2
+  exit 1
+fi
+
+if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|gs-loc-corpa|apple\.com\.cn|bluedot' \
+  "$helper" >/dev/null; then
+  printf '%s\n' 'profile redirect helper exceeded the approved WLOC scope' >&2
+  exit 1
+fi
+
+printf '%s\n' 'profile redirect shell tests passed'

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -59,6 +59,11 @@ if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
   printf '%s\n' 'MAC binding must remain unsupported by the IP-only runtime' >&2
   exit 1
 fi
+if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$helper" start documentation 192.0.2.1; then
+  printf '%s\n' 'non-private 192/8 address must be rejected' >&2
+  exit 1
+fi
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|gs-loc-corpa|apple\.com\.cn|bluedot' \
   "$helper" >/dev/null; then

--- a/tests/scripts/test-profile-status.sh
+++ b/tests/scripts/test-profile-status.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+status="$repo_root/openwrt/files/usr/sbin/wloc-profile-status.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-profile-status.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+sh -n "$status"
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/uci" <<'EOF'
+#!/bin/sh
+case "$*" in
+  '-q show wloc-service')
+    printf '%s\n' 'wloc-service.phone=device' 'wloc-service.tablet=device'
+    ;;
+  '-q get wloc-service.phone.label') printf '%s\n' 'Living room phone' ;;
+  '-q get wloc-service.phone.enabled') printf '%s\n' '1' ;;
+  '-q get wloc-service.phone.assigned_device') printf '%s\n' '192.168.1.10' ;;
+  '-q get wloc-service.phone.node_ref') printf '%s\n' 'node-phone' ;;
+  '-q get wloc-service.tablet.label') printf '%s\n' 'Tablet' ;;
+  '-q get wloc-service.tablet.enabled') printf '%s\n' '1' ;;
+  '-q get wloc-service.tablet.assigned_device') printf '%s\n' '' ;;
+  '-q get wloc-service.tablet.node_ref') printf '%s\n' 'node-tablet' ;;
+  *) exit 1 ;;
+esac
+EOF
+cat > "$tmp/bin/nft" <<'EOF'
+#!/bin/sh
+case "$*" in
+  'list table inet wloc_profile_phone') exit 0 ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod 0755 "$tmp/bin/uci" "$tmp/bin/nft"
+
+output=$(PATH="$tmp/bin:$PATH" "$status")
+printf '%s\n' "$output" | grep -F '"id":"phone"' >/dev/null
+printf '%s\n' "$output" | grep -F '"phase":"intercepting"' >/dev/null
+printf '%s\n' "$output" | grep -F '"id":"tablet"' >/dev/null
+printf '%s\n' "$output" | grep -F '"reason_code":"missing_device_binding"' >/dev/null
+if printf '%s\n' "$output" | grep -E '192\.168\.1\.10|node-phone|node-tablet' >/dev/null; then
+  printf '%s\n' 'profile status must not expose device addresses or node references' >&2
+  exit 1
+fi
+
+printf '%s\n' 'profile status shell tests passed'

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -133,6 +133,7 @@ for member in \
 	'./usr/sbin/wloc-service' \
 	'./usr/sbin/wloc-ctl' \
 	'./usr/sbin/wloc-profile-redirect.sh' \
+	'./usr/sbin/wloc-profile-status.sh' \
 	'./usr/libexec/wificalling-location-gateway/unified-supervisor.sh'; do
 	printf '%s\n' "$data_members" | grep -Fx "$member" >/dev/null ||
 		fail "standalone package is missing $member"

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -113,18 +113,26 @@ printf '%s\n' "$postinst" | grep -F 'mkdir -p /var/run/wificalling-gateway' >/de
 printf '%s\n' "$postinst" | grep -F 'chmod 0700 /var/run/wificalling-gateway' >/dev/null ||
 	fail 'standalone post-install must restrict the Gateway runtime directory'
 runtime_line=$(printf '%s\n' "$postinst" | grep -n -F 'mkdir -p /var/run/wificalling-gateway' | cut -d: -f1)
-restart_line=$(printf '%s\n' "$postinst" | grep -n -F '/etc/init.d/wificalling-gateway restart' | cut -d: -f1)
+restart_line=$(printf '%s\n' "$postinst" | grep -n -F '/etc/init.d/wificalling-location-gateway restart' | cut -d: -f1)
 [ "$runtime_line" -lt "$restart_line" ] ||
 	fail 'standalone post-install must create the Gateway runtime directory before restart'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wificalling-gateway disable' >/dev/null ||
+	fail 'standalone post-install must disable the legacy Gateway owner'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wloc-service disable' >/dev/null ||
+	fail 'standalone post-install must disable the legacy WLOC owner'
+printf '%s\n' "$postinst" | grep -F '/etc/init.d/wificalling-location-gateway enable' >/dev/null ||
+	fail 'standalone post-install must enable the unified supervisor'
 printf '%s\n' "$postinst" | grep -F 'rm -f /tmp/luci-indexcache.*' >/dev/null ||
 	fail 'standalone post-install must invalidate every LuCI menu cache variant'
 for member in \
 	'./etc/config/wificalling-gateway' \
 	'./etc/init.d/wificalling-gateway' \
+	'./etc/init.d/wificalling-location-gateway' \
 	'./etc/config/wloc-service' \
 	'./etc/init.d/wloc-service' \
 	'./usr/sbin/wloc-service' \
-	'./usr/sbin/wloc-ctl'; do
+	'./usr/sbin/wloc-ctl' \
+	'./usr/libexec/wificalling-location-gateway/unified-supervisor.sh'; do
 	printf '%s\n' "$data_members" | grep -Fx "$member" >/dev/null ||
 		fail "standalone package is missing $member"
 done

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -132,6 +132,7 @@ for member in \
 	'./etc/init.d/wloc-service' \
 	'./usr/sbin/wloc-service' \
 	'./usr/sbin/wloc-ctl' \
+	'./usr/sbin/wloc-profile-redirect.sh' \
 	'./usr/libexec/wificalling-location-gateway/unified-supervisor.sh'; do
 	printf '%s\n' "$data_members" | grep -Fx "$member" >/dev/null ||
 		fail "standalone package is missing $member"

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -17,6 +17,7 @@ grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 
@@ -27,8 +28,13 @@ redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]
 [ "$health" -lt "$redirect_start" ]
-grep -F 'cleanup_runtime wloc_start_failed keep_gateway' "$supervisor" >/dev/null
-grep -F 'cleanup_runtime health_failed keep_gateway' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime wloc_start_failed 1' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime health_failed 1' "$supervisor" >/dev/null
+if grep -F 'stop_child "$GATEWAY_INIT"' "$supervisor" >/dev/null; then
+	printf '%s\n' 'unified supervisor must not stop the stable Gateway table owner' >&2
+	exit 1
+fi
+grep -F 'START_TIMEOUT' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
+init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
+redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+sh -n "$supervisor" "$init" "$redirect"
+grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
+grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
+grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
+grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
+
+gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
+wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
+health=$(grep -n 'if ! health_ok' "$supervisor" | head -n 1 | cut -d: -f1)
+redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
+[ "$gateway_start" -lt "$wloc_start" ]
+[ "$wloc_start" -lt "$health" ]
+[ "$health" -lt "$redirect_start" ]
+
+if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
+	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2
+	exit 1
+fi
+
+mkdir -p "$tmp/bin" "$tmp/hosts"
+printf '%s\n' '# wloc-service DNS hijack (do not edit)' '192.0.2.1 old.example' '# wloc-service end' > "$tmp/hosts/a"
+printf '%s\n' '# keep' > "$tmp/hosts/b"
+cat > "$tmp/bin/nft" <<'EOF'
+#!/bin/sh
+printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+cat > "$tmp/bin/ip" <<'EOF'
+#!/bin/sh
+printf 'ip %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+chmod 0755 "$tmp/bin/nft" "$tmp/bin/ip"
+: > "$tmp/commands.log"
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+	WLOC_HOSTS_FILES="$tmp/hosts/a $tmp/hosts/b" "$redirect" stop
+grep -F 'nft delete table inet wloc_service' "$tmp/commands.log" >/dev/null
+grep -F 'ip rule del fwmark 1 lookup 100' "$tmp/commands.log" >/dev/null
+grep -F '# keep' "$tmp/hosts/b" >/dev/null
+if grep -F 'wificalling-gateway' "$tmp/commands.log" >/dev/null; then
+	printf '%s\n' 'WLOC cleanup touched the Gateway namespace' >&2
+	exit 1
+fi
+
+printf '%s\n' 'unified supervisor shell tests passed'

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -5,14 +5,18 @@ repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
 redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+wloc_init="$repo_root/openwrt/files/etc/init.d/wloc-service"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
 sh -n "$supervisor" "$init" "$redirect"
+sh -n "$wloc_init"
 grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
+grep -F 'WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
@@ -21,6 +25,8 @@ redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]
 [ "$health" -lt "$redirect_start" ]
+grep -F 'cleanup_runtime wloc_start_failed keep_gateway' "$supervisor" >/dev/null
+grep -F 'cleanup_runtime health_failed keep_gateway' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -15,7 +15,7 @@ grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
-grep -F 'WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -5,17 +5,19 @@ repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 supervisor="$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 init="$repo_root/openwrt/files/etc/init.d/wificalling-location-gateway"
 redirect="$repo_root/openwrt/files/usr/sbin/wloc-redirect-sync.sh"
+wloc_refresh="$repo_root/openwrt/files/usr/sbin/wloc-refresh-set.sh"
 wloc_init="$repo_root/openwrt/files/etc/init.d/wloc-service"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-unified-supervisor.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
 sh -n "$supervisor" "$init" "$redirect"
+sh -n "$wloc_refresh"
 sh -n "$wloc_init"
 grep -F 'procd_set_param command "$SUPERVISOR" start' "$init" >/dev/null
 grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
-grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 WLOC_DEFER_REDIRECT=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
@@ -38,6 +40,10 @@ grep -F 'START_TIMEOUT' "$supervisor" >/dev/null
 
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2
+	exit 1
+fi
+if grep -E 'gs-loc-corpa|apple\.com\.cn|bluedot' "$redirect" "$wloc_refresh" >/dev/null; then
+	printf '%s\n' 'WLOC scope must remain limited to the two exact Apple hostnames' >&2
 	exit 1
 fi
 

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -16,7 +16,9 @@ grep -F 'procd_set_param respawn 3600 5 3' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wificalling-gateway' "$init" >/dev/null
 grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
+grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
+grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -25,7 +25,7 @@ grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gatew
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
-health=$(grep -n 'if ! health_ok' "$supervisor" | head -n 1 | cut -d: -f1)
+health=$(grep -n 'if ! wait_for_health' "$supervisor" | head -n 1 | cut -d: -f1)
 redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -70,6 +70,12 @@ fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
         decode_v2_profile_request(bad_address).unwrap_err(),
         ApiV2ErrorCode::InvalidParams
     );
+
+    let list_with_mutation = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.list","params":{"label":"unexpected"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(list_with_mutation).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
 }
 
 #[test]

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -12,8 +12,13 @@ fn profile_methods_decode_only_on_the_v2_contract() {
         ("profile.update", ProfileApiMethod::Update),
         ("profile.delete", ProfileApiMethod::Delete),
     ] {
+        let params = if method == "profile.create" {
+            r#"{"profile_id":"phone","label":"Phone","assigned_device":"192.168.1.10","node_ref":"node-a","node_mode":"fixed","geo_source":"auto","enabled":true}"#
+        } else {
+            r#"{"profile_id":"phone"}"#
+        };
         let payload = format!(
-            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{{"profile_id":"phone"}}}}"#
+            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{params}}}"#
         );
         assert_eq!(
             decode_v2_profile_request(payload.as_bytes())
@@ -74,6 +79,12 @@ fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
     let list_with_mutation = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.list","params":{"label":"unexpected"}}"#;
     assert_eq!(
         decode_v2_profile_request(list_with_mutation).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let incomplete_create = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.create","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(incomplete_create).unwrap_err(),
         ApiV2ErrorCode::InvalidParams
     );
 }

--- a/tests/service_api_v2_profiles.rs
+++ b/tests/service_api_v2_profiles.rs
@@ -1,0 +1,92 @@
+use wificalling_location_gateway::service::api::{
+    decode_v2_profile_request, encode_v2_result_response, ApiV2ErrorCode, ProfileApiMethod,
+    MAX_CONTROL_FRAME_BYTES, SERVICE_API_V2_ID,
+};
+
+#[test]
+fn profile_methods_decode_only_on_the_v2_contract() {
+    for (method, expected) in [
+        ("profile.list", ProfileApiMethod::List),
+        ("profile.get", ProfileApiMethod::Get),
+        ("profile.create", ProfileApiMethod::Create),
+        ("profile.update", ProfileApiMethod::Update),
+        ("profile.delete", ProfileApiMethod::Delete),
+    ] {
+        let payload = format!(
+            r#"{{"api_version":"{SERVICE_API_V2_ID}","request_id":"req-1","method":"{method}","params":{{"profile_id":"phone"}}}}"#
+        );
+        assert_eq!(
+            decode_v2_profile_request(payload.as_bytes())
+                .unwrap()
+                .method(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn v1_and_unknown_v2_methods_are_not_reinterpreted_as_profile_operations() {
+    let v1 = br#"{"api_version":"wloc.service/v1","request_id":"req-1","method":"profile.list","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(v1).unwrap_err(),
+        ApiV2ErrorCode::IncompatibleVersion
+    );
+
+    let unknown = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"debug.dump","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(unknown).unwrap_err(),
+        ApiV2ErrorCode::UnknownMethod
+    );
+}
+
+#[test]
+fn unsupported_params_and_invalid_profile_ids_fail_before_dispatch() {
+    let unknown = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{"profile_id":"phone","raw":true}}"#;
+    assert_eq!(
+        decode_v2_profile_request(unknown).unwrap_err(),
+        ApiV2ErrorCode::MalformedRequest
+    );
+
+    let invalid = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{"profile_id":"../phone"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(invalid).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let missing = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.get","params":{}}"#;
+    assert_eq!(
+        decode_v2_profile_request(missing).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let bad_mode = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.update","params":{"profile_id":"phone","node_mode":"random"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(bad_mode).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+
+    let bad_address = br#"{"api_version":"wloc.service/v2","request_id":"req-1","method":"profile.update","params":{"profile_id":"phone","assigned_device":"not-an-address"}}"#;
+    assert_eq!(
+        decode_v2_profile_request(bad_address).unwrap_err(),
+        ApiV2ErrorCode::InvalidParams
+    );
+}
+
+#[test]
+fn v2_frame_bound_is_enforced() {
+    let oversized = vec![b' '; MAX_CONTROL_FRAME_BYTES + 1];
+    assert_eq!(
+        decode_v2_profile_request(&oversized).unwrap_err(),
+        ApiV2ErrorCode::FrameTooLarge
+    );
+}
+
+#[test]
+fn v2_result_uses_the_v2_envelope_and_frame_limit() {
+    let body = serde_json::json!({"profiles": []});
+    let encoded = encode_v2_result_response("req-1", &body).unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+    assert_eq!(value["api_version"], SERVICE_API_V2_ID);
+    assert_eq!(value["request_id"], "req-1");
+    assert!(value.get("error").is_none());
+}

--- a/tests/service_contract.rs
+++ b/tests/service_contract.rs
@@ -5,6 +5,15 @@ use wificalling_location_gateway::service::{
     current_response_mode, decide_ingress, GeoRecord, IngressDisposition, ResponseMode,
     RuntimeHealth, ServiceConfig, ServiceConfigError, TrafficMeta, Transport, SERVICE_API_VERSION,
 };
+use wificalling_location_gateway::APPROVED_WLOC_HOSTS;
+
+#[test]
+fn approved_wloc_hosts_are_exactly_the_two_apple_names() {
+    assert_eq!(
+        APPROVED_WLOC_HOSTS,
+        ["gs-loc.apple.com", "gs-loc-cn.apple.com"]
+    );
+}
 
 fn assigned_device() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10))

--- a/tests/service_supervisor.rs
+++ b/tests/service_supervisor.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+
+use wificalling_location_gateway::service::control::{RuntimeControl, RuntimeFailure, RuntimeStep};
+use wificalling_location_gateway::service::supervisor::{
+    reduce, RestartBudget, RestartDecision, SupervisorEvent, SupervisorLimits, SupervisorPhase,
+    SupervisorState, SupervisorTransitionError, MANAGED_CHILDREN, MAX_MANAGED_CHILDREN,
+};
+
+fn limits() -> SupervisorLimits {
+    SupervisorLimits {
+        max_children: MAX_MANAGED_CHILDREN,
+        max_restart_attempts: 3,
+        restart_window: Duration::from_secs(300),
+        initial_restart_backoff: Duration::from_secs(5),
+        max_restart_backoff: Duration::from_secs(30),
+        health_poll_interval: Duration::from_secs(10),
+    }
+}
+
+fn ready_for_redirect() -> SupervisorState {
+    let limits = limits();
+    let state = reduce(
+        &SupervisorState::stopped(),
+        SupervisorEvent::StartRequested {
+            scope_valid: true,
+            ipv6_ready: true,
+            child_count: MANAGED_CHILDREN,
+        },
+        limits,
+    )
+    .unwrap();
+    let state = reduce(&state, SupervisorEvent::ChildrenReady, limits).unwrap();
+    reduce(&state, SupervisorEvent::WatchdogArmed, limits).unwrap()
+}
+
+#[test]
+fn redirect_is_last_and_stop_withdraws_before_children() {
+    let limits = limits();
+    let ready = ready_for_redirect();
+    let active = reduce(&ready, SupervisorEvent::RedirectInstalled, limits).unwrap();
+    assert_eq!(active.phase(), SupervisorPhase::Intercepting);
+    assert!(active.redirect_present());
+
+    let draining = reduce(&active, SupervisorEvent::StopRequested, limits).unwrap();
+    assert_eq!(draining.phase(), SupervisorPhase::Draining);
+    assert!(!draining.redirect_present());
+    assert!(!draining.watchdog_armed());
+
+    let stopped = reduce(&draining, SupervisorEvent::ChildrenStopped, limits).unwrap();
+    assert_eq!(stopped, SupervisorState::stopped());
+}
+
+#[test]
+fn invalid_scope_and_child_count_never_start() {
+    let limits = limits();
+    for (scope_valid, ipv6_ready) in [(false, true), (true, false), (false, false)] {
+        assert_eq!(
+            reduce(
+                &SupervisorState::stopped(),
+                SupervisorEvent::StartRequested {
+                    scope_valid,
+                    ipv6_ready,
+                    child_count: MANAGED_CHILDREN,
+                },
+                limits,
+            ),
+            Err(SupervisorTransitionError::InvalidSafetyScope)
+        );
+    }
+    assert_eq!(
+        reduce(
+            &SupervisorState::stopped(),
+            SupervisorEvent::StartRequested {
+                scope_valid: true,
+                ipv6_ready: true,
+                child_count: MAX_MANAGED_CHILDREN + 1,
+            },
+            limits,
+        ),
+        Err(SupervisorTransitionError::TooManyChildren)
+    );
+}
+
+#[test]
+fn health_failure_withdraws_redirect_and_enters_passthrough() {
+    let limits = limits();
+    let active = reduce(
+        &ready_for_redirect(),
+        SupervisorEvent::RedirectInstalled,
+        limits,
+    )
+    .unwrap();
+    let degraded = reduce(&active, SupervisorEvent::HealthFailed, limits).unwrap();
+    assert_eq!(degraded.phase(), SupervisorPhase::DegradedPassthrough);
+    assert!(!degraded.redirect_present());
+    assert!(!degraded.watchdog_armed());
+    assert_eq!(degraded.child_count(), MANAGED_CHILDREN);
+}
+
+#[test]
+fn restart_budget_is_bounded_and_backed_off() {
+    let limits = limits();
+    let mut budget = RestartBudget::new();
+    assert_eq!(
+        budget.decide(100, limits),
+        RestartDecision::Allowed {
+            delay: Duration::ZERO
+        }
+    );
+    budget.record_attempt(100, limits);
+    assert_eq!(
+        budget.decide(100, limits),
+        RestartDecision::Backoff { retry_at_unix: 105 }
+    );
+    assert_eq!(
+        budget.decide(105, limits),
+        RestartDecision::Allowed {
+            delay: Duration::from_secs(10)
+        }
+    );
+    budget.record_attempt(105, limits);
+    budget.record_attempt(115, limits);
+    assert_eq!(budget.decide(120, limits), RestartDecision::Exhausted);
+    assert_eq!(
+        budget.decide(401, limits),
+        RestartDecision::Allowed {
+            delay: Duration::ZERO
+        }
+    );
+}
+
+#[test]
+fn limits_reject_unbounded_runtime_configuration() {
+    let mut invalid = limits();
+    invalid.max_children = MAX_MANAGED_CHILDREN + 1;
+    assert!(invalid.validate().is_err());
+    invalid = limits();
+    invalid.health_poll_interval = Duration::from_secs(61);
+    assert!(invalid.validate().is_err());
+}
+
+#[derive(Default)]
+struct FakeRuntime {
+    operations: Vec<RuntimeStep>,
+    healthy: bool,
+    redirect_present: bool,
+}
+
+impl RuntimeControl for FakeRuntime {
+    fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::StartEngine);
+        Ok(())
+    }
+    fn engine_healthy(&mut self) -> Result<bool, RuntimeFailure> {
+        self.operations.push(RuntimeStep::CheckHealth);
+        Ok(self.healthy)
+    }
+    fn arm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::ArmWatchdog);
+        Ok(())
+    }
+    fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::InstallRedirect);
+        self.redirect_present = true;
+        Ok(())
+    }
+    fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::RemoveRedirect);
+        self.redirect_present = false;
+        Ok(())
+    }
+    fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
+        self.operations.push(RuntimeStep::VerifyRedirectAbsent);
+        Ok(self.redirect_present)
+    }
+    fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::DisarmWatchdog);
+        Ok(())
+    }
+    fn drain_engine(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::DrainEngine);
+        Ok(())
+    }
+    fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
+        self.operations.push(RuntimeStep::StopEngine);
+        Ok(())
+    }
+}
+
+#[test]
+fn supervisor_adapter_owns_control_ordering() {
+    let runtime = FakeRuntime {
+        healthy: true,
+        ..FakeRuntime::default()
+    };
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    supervisor.enable(true, true).unwrap();
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::Intercepting);
+    supervisor.disable().unwrap();
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::Stopped);
+}
+
+#[test]
+fn supervisor_maps_invalid_control_to_a_safe_stopped_state() {
+    let runtime = FakeRuntime::default();
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    assert!(supervisor.enable(false, true).is_err());
+    assert_eq!(supervisor.state(), SupervisorState::stopped());
+}

--- a/tests/service_supervisor.rs
+++ b/tests/service_supervisor.rs
@@ -144,46 +144,61 @@ struct FakeRuntime {
     operations: Vec<RuntimeStep>,
     healthy: bool,
     redirect_present: bool,
+    fail_step: Option<RuntimeStep>,
+}
+
+impl FakeRuntime {
+    fn should_fail(&self, step: RuntimeStep) -> Result<(), RuntimeFailure> {
+        if self.fail_step == Some(step) {
+            Err(RuntimeFailure)
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl RuntimeControl for FakeRuntime {
     fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::StartEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::StartEngine)
     }
     fn engine_healthy(&mut self) -> Result<bool, RuntimeFailure> {
         self.operations.push(RuntimeStep::CheckHealth);
+        self.should_fail(RuntimeStep::CheckHealth)?;
         Ok(self.healthy)
     }
     fn arm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::ArmWatchdog);
-        Ok(())
+        self.should_fail(RuntimeStep::ArmWatchdog)
     }
     fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::InstallRedirect);
+        self.should_fail(RuntimeStep::InstallRedirect)?;
         self.redirect_present = true;
         Ok(())
     }
     fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::RemoveRedirect);
+        self.should_fail(RuntimeStep::RemoveRedirect)?;
         self.redirect_present = false;
         Ok(())
     }
     fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
         self.operations.push(RuntimeStep::VerifyRedirectAbsent);
+        self.should_fail(RuntimeStep::VerifyRedirectAbsent)?;
         Ok(self.redirect_present)
     }
     fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::DisarmWatchdog);
-        Ok(())
+        self.should_fail(RuntimeStep::DisarmWatchdog)
     }
     fn drain_engine(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::DrainEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::DrainEngine)
     }
     fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
         self.operations.push(RuntimeStep::StopEngine);
-        Ok(())
+        self.should_fail(RuntimeStep::StopEngine)
     }
 }
 
@@ -208,4 +223,20 @@ fn supervisor_maps_invalid_control_to_a_safe_stopped_state() {
         wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
     assert!(supervisor.enable(false, true).is_err());
     assert_eq!(supervisor.state(), SupervisorState::stopped());
+}
+
+#[test]
+fn cleanup_failure_is_not_reported_as_stopped() {
+    let runtime = FakeRuntime {
+        healthy: true,
+        fail_step: Some(RuntimeStep::RemoveRedirect),
+        ..FakeRuntime::default()
+    };
+    let mut supervisor =
+        wificalling_location_gateway::service::supervisor::UnifiedSupervisor::new(runtime);
+    supervisor.enable(true, true).unwrap();
+
+    assert!(supervisor.disable().is_err());
+    assert_eq!(supervisor.state().phase(), SupervisorPhase::CleanupUnsafe);
+    assert!(supervisor.state().redirect_present());
 }

--- a/tests/test_v2_ui_contract.py
+++ b/tests/test_v2_ui_contract.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class V2UiContractTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[1]
+
+    def test_profile_pages_and_menu_are_present_in_both_package_sources(self):
+        for prefix in (
+            self.root / "openwrt/files",
+            self.root / "openwrt/luci-app-wificalling-location-gateway/files",
+        ):
+            page = prefix / "www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js"
+            health = prefix / "www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js"
+            menu = prefix / "usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json"
+            rpc = prefix / "usr/libexec/rpcd/luci.wloc"
+            self.assertTrue(page.exists(), prefix)
+            self.assertIn("restart_unified", rpc.read_text(encoding="utf-8"))
+            self.assertIn("profiles", health.read_text(encoding="utf-8"))
+            menu_data = json.loads(menu.read_text(encoding="utf-8"))
+            self.assertIn(
+                "admin/services/wificalling-location-gateway/wloc-devices",
+                menu_data,
+            )
+
+    def test_profile_page_sources_parse_as_javascript(self):
+        for relative in (
+            "openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js",
+            "openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-devices.js",
+        ):
+            result = subprocess.run(
+                ["node", "--check", str(self.root / relative)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, result.returncode, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35

## Summary

- Adds bounded per-profile runtime state and independent redirect lifecycle.
- Adds isolated OpenWrt profile nftables helpers, redacted health projection, and LuCI device/status surfaces.
- Bounds WLOC/Gateway logs, synthesized-client cache, and debug samples for small gateways.

## Verification

- `./scripts/ci/verify.sh` passed.
- Rust tests, clippy, profile redirect/status, log bound, supervisor, AX6S package, release packaging, and LuCI contract tests passed.
- Independent review found no P0-P3 findings.

## Release boundary

The production daemon still intentionally refuses live multi-profile selection until Issue #36 integrates per-profile node probing and source-device patch routing. This PR is foundations only and does not claim the complete V2.0 feature.

Handoff capsule: `.handoffs/issue-35.md`
