### PR TITLE
feat: add production multi-profile WLOC dispatcher

### DIFF
--- a/.handoffs/issue-36.md
+++ b/.handoffs/issue-36.md
@@ -1,0 +1,117 @@
+# Agent handoff: Issue 36
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: rust,openwrt,network,test
+- Branch: codex/issue-36-v2-profile-dispatcher-codex-v2-lead-20260821071402-acda6a62
+- Checkpoint parent: 7a50ef8
+- Updated at (UTC): 2026-08-21T08:32:35Z
+- Credentials included: no
+
+## Objective
+
+Implement production multi-profile WLOC routing for Issue #36: one validated
+IPv4 LAN device per profile, independent node/probe/Geo handler and patch sink,
+shared Gateway/WLOC engine, fail-open behavior, and verified profile-scoped
+redirect ownership.
+
+## Completed
+
+- Added bounded `ProfilePatchRouter` source-device dispatch with no default
+  profile fallback and explicit MAC/IPv6 rejection in the current adapter.
+- Added one independent WLOC probe/Geo handler per profile while retaining one
+  shared `ProfileRuntimeManager`/Gateway engine.
+- Added profile enable/disable/reload routing and auto/manual target isolation.
+- Made every profile route start disabled and enable only after redirect
+  installation and status verification.
+- Removed legacy all-device redirect ownership from multi-profile mode while
+  preserving the shared fwmark/local TPROXY route required by profile tables.
+- Added profile `stop-all`, orphan/disabled table cleanup, stale legacy table
+  cleanup, and bounded proxy-ready/activation/profile-ready startup markers.
+- Added Rust and shell regression coverage, documentation, and integrated the
+  profile tests into `scripts/ci/verify.sh`.
+
+## Files changed
+
+- `src/bin/wloc-service.rs`
+- `src/service/dispatch.rs`
+- `src/service/profile_dispatch.rs`
+- `src/mitm/proxy.rs`
+- `openwrt/files/usr/sbin/wloc-profile-redirect.sh`
+- `openwrt/files/usr/sbin/wloc-redirect-sync.sh`
+- `openwrt/files/usr/sbin/wloc-refresh-set.sh`
+- `openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh`
+- `openwrt/files/etc/init.d/wloc-service`
+- `openwrt/files/etc/init.d/wificalling-location-gateway`
+- `openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc`
+- `tests/profile_dispatch.rs`
+- `tests/scripts/test-profile-redirect.sh`
+- `tests/scripts/test-unified-supervisor.sh`
+- `scripts/ci/verify.sh`
+- `docs/testing/V2_PROFILE_DISPATCHER.tdd.md`
+- `docs/api/WLOC_SERVICE_API_V2_DRAFT.md`
+- `docs/releases/V2.0_TASK_BREAKDOWN.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./scripts/ci/verify.sh` | Passed | Full repository gates; 71 Python tests, OpenWrt/AX6S packaging, Rust audit and release checks |
+| `cargo test --all-targets` | Passed | All Rust unit/integration targets passed; one documented live-network test ignored |
+| `cargo clippy --all-targets --all-features -- -D warnings` | Passed | No warnings |
+| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed | 80.17% total Rust line coverage on final full run |
+| `./tests/scripts/test-profile-redirect.sh` | Passed | Route install/remove, stale global cleanup, disabled/orphan cleanup, scope guards |
+| `./tests/scripts/test-unified-supervisor.sh` | Passed | Profile route/readiness contract, legacy-table exclusion, cleanup ordering |
+| Independent reviewer | APPROVE | No P0/P1/P2; one non-blocking P3 test marker hygiene suggestion |
+
+## Failed attempts
+
+- Initial full verification was below the 80% Rust coverage gate; added
+  profile-group lifecycle tests and restored coverage above the threshold.
+- Independent review found and fixed three successive P1 classes: legacy
+  global redirect overlap, missing shared policy route/stale table cleanup,
+  and profile redirect installation before proxy/supervisor readiness.
+
+## Unresolved decisions and blockers
+
+- Live v2 profile CRUD/mutation dispatch and the unified LuCI device management
+  UI remain Issue #37 by design; the current V1 control facade targets the
+  deterministic default profile.
+- Structured log UI/support bundle remains Issue #38.
+- Component update/compatibility/rollback remains Issue #39.
+- AX6S real-device resource evidence remains Issue #40.
+- Migration rehearsal and final release acceptance remain Issue #41.
+- Non-blocking hygiene: the Rust profile-group lifecycle test uses the default
+  readiness marker path and may log a permission warning in an unprivileged
+  checkout; production startup marker handling is bounded and fail-safe.
+
+## Next executable steps
+
+1. Run `scripts/agent-handoff.sh 36 codex-v2-lead rust,openwrt,network,test`.
+2. Open a PR against `main` with `Closes #36` and this handoff capsule.
+3. Require the independent review and all GitHub checks before merging.
+4. After merge, take Issue #37 and implement live profile mutation plus the
+   unified LuCI settings/device/status UI.
+
+## Capabilities required for the next Agent
+
+- `rust`, `openwrt`, `network`, `test`, and security-sensitive nft/procd review.
+
+## Environment assumptions
+
+- OpenWrt provides UCI, nft, ip, procd, a root-owned `/var/run` hierarchy,
+  and the packaged profile/global helper paths.
+- Multi-profile runtime bindings are IPv4 addresses until a future adapter
+  explicitly supports MAC/IPv6 bindings.
+- `WLOC_SUPERVISED=1` is set by the unified procd supervisor; standalone
+  daemon mode activates only after the proxy listener is bound.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- Redirect scope remains profile-assigned device + exact Apple WLOC hostnames
+  + TCP 443; UDP 500/4500 and the stable Gateway nft namespace are untouched.
+- Unknown sources, disabled/degraded profiles, invalid Geo targets, missing
+  readiness markers, and runtime failures fail open without fake coordinates.

--- a/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
+++ b/docs/api/WLOC_SERVICE_API_V2_DRAFT.md
@@ -1,8 +1,9 @@
 # Unified Gateway/WLOC control API v2 draft
 
 Status: proposed contract; profile request decoding and bounded local runtime
-primitives are implemented, but the v2 dispatcher and production multi-profile
-Geo/patch routing are not complete. It does not change the frozen
+primitives are implemented, and production source-device multi-profile
+Geo/patch routing is now integrated. Live v2 profile mutation dispatch remains
+a subsequent control-plane slice. It does not change the frozen
 `wloc.service/v1` contract.
 
 ## Purpose

--- a/docs/releases/V2.0_TASK_BREAKDOWN.md
+++ b/docs/releases/V2.0_TASK_BREAKDOWN.md
@@ -1,6 +1,6 @@
 # v2.0 task breakdown and ownership
 
-Status: active implementation under GitHub Issue #35; the project lead owns
+Status: active implementation under GitHub Issue #36; the project lead owns
 integration and acceptance. This document is the implementation checklist,
 not a release approval.
 
@@ -16,12 +16,14 @@ Completed on the V2-03 branch and covered by focused tests:
   page/status table;
 - bounded WLOC event log (64 KiB), Gateway activity log (configurable default
   64 KiB), synthesized-client cache, and debug sample files.
+- V2-04 source-device profile patch routing, independent per-profile probe/Geo
+  handlers, auto/manual target isolation, and redirect-gated route activation.
 
 Still not accepted for a v2 release:
 
-- the production daemon still consumes one `WlocService` patch/Geo context;
-  multiple profiles must not be enabled against it until per-profile node
-  probing and source-device patch routing are integrated;
+- live v2 profile API mutation and LuCI per-profile operations are still
+  pending; the V1 control facade remains bound to the deterministic default
+  profile while the production data plane is profile-scoped;
 - LuCI profile save/restart is a configuration surface, not proof of live
   multi-profile interception;
 - component update/rollback, migration rehearsal, AX6S real-device memory and

--- a/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
+++ b/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
@@ -1,0 +1,32 @@
+# V2-04 profile dispatcher test evidence
+
+## Scope
+
+The production data path now creates one probe/Geo handler per validated IPv4
+device profile while keeping one shared Gateway/WLOC supervisor. The MITM
+proxy resolves the source TCP address to exactly one profile target.
+
+## Safety contract
+
+- Every route starts disabled, even when UCI says `enabled=1`.
+- A route is enabled only after its isolated redirect is installed and verified.
+- Unknown, invalid, disabled, degraded, or target-less routes return no target.
+- Manual target clear withdraws that profile until fresh auto evidence returns.
+- MAC and IPv6 bindings are rejected by the current IPv4 redirect adapter.
+
+## Verification
+
+| Command | Result |
+|---|---|
+| `cargo test --all-targets` | Passed; all Rust targets including 6 dispatcher tests |
+| `cargo clippy --all-targets --all-features -- -D warnings` | Passed |
+| `tests/scripts/test-profile-redirect.sh` | Passed |
+| `tests/scripts/test-profile-status.sh` | Passed |
+| `tests/scripts/test-unified-supervisor.sh` | Passed |
+| `python3 -m unittest tests.test_v2_ui_contract tests.test_wloc_luci_mode` | Passed |
+
+## Remaining release gates
+
+- Live v2 profile mutation dispatch and LuCI mutations remain Issue #37.
+- Real AX6S resource evidence remains Issue #40.
+- Update/rollback and migration rehearsal remain Issues #39 and #41.

--- a/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
+++ b/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
@@ -15,8 +15,11 @@ proxy resolves the source TCP address to exactly one profile target.
 - MAC and IPv6 bindings are rejected by the current IPv4 redirect adapter.
 - Multi-profile mode never installs the legacy all-device `wloc_service` table;
   only verified profile-scoped tables may intercept.
+- Profile-scoped start installs the shared fwmark/local policy route required
+  by every profile TPROXY chain, without recreating the legacy table.
 - Supervisor, init, and CA/reload cleanup paths remove all profile tables;
-  refresh deletes disabled or orphaned tables instead of refreshing them.
+  refresh deletes disabled or orphaned tables instead of refreshing them. A
+  stale legacy table is removed during profile-mode startup and refresh.
 
 ## Verification
 
@@ -31,9 +34,9 @@ proxy resolves the source TCP address to exactly one profile target.
 | `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed; 80.74% lines |
 
 The independent review initially returned `REQUEST_CHANGES` for global redirect
-ownership and stale profile-table cleanup. Those findings were fixed before
-handoff and are covered by the profile helper and unified supervisor shell
-tests above.
+ownership, stale profile-table cleanup, and the shared policy route. Those
+findings were fixed before handoff and are covered by the profile helper and
+unified supervisor shell tests above.
 
 ## Remaining release gates
 

--- a/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
+++ b/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
@@ -13,6 +13,10 @@ proxy resolves the source TCP address to exactly one profile target.
 - Unknown, invalid, disabled, degraded, or target-less routes return no target.
 - Manual target clear withdraws that profile until fresh auto evidence returns.
 - MAC and IPv6 bindings are rejected by the current IPv4 redirect adapter.
+- Multi-profile mode never installs the legacy all-device `wloc_service` table;
+  only verified profile-scoped tables may intercept.
+- Supervisor, init, and CA/reload cleanup paths remove all profile tables;
+  refresh deletes disabled or orphaned tables instead of refreshing them.
 
 ## Verification
 
@@ -24,6 +28,12 @@ proxy resolves the source TCP address to exactly one profile target.
 | `tests/scripts/test-profile-status.sh` | Passed |
 | `tests/scripts/test-unified-supervisor.sh` | Passed |
 | `python3 -m unittest tests.test_v2_ui_contract tests.test_wloc_luci_mode` | Passed |
+| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed; 80.74% lines |
+
+The independent review initially returned `REQUEST_CHANGES` for global redirect
+ownership and stale profile-table cleanup. Those findings were fixed before
+handoff and are covered by the profile helper and unified supervisor shell
+tests above.
 
 ## Remaining release gates
 

--- a/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
+++ b/docs/testing/V2_PROFILE_DISPATCHER.tdd.md
@@ -20,6 +20,9 @@ proxy resolves the source TCP address to exactly one profile target.
 - Supervisor, init, and CA/reload cleanup paths remove all profile tables;
   refresh deletes disabled or orphaned tables instead of refreshing them. A
   stale legacy table is removed during profile-mode startup and refresh.
+- In supervised mode, the daemon publishes proxy-listener readiness first;
+  the supervisor then installs the shared route and signals profile activation.
+  Profile redirects are not installed until that signal and readiness return.
 
 ## Verification
 

--- a/openwrt/files/etc/init.d/wificalling-location-gateway
+++ b/openwrt/files/etc/init.d/wificalling-location-gateway
@@ -36,6 +36,8 @@ stop_service() {
 	[ -x "$SUPERVISOR" ] && "$SUPERVISOR" stop >/dev/null 2>&1 || true
 	# Idempotent defensive cleanup if the procd instance was already gone.
 	[ -x /usr/sbin/wloc-redirect-sync.sh ] && /usr/sbin/wloc-redirect-sync.sh stop >/dev/null 2>&1 || true
+	[ -x /usr/sbin/wloc-profile-redirect.sh ] && \
+		/usr/sbin/wloc-profile-redirect.sh stop-all >/dev/null 2>&1 || true
 }
 
 reload_service() {

--- a/openwrt/files/etc/init.d/wloc-service
+++ b/openwrt/files/etc/init.d/wloc-service
@@ -43,4 +43,6 @@ start_service() {
 
 stop_service() {
 	rm -f "$SOCKET"
+	[ -x /usr/sbin/wloc-profile-redirect.sh ] && \
+		/usr/sbin/wloc-profile-redirect.sh stop-all >/dev/null 2>&1 || true
 }

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -17,6 +17,7 @@ LOCKDIR=$RUNDIR/.lock
 WLOC_INIT=${WLOC_INIT:-/etc/init.d/wloc-service}
 GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
+PROFILE_REDIRECT_HELPER=${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
 START_TIMEOUT=${WLOC_SUPERVISOR_START_TIMEOUT:-30}
@@ -69,11 +70,40 @@ withdraw_redirect() {
 	[ -x "$REDIRECT_HELPER" ] && "$REDIRECT_HELPER" stop >/dev/null 2>&1 || true
 }
 
+withdraw_profile_redirects() {
+	[ -x "$PROFILE_REDIRECT_HELPER" ] && \
+		"$PROFILE_REDIRECT_HELPER" stop-all >/dev/null 2>&1 || true
+}
+
+profile_mode() {
+	case "${WLOC_PROFILE_MODE:-auto}" in
+		1|yes|profile) return 0 ;;
+		0|no|legacy) return 1 ;;
+	esac
+	command -v uci >/dev/null 2>&1 || return 1
+	profiles=$(uci -q show wloc-service 2>/dev/null \
+		| sed -n 's/^wloc-service\.[a-z0-9_-]*=device$/x/p' \
+		| wc -l | tr -d ' ')
+	[ "${profiles:-0}" -gt 1 ] 2>/dev/null
+}
+
+install_redirect() {
+	if profile_mode; then
+		# In multi-profile mode wloc-service owns one verified redirect per
+		# profile. Installing the legacy all-device table here would bypass
+		# ProfilePatchRouter's disabled/fail-closed boundary.
+		redirect_present=1
+		return 0
+	fi
+	"$REDIRECT_HELPER" start
+}
+
 cleanup_runtime() {
 	reason=$1
 	keep_gateway=${2:-1}
 	state_phase=${3:-degraded_passthrough}
 	withdraw_redirect
+	withdraw_profile_redirects
 	stop_child "$WLOC_INIT"
 	wloc_running=0
 	if [ "$keep_gateway" -eq 1 ]; then
@@ -172,7 +202,7 @@ start_supervisor() {
 		cleanup_runtime child_health_failed 1
 		exit 1
 	fi
-	if ! "$REDIRECT_HELPER" start >/dev/null 2>&1; then
+	if ! install_redirect >/dev/null 2>&1; then
 		cleanup_runtime redirect_install_failed 1
 		exit 1
 	fi

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -91,7 +91,11 @@ install_redirect() {
 	if profile_mode; then
 		# In multi-profile mode wloc-service owns one verified redirect per
 		# profile. Installing the legacy all-device table here would bypass
-		# ProfilePatchRouter's disabled/fail-closed boundary.
+		# ProfilePatchRouter's disabled/fail-closed boundary. The shared
+		# policy route is still required by every profile-scoped TPROXY chain.
+		"$REDIRECT_HELPER" legacy-stop
+		[ -x "$PROFILE_REDIRECT_HELPER" ] || return 1
+		"$PROFILE_REDIRECT_HELPER" route-start
 		redirect_present=1
 		return 0
 	fi
@@ -179,6 +183,11 @@ start_supervisor() {
 	[ -x "$WLOC_INIT" ] && "$WLOC_INIT" disable >/dev/null 2>&1 || true
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
+	if profile_mode; then
+		# Remove a legacy all-device table before either child becomes ready;
+		# startup must never inherit interception from the previous mode.
+		"$REDIRECT_HELPER" legacy-stop >/dev/null 2>&1 || true
+	fi
 
 	if ! gateway_healthy; then
 		if ! WLOC_SUPERVISED=1 "$GATEWAY_INIT" start >/dev/null 2>&1; then

--- a/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
+++ b/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh
@@ -18,6 +18,9 @@ WLOC_INIT=${WLOC_INIT:-/etc/init.d/wloc-service}
 GATEWAY_INIT=${GATEWAY_INIT:-/etc/init.d/wificalling-gateway}
 REDIRECT_HELPER=${WLOC_REDIRECT_HELPER:-/usr/sbin/wloc-redirect-sync.sh}
 PROFILE_REDIRECT_HELPER=${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}
+PROFILE_PROXY_READY_FILE=${WLOC_PROFILE_PROXY_READY_FILE:-/var/run/wloc-service/profiles/.proxy-ready}
+PROFILE_ACTIVATE_FILE=${WLOC_PROFILE_ACTIVATE_FILE:-/var/run/wloc-service/profiles/.activate}
+PROFILE_READY_FILE=${WLOC_PROFILE_READY_FILE:-/var/run/wloc-service/profiles/.ready}
 CHECK_INTERVAL=${WLOC_SUPERVISOR_HEALTH_INTERVAL:-10}
 MAX_RUNTIME_SECONDS=${WLOC_SUPERVISOR_MAX_RUNTIME:-0}
 START_TIMEOUT=${WLOC_SUPERVISOR_START_TIMEOUT:-30}
@@ -73,6 +76,7 @@ withdraw_redirect() {
 withdraw_profile_redirects() {
 	[ -x "$PROFILE_REDIRECT_HELPER" ] && \
 		"$PROFILE_REDIRECT_HELPER" stop-all >/dev/null 2>&1 || true
+	rm -f "$PROFILE_PROXY_READY_FILE" "$PROFILE_ACTIVATE_FILE" "$PROFILE_READY_FILE"
 }
 
 profile_mode() {
@@ -96,6 +100,12 @@ install_redirect() {
 		"$REDIRECT_HELPER" legacy-stop
 		[ -x "$PROFILE_REDIRECT_HELPER" ] || return 1
 		"$PROFILE_REDIRECT_HELPER" route-start
+		: > "$PROFILE_ACTIVATE_FILE"
+		deadline=$(( $(now) + START_TIMEOUT ))
+		while [ ! -f "$PROFILE_READY_FILE" ]; do
+			[ "$(now)" -lt "$deadline" ] || return 1
+			sleep 1
+		done
 		redirect_present=1
 		return 0
 	fi
@@ -145,6 +155,9 @@ health_ok() {
 		return 1
 	fi
 	[ -S "${WLOC_SOCKET:-/var/run/wloc-service/control.sock}" ] || return 1
+	if profile_mode; then
+		[ -f "$PROFILE_PROXY_READY_FILE" ] || return 1
+	fi
 }
 
 gateway_healthy() {
@@ -184,8 +197,9 @@ start_supervisor() {
 	[ -x "$GATEWAY_INIT" ] && "$GATEWAY_INIT" disable >/dev/null 2>&1 || true
 	stop_child "$WLOC_INIT"
 	if profile_mode; then
-		# Remove a legacy all-device table before either child becomes ready;
-		# startup must never inherit interception from the previous mode.
+		# Remove all profile and legacy tables before either child becomes
+		# ready; startup must never inherit interception from the previous mode.
+		withdraw_profile_redirects
 		"$REDIRECT_HELPER" legacy-stop >/dev/null 2>&1 || true
 	fi
 

--- a/openwrt/files/usr/sbin/wloc-profile-redirect.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-redirect.sh
@@ -53,11 +53,31 @@ valid_private_ipv4() {
 	esac
 }
 
+stop_all_profiles() {
+	# This is the crash/upgrade cleanup boundary. Only tables with the exact
+	# component-owned prefix are eligible; the stable Gateway namespace is
+	# never enumerated or modified here.
+	for table in $("$nft_binary" list tables inet 2>/dev/null \
+		| sed -n 's/^table inet \(wloc_profile_[a-z0-9_-]*\)$/\1/p'); do
+		case "$table" in
+			wloc_profile_*|*[!a-z0-9_-]*)
+				case "$table" in *[!a-z0-9_-]*) continue ;; esac
+				;;
+			*) continue ;;
+		esac
+		"$nft_binary" delete table inet "$table" 2>/dev/null || true
+	done
+}
+
 action=${1:-}
 profile_id=${2:-}
 nft_binary=${WLOC_NFT_BINARY:-nft}
 
 case "$action" in
+	stop-all)
+		[ "$#" -eq 1 ] || fail 'usage: stop-all'
+		stop_all_profiles
+		;;
 	start)
 		[ "$#" -eq 3 ] || fail 'usage: start PROFILE_ID PRIVATE_IPV4'
 		valid_profile_id "$profile_id" || fail 'invalid profile id'

--- a/openwrt/files/usr/sbin/wloc-profile-redirect.sh
+++ b/openwrt/files/usr/sbin/wloc-profile-redirect.sh
@@ -12,6 +12,8 @@ set -eu
 PROFILE_TABLE_PREFIX=wloc_profile_
 PROXY_PORT=${WLOC_PROFILE_PROXY_PORT:-${WLOC_PROXY_PORT:-8443}}
 FWMARK=1
+ROUTE_TABLE=100
+IP_BINARY=${WLOC_IP_BINARY:-ip}
 
 fail() {
 	printf 'wloc-profile-redirect: %s\n' "$*" >&2
@@ -67,6 +69,19 @@ stop_all_profiles() {
 		esac
 		"$nft_binary" delete table inet "$table" 2>/dev/null || true
 	done
+	remove_policy_route
+}
+
+install_policy_route() {
+	"$IP_BINARY" rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+	"$IP_BINARY" route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
+	"$IP_BINARY" rule add fwmark "$FWMARK" lookup "$ROUTE_TABLE"
+	"$IP_BINARY" route add local 0.0.0.0/0 dev lo table "$ROUTE_TABLE"
+}
+
+remove_policy_route() {
+	"$IP_BINARY" rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+	"$IP_BINARY" route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
 }
 
 action=${1:-}
@@ -74,6 +89,14 @@ profile_id=${2:-}
 nft_binary=${WLOC_NFT_BINARY:-nft}
 
 case "$action" in
+	route-start)
+		[ "$#" -eq 1 ] || fail 'usage: route-start'
+		install_policy_route
+		;;
+	route-stop)
+		[ "$#" -eq 1 ] || fail 'usage: route-stop'
+		remove_policy_route
+		;;
 	stop-all)
 		[ "$#" -eq 1 ] || fail 'usage: stop-all'
 		stop_all_profiles
@@ -91,12 +114,16 @@ case "$action" in
 		"$nft_binary" delete chain inet "$table" prerouting 2>/dev/null || true
 		"$nft_binary" "add chain inet $table prerouting { type filter hook prerouting priority mangle; }"
 		"$nft_binary" "add rule inet $table prerouting ip saddr $device_ip tcp dport 443 ip daddr @apple_hosts meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
+		install_policy_route
 		printf 'wloc-profile-redirect: %s -> :%s\n' "$profile_id" "$PROXY_PORT"
 		;;
 	stop)
 		[ "$#" -eq 2 ] || fail 'usage: stop PROFILE_ID'
 		valid_profile_id "$profile_id" || fail 'invalid profile id'
 		"$nft_binary" delete table inet "${PROFILE_TABLE_PREFIX}${profile_id}" 2>/dev/null || true
+		remaining=$("$nft_binary" list tables inet 2>/dev/null \
+			| sed -n 's/^table inet \(wloc_profile_[a-z0-9_-]*\)$/\1/p')
+		[ -n "$remaining" ] || remove_policy_route
 		;;
 	status)
 		[ "$#" -eq 2 ] || fail 'usage: status PROFILE_ID'

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -18,6 +18,8 @@ FWMARK=1
 ROUTE_TABLE=100
 action=${1:-start}
 NFT_BINARY=${WLOC_NFT_BINARY:-nft}
+IP_BINARY=${WLOC_IP_BINARY:-ip}
+PROFILE_HELPER=${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}
 
 multiple_profiles_configured() {
 	command -v uci >/dev/null 2>&1 || return 1
@@ -27,24 +29,34 @@ multiple_profiles_configured() {
 	[ "${profiles:-0}" -gt 1 ] 2>/dev/null
 }
 
-if [ "$action" = stop ]; then
+withdraw_legacy_redirect() {
 	# Only remove the WLOC-owned table, policy route, and DNS marker. The
 	# stable Gateway 1.7 nftables table (and UDP 500/4500 handling) is never
 	# touched by this cleanup path.
 	"$NFT_BINARY" delete table inet "$TABLE" 2>/dev/null || true
-	ip rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
-	ip route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
-	[ -x "${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}" ] && \
-		"${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}" stop-all >/dev/null 2>&1 || true
+	"$IP_BINARY" rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+	"$IP_BINARY" route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
 	for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
 		sed -i '/# wloc-service DNS hijack (do not edit)/,/^# wloc-service end/d' "$hosts_file" 2>/dev/null || true
 	done
+	}
+
+if [ "$action" = stop ] || [ "$action" = legacy-stop ]; then
+	withdraw_legacy_redirect
+	if [ "$action" = stop ] && [ -x "$PROFILE_HELPER" ]; then
+		"$PROFILE_HELPER" stop-all >/dev/null 2>&1 || true
+	fi
 	exit 0
 fi
 
 if [ "$action" = start ] && multiple_profiles_configured; then
 	# The profile dispatcher installs only verified, profile-scoped rules. The
-	# legacy all-device table must not be installed alongside it.
+	# legacy all-device table must not be installed alongside it. Its stale
+	# table and DNS marker are removed, while the shared policy route remains
+	# available to the profile-scoped TPROXY chains.
+	withdraw_legacy_redirect
+	[ -x "$PROFILE_HELPER" ] || exit 1
+	"$PROFILE_HELPER" route-start
 	exit 0
 fi
 
@@ -94,26 +106,26 @@ EOF
 done
 
 # TPROXY plumbing: marked packets are routed back to the local stack.
-ip rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
-ip route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
-ip rule add fwmark "$FWMARK" lookup "$ROUTE_TABLE"
-ip route add local 0.0.0.0/0 dev lo table "$ROUTE_TABLE"
+"$IP_BINARY" rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
+"$IP_BINARY" route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
+"$IP_BINARY" rule add fwmark "$FWMARK" lookup "$ROUTE_TABLE"
+"$IP_BINARY" route add local 0.0.0.0/0 dev lo table "$ROUTE_TABLE"
 
 # Table + set + mangle prerouting chain (filter hook, before DNAT).
-nft add table inet "$TABLE" 2>/dev/null || true
-nft add set inet "$TABLE" apple_hosts '{ type ipv4_addr; }' 2>/dev/null || true
+"$NFT_BINARY" add table inet "$TABLE" 2>/dev/null || true
+"$NFT_BINARY" add set inet "$TABLE" apple_hosts '{ type ipv4_addr; }' 2>/dev/null || true
 # The chain must be a filter/mangle chain for tproxy; drop a leftover
 # nat chain (from the old redirect scheme) first.
-nft flush chain inet "$TABLE" "$CHAIN" 2>/dev/null || true
-nft delete chain inet "$TABLE" "$CHAIN" 2>/dev/null || true
-nft "add chain inet $TABLE $CHAIN { type filter hook prerouting priority mangle; }"
+"$NFT_BINARY" flush chain inet "$TABLE" "$CHAIN" 2>/dev/null || true
+"$NFT_BINARY" delete chain inet "$TABLE" "$CHAIN" 2>/dev/null || true
+"$NFT_BINARY" "add chain inet $TABLE $CHAIN { type filter hook prerouting priority mangle; }"
 
 # Rebuild only the rules; the apple_hosts set content is untouched.
 # Match both the DNS-set Apple IPs and the hijacked local address.
-nft flush chain inet "$TABLE" "$CHAIN"
+"$NFT_BINARY" flush chain inet "$TABLE" "$CHAIN"
 for ip in $ips; do
-    nft "add rule inet $TABLE $CHAIN ip saddr $ip tcp dport 443 ip daddr @apple_hosts meta l4proto tcp meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
-    nft "add rule inet $TABLE $CHAIN ip saddr $ip tcp dport 443 ip daddr $ROUTER_IP meta l4proto tcp meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
+    "$NFT_BINARY" "add rule inet $TABLE $CHAIN ip saddr $ip tcp dport 443 ip daddr @apple_hosts meta l4proto tcp meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
+    "$NFT_BINARY" "add rule inet $TABLE $CHAIN ip saddr $ip tcp dport 443 ip daddr $ROUTER_IP meta l4proto tcp meta mark set $FWMARK tproxy ip to :$PROXY_PORT"
 done
 
 echo "wloc-redirect-sync: tproxy $ips -> :$PROXY_PORT (mark $FWMARK, table $ROUTE_TABLE)"

--- a/openwrt/files/usr/sbin/wloc-redirect-sync.sh
+++ b/openwrt/files/usr/sbin/wloc-redirect-sync.sh
@@ -17,17 +17,34 @@ PROXY_PORT="${WLOC_PROXY_PORT:-8443}"
 FWMARK=1
 ROUTE_TABLE=100
 action=${1:-start}
+NFT_BINARY=${WLOC_NFT_BINARY:-nft}
+
+multiple_profiles_configured() {
+	command -v uci >/dev/null 2>&1 || return 1
+	profiles=$(uci -q show wloc-service 2>/dev/null \
+		| sed -n 's/^wloc-service\.[a-z0-9_-]*=device$/x/p' \
+		| wc -l | tr -d ' ')
+	[ "${profiles:-0}" -gt 1 ] 2>/dev/null
+}
 
 if [ "$action" = stop ]; then
 	# Only remove the WLOC-owned table, policy route, and DNS marker. The
 	# stable Gateway 1.7 nftables table (and UDP 500/4500 handling) is never
 	# touched by this cleanup path.
-	nft delete table inet "$TABLE" 2>/dev/null || true
+	"$NFT_BINARY" delete table inet "$TABLE" 2>/dev/null || true
 	ip rule del fwmark "$FWMARK" lookup "$ROUTE_TABLE" 2>/dev/null || true
 	ip route del local 0.0.0.0/0 dev lo table "$ROUTE_TABLE" 2>/dev/null || true
+	[ -x "${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}" ] && \
+		"${WLOC_PROFILE_REDIRECT_HELPER:-/usr/sbin/wloc-profile-redirect.sh}" stop-all >/dev/null 2>&1 || true
 	for hosts_file in ${WLOC_HOSTS_FILES:-/etc/hosts\ /tmp/hosts/wloc-hosts}; do
 		sed -i '/# wloc-service DNS hijack (do not edit)/,/^# wloc-service end/d' "$hosts_file" 2>/dev/null || true
 	done
+	exit 0
+fi
+
+if [ "$action" = start ] && multiple_profiles_configured; then
+	# The profile dispatcher installs only verified, profile-scoped rules. The
+	# legacy all-device table must not be installed alongside it.
 	exit 0
 fi
 

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -65,8 +65,19 @@ fi
 profile_tables=$(
     "$NFT_BINARY" list tables inet 2>/dev/null \
         | sed -n 's/^table inet \(wloc_profile_[a-z0-9_-]*\)$/\1/p' \
-        || true
+		|| true
 )
+profile_is_live() {
+	profile_id=$1
+	command -v uci >/dev/null 2>&1 || return 1
+	uci -q show wloc-service 2>/dev/null \
+		| grep -F "wloc-service.${profile_id}=device" >/dev/null 2>&1 || return 1
+	enabled=$(uci -q get "wloc-service.${profile_id}.enabled" 2>/dev/null || true)
+	case "$enabled" in
+		''|1|true|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
 while IFS= read -r profile_table; do
     [ -n "$profile_table" ] || continue
     case "$profile_table" in
@@ -75,9 +86,17 @@ while IFS= read -r profile_table; do
                 *[!a-z0-9_-]*) continue ;;
             esac
             ;;
-        *) continue ;;
-    esac
-    "$NFT_BINARY" flush set inet "$profile_table" "$SET" 2>/dev/null || \
+		*) continue ;;
+	esac
+	profile_id=${profile_table#wloc_profile_}
+	if ! profile_is_live "$profile_id"; then
+		# A daemon crash, config removal, or upgrade can leave a kernel table
+		# behind. Do not refresh it back into an apparently live interception
+		# path; remove it at this bounded cleanup point.
+		"$NFT_BINARY" delete table inet "$profile_table" 2>/dev/null || true
+		continue
+	fi
+	"$NFT_BINARY" flush set inet "$profile_table" "$SET" 2>/dev/null || \
         "$NFT_BINARY" add set inet "$profile_table" "$SET" '{ type ipv4_addr; }'
     "$NFT_BINARY" add element inet "$profile_table" "$SET" "{ $ips }"
 done <<EOF

--- a/openwrt/files/usr/sbin/wloc-refresh-set.sh
+++ b/openwrt/files/usr/sbin/wloc-refresh-set.sh
@@ -52,7 +52,19 @@ ips=$(collect | grep -v "^$ROUTER_IP$" | sort -u | tr '
     exit 1
 }
 
-if "$NFT_BINARY" list table inet "$TABLE" >/dev/null 2>&1; then
+multiple_profiles_configured() {
+	command -v uci >/dev/null 2>&1 || return 1
+	profiles=$(uci -q show wloc-service 2>/dev/null \
+		| sed -n 's/^wloc-service\.[a-z0-9_-]*=device$/x/p' \
+		| wc -l | tr -d ' ')
+	[ "${profiles:-0}" -gt 1 ] 2>/dev/null
+}
+
+if multiple_profiles_configured; then
+	# A legacy table can survive a mode migration or abrupt kill. It is never
+	# refreshed in multi-profile mode; remove it before refreshing profile sets.
+	"$NFT_BINARY" delete table inet "$TABLE" 2>/dev/null || true
+elif "$NFT_BINARY" list table inet "$TABLE" >/dev/null 2>&1; then
 	"$NFT_BINARY" flush set inet "$TABLE" "$SET" 2>/dev/null || \
 		"$NFT_BINARY" add set inet "$TABLE" "$SET" '{ type ipv4_addr; }'
 	"$NFT_BINARY" add element inet "$TABLE" "$SET" "{ $ips }"

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
@@ -214,6 +214,7 @@ call)
 	restart_service)
 		# Re-sync the redirect rules first (the followed device may have
 		# changed), then restart the daemon so it reads the new config.
+		/usr/sbin/wloc-profile-redirect.sh stop-all >/dev/null 2>&1 || true
 		/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
 		/etc/init.d/wloc-service restart >/dev/null 2>&1
 		sleep 2
@@ -284,6 +285,7 @@ call)
 		# daemon (procd respawns and creates a fresh CA + info), then rewrite
 		# the iOS profile. The iPhone must reinstall and re-trust the CA.
 		rm -f /etc/wloc-service/ca.pem /etc/wloc-service/ca.key /etc/wloc-service/ca.info.json
+		/usr/sbin/wloc-profile-redirect.sh stop-all >/dev/null 2>&1 || true
 		/usr/sbin/wloc-redirect-sync.sh >/dev/null 2>&1 || true
 		/etc/init.d/wloc-service restart >/dev/null 2>&1
 		sleep 3

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -23,6 +23,8 @@ done
 ./tests/scripts/test-standalone-ax6s-package.sh
 ./tests/scripts/test-release-version.sh
 ./tests/scripts/test-unified-supervisor.sh
+./tests/scripts/test-profile-redirect.sh
+./tests/scripts/test-profile-status.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -688,8 +688,8 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             ProfilePatchRouter::new(model)
                 .map_err(|_| "multiple profiles require IPv4 device bindings")?,
         )),
-        Some(model) => ProfilePatchRouter::new(model).ok().map(std::sync::Arc::new),
         None => None,
+        Some(_) => None,
     };
     let patch_state = profile_router
         .as_ref()
@@ -881,8 +881,15 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .is_none_or(|model| model.profiles().len() <= 1)
         && runtime_profile.enabled
     {
-        if let Err(error) = service.enable() {
-            eprintln!("wloc-service: enable failed: {error:?}");
+        match service.enable() {
+            Ok(()) => {
+                if let Some(router) = profile_router.as_ref() {
+                    if let Err(error) = router.set_enabled(&runtime_profile.id, true) {
+                        eprintln!("wloc-service: enabling profile route failed: {error:?}");
+                    }
+                }
+            }
+            Err(error) => eprintln!("wloc-service: enable failed: {error:?}"),
         }
     }
 

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -52,6 +52,36 @@ fn now_unix() -> u64 {
         .unwrap_or(0)
 }
 
+fn profile_marker_path(name: &str, default: &str) -> std::path::PathBuf {
+    std::env::var(name)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(default))
+}
+
+fn write_profile_marker(path: &std::path::Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, b"ready\n")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn wait_for_profile_marker(path: &std::path::Path, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while !path.exists() {
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    true
+}
+
 fn disabled_runtime_profile() -> RuntimeProfile {
     RuntimeProfile {
         id: "invalid".to_owned(),
@@ -308,6 +338,16 @@ impl ProfileServiceGroup {
         handlers: HashMap<String, BoxedProfileService>,
         runtime: OpenWrtRuntime,
     ) -> Self {
+        let ready = profile_marker_path(
+            "WLOC_PROFILE_READY_FILE",
+            "/var/run/wloc-service/profiles/.ready",
+        );
+        let activate = profile_marker_path(
+            "WLOC_PROFILE_ACTIVATE_FILE",
+            "/var/run/wloc-service/profiles/.activate",
+        );
+        let _ = std::fs::remove_file(ready);
+        let _ = std::fs::remove_file(activate);
         let default_profile_id = model
             .profiles()
             .first()
@@ -334,6 +374,13 @@ impl ProfileServiceGroup {
             if self.enable_profile(&profile_id).is_err() {
                 let _ = self.router.set_enabled(&profile_id, false);
             }
+        }
+        let ready = profile_marker_path(
+            "WLOC_PROFILE_READY_FILE",
+            "/var/run/wloc-service/profiles/.ready",
+        );
+        if let Err(error) = write_profile_marker(&ready) {
+            eprintln!("wloc-service: profile readiness marker failed: {error}");
         }
     }
 
@@ -377,6 +424,10 @@ impl ProfileServiceGroup {
 }
 
 impl ServiceDispatch for ProfileServiceGroup {
+    fn activate_profiles(&mut self) {
+        self.activate_enabled_profiles();
+    }
+
     fn status(&mut self) -> Result<serde_json::Value, DispatchError> {
         self.default_handler()?.status()
     }
@@ -715,13 +766,12 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 build_profile_handler(profile, &uci, config_valid, &geo_provider, router)?;
             handlers.insert(profile.id.clone(), handler);
         }
-        let mut group = ProfileServiceGroup::new(
+        let group = ProfileServiceGroup::new(
             model,
             std::sync::Arc::clone(router),
             handlers,
             OpenWrtRuntime::from_env(),
         );
-        group.activate_enabled_profiles();
         Box::new(group)
     } else {
         let service = WlocService::new(
@@ -921,6 +971,36 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // REDIRECT, which rewrites the destination to this router and newer iOS
     // versions answer with RST.
     let proxy_listener = runtime.block_on(async { bind_tproxy_listener(proxy_port) })?;
+    let multi_profile_mode = profile_model
+        .as_ref()
+        .is_some_and(|model| model.profiles().len() > 1);
+    if multi_profile_mode {
+        let proxy_ready = profile_marker_path(
+            "WLOC_PROFILE_PROXY_READY_FILE",
+            "/var/run/wloc-service/profiles/.proxy-ready",
+        );
+        let _ = std::fs::remove_file(&proxy_ready);
+        write_profile_marker(&proxy_ready)?;
+        if std::env::var("WLOC_SUPERVISED").as_deref() == Ok("1") {
+            let activate = profile_marker_path(
+                "WLOC_PROFILE_ACTIVATE_FILE",
+                "/var/run/wloc-service/profiles/.activate",
+            );
+            let timeout = Duration::from_secs(env_or("WLOC_PROFILE_ACTIVATE_TIMEOUT", 30_u64));
+            if !wait_for_profile_marker(&activate, timeout) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "supervisor did not authorize profile activation",
+                )
+                .into());
+            }
+        }
+        // In supervised mode this runs only after the supervisor has passed
+        // its child health gate, installed the shared route, and published
+        // the activation marker. Standalone mode still activates only after
+        // the listener is bound, never during daemon construction.
+        service.activate_profiles();
+    }
     runtime.spawn(async move {
         loop {
             if let Ok((stream, _)) = proxy_listener.accept().await {

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -1218,4 +1218,160 @@ mod tests {
         );
         let _ = std::fs::remove_dir_all(root);
     }
+
+    struct MockProfileDispatch;
+
+    impl ServiceDispatch for MockProfileDispatch {
+        fn status(&mut self) -> Result<serde_json::Value, DispatchError> {
+            Ok(serde_json::json!({"profile": "mock"}))
+        }
+
+        fn enable(&mut self) -> Result<(), DispatchError> {
+            Ok(())
+        }
+
+        fn disable(&mut self) -> Result<(), DispatchError> {
+            Ok(())
+        }
+
+        fn reload(&mut self) -> Result<(), DispatchError> {
+            Ok(())
+        }
+
+        fn set_manual_location(&mut self, _params: &RequestParams) -> Result<(), DispatchError> {
+            Ok(())
+        }
+
+        fn clear_manual_location(&mut self) -> Result<(), DispatchError> {
+            Ok(())
+        }
+
+        fn search_location(
+            &mut self,
+            query: &str,
+        ) -> Result<serde_json::Value, DispatchError> {
+            Ok(serde_json::json!({"query": query}))
+        }
+
+        fn refresh_periodic(&mut self) {}
+
+        fn refresh_evidence(&mut self) -> Result<(), DispatchError> {
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_service_group_coordinates_shared_runtime_and_handlers() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let model = ProfileModel::new(vec![
+            DeviceProfile {
+                id: "phone".to_owned(),
+                label: "Phone".to_owned(),
+                assigned_device: Some("192.168.1.100".to_owned()),
+                node_ref: "phone-node".to_owned(),
+                node_mode: wificalling_location_gateway::config::NodeSelectionMode::Fixed,
+                location_mode: LocationMode::Auto,
+                manual_latitude: None,
+                manual_longitude: None,
+                manual_location_ref: None,
+                enabled: true,
+            },
+            DeviceProfile {
+                id: "tablet".to_owned(),
+                label: "Tablet".to_owned(),
+                assigned_device: Some("192.168.1.101".to_owned()),
+                node_ref: "tablet-node".to_owned(),
+                node_mode: wificalling_location_gateway::config::NodeSelectionMode::Fixed,
+                location_mode: LocationMode::Auto,
+                manual_latitude: None,
+                manual_longitude: None,
+                manual_location_ref: None,
+                enabled: true,
+            },
+        ])
+        .unwrap();
+        let router = std::sync::Arc::new(ProfilePatchRouter::new(&model).unwrap());
+        let mut handlers = HashMap::new();
+        handlers.insert(
+            "phone".to_owned(),
+            Box::new(MockProfileDispatch) as BoxedProfileService,
+        );
+        handlers.insert(
+            "tablet".to_owned(),
+            Box::new(MockProfileDispatch) as BoxedProfileService,
+        );
+
+        let root = std::env::temp_dir().join(format!(
+            "wloc-profile-group-test-{}-{}",
+            std::process::id(),
+            now_unix()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let helper = root.join("profile-redirect-helper.sh");
+        let script = format!(
+            "#!/bin/sh\nmarker='{}'/$2\ncase \"$1\" in\nstart) touch \"$marker\";;\nstop) rm -f \"$marker\";;\nstatus) test -f \"$marker\";;\nesac\n",
+            root.display()
+        );
+        std::fs::write(&helper, script).unwrap();
+        std::fs::set_permissions(&helper, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut group = ProfileServiceGroup::new(
+            model,
+            std::sync::Arc::clone(&router),
+            handlers,
+            OpenWrtRuntime::new(&helper, &helper),
+        );
+        group.activate_enabled_profiles();
+        assert_eq!(group.runtime.statuses().len(), 2);
+        assert!(group
+            .runtime
+            .statuses()
+            .iter()
+            .all(|status| status.phase
+                == wificalling_location_gateway::service::profile_runtime::ProfileRuntimePhase::Intercepting));
+        router
+            .set_target("phone", Some(PatchTarget::new(1.0, 2.0)))
+            .unwrap();
+        assert_eq!(
+            router.resolve_source("192.168.1.100").unwrap(),
+            PatchTarget::new(1.0, 2.0)
+        );
+
+        assert_eq!(group.status().unwrap()["profile"], "mock");
+        group.reload().unwrap();
+        group
+            .set_manual_location(&RequestParams {
+                query: None,
+                latitude: Some(1.0),
+                longitude: Some(2.0),
+            })
+            .unwrap();
+        group.clear_manual_location().unwrap();
+        assert_eq!(group.search_location("Singapore").unwrap()["query"], "Singapore");
+        group.refresh_periodic();
+        group.refresh_evidence().unwrap();
+
+        group.disable().unwrap();
+        assert!(router.resolve_source("192.168.1.100").is_none());
+        group.enable().unwrap();
+        assert!(router.resolve_source("192.168.1.100").is_none());
+
+        for error in [
+            ProfileRuntimeError::EngineStart,
+            ProfileRuntimeError::EngineUnhealthy,
+            ProfileRuntimeError::RedirectInstall,
+            ProfileRuntimeError::RedirectStillPresent,
+            ProfileRuntimeError::CleanupUnsafe,
+            ProfileRuntimeError::UnsupportedDevice,
+            ProfileRuntimeError::ProfileDisabled,
+            ProfileRuntimeError::UnknownProfile,
+        ] {
+            let mapped = map_profile_runtime_error(error);
+            assert!(!mapped.wire_code().is_empty());
+        }
+
+        let _ = std::fs::remove_dir_all(root);
+    }
 }

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -7,6 +7,7 @@
 //!
 //! Socket path: `WLOC_SOCKET` (default `/var/run/wloc-service/control.sock`).
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
@@ -14,7 +15,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wificalling_location_gateway::app::{WlocService, WlocServiceConfig};
 use wificalling_location_gateway::config::{
-    DeviceProfile, LocationMode, RuntimeProfile, WlocUciConfig,
+    DeviceProfile, LocationMode, ProfileModel, RuntimeProfile, WlocUciConfig,
 };
 use wificalling_location_gateway::exitprobe::runtime::{ExitProbeRuntime, ProbeFailure};
 use wificalling_location_gateway::exitprobe::{NodeRef, ProbeLimits};
@@ -25,9 +26,10 @@ use wificalling_location_gateway::mitm::proxy::MitmProxy;
 use wificalling_location_gateway::mitm::CaBundle;
 use wificalling_location_gateway::service::api::RequestParams;
 use wificalling_location_gateway::service::control::{RuntimeControl, RuntimeFailure};
-use wificalling_location_gateway::service::dispatch::ServiceDispatch;
+use wificalling_location_gateway::service::dispatch::{DispatchError, ServiceDispatch};
+use wificalling_location_gateway::service::profile_dispatch::ProfilePatchRouter;
 use wificalling_location_gateway::service::profile_runtime::{
-    ProfileRuntimeControl, ProfileRuntimeError,
+    ProfileRuntimeControl, ProfileRuntimeError, ProfileRuntimeManager,
 };
 use wificalling_location_gateway::service::server::ControlServer;
 use wificalling_location_gateway::service::GeoRecord;
@@ -241,6 +243,193 @@ impl ProfileRuntimeControl for OpenWrtRuntime {
     }
 }
 
+/// Per-profile WlocService state does not own the shared Gateway process.
+/// The unified procd supervisor and `ProfileRuntimeManager` own that process
+/// and each profile's redirect; this adapter keeps the profile's probe/Geo
+/// state machine independent without spawning another engine.
+#[derive(Default)]
+struct ProfileServiceRuntime;
+
+impl RuntimeControl for ProfileServiceRuntime {
+    fn start_engine_passthrough(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn engine_healthy(&mut self) -> Result<bool, RuntimeFailure> {
+        Ok(true)
+    }
+
+    fn arm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn install_exact_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn remove_redirect(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn redirect_present(&mut self) -> Result<bool, RuntimeFailure> {
+        Ok(false)
+    }
+
+    fn disarm_watchdog(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn drain_engine(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+
+    fn stop_engine(&mut self) -> Result<(), RuntimeFailure> {
+        Ok(())
+    }
+}
+
+type BoxedProfileService = Box<dyn ServiceDispatch>;
+
+/// One control-plane facade over independent per-profile probe/Geo handlers
+/// and the shared profile redirect manager. V1 requests retain their legacy
+/// meaning and operate on the deterministic default profile; periodic work
+/// refreshes every enabled profile.
+struct ProfileServiceGroup {
+    default_profile_id: String,
+    handlers: HashMap<String, BoxedProfileService>,
+    runtime: ProfileRuntimeManager<OpenWrtRuntime>,
+    router: std::sync::Arc<ProfilePatchRouter>,
+}
+
+impl ProfileServiceGroup {
+    fn new(
+        model: ProfileModel,
+        router: std::sync::Arc<ProfilePatchRouter>,
+        handlers: HashMap<String, BoxedProfileService>,
+        runtime: OpenWrtRuntime,
+    ) -> Self {
+        let default_profile_id = model
+            .profiles()
+            .first()
+            .map(|profile| profile.id.clone())
+            .unwrap_or_else(|| "default".to_owned());
+        Self {
+            default_profile_id,
+            handlers,
+            runtime: ProfileRuntimeManager::new(model, runtime),
+            router,
+        }
+    }
+
+    fn activate_enabled_profiles(&mut self) {
+        let ids: Vec<String> = self
+            .runtime
+            .model()
+            .profiles()
+            .iter()
+            .filter(|profile| profile.enabled)
+            .map(|profile| profile.id.clone())
+            .collect();
+        for profile_id in ids {
+            if self.enable_profile(&profile_id).is_err() {
+                let _ = self.router.set_enabled(&profile_id, false);
+            }
+        }
+    }
+
+    fn enable_profile(&mut self, profile_id: &str) -> Result<(), DispatchError> {
+        self.runtime
+            .enable(profile_id)
+            .map_err(map_profile_runtime_error)?;
+        let handler = self
+            .handlers
+            .get_mut(profile_id)
+            .ok_or(DispatchError::InvalidConfig)?;
+        if let Err(error) = handler.enable() {
+            let _ = self.runtime.disable(profile_id);
+            let _ = self.router.set_enabled(profile_id, false);
+            return Err(error);
+        }
+        self.router
+            .set_enabled(profile_id, true)
+            .map_err(|_| DispatchError::RuntimeFailure)
+    }
+
+    fn disable_profile(&mut self, profile_id: &str) -> Result<(), DispatchError> {
+        let handler = self
+            .handlers
+            .get_mut(profile_id)
+            .ok_or(DispatchError::InvalidConfig)?;
+        let handler_result = handler.disable();
+        let runtime_result = self
+            .runtime
+            .disable(profile_id)
+            .map_err(map_profile_runtime_error);
+        let _ = self.router.set_enabled(profile_id, false);
+        handler_result.and(runtime_result)
+    }
+
+    fn default_handler(&mut self) -> Result<&mut BoxedProfileService, DispatchError> {
+        self.handlers
+            .get_mut(&self.default_profile_id)
+            .ok_or(DispatchError::InvalidConfig)
+    }
+}
+
+impl ServiceDispatch for ProfileServiceGroup {
+    fn status(&mut self) -> Result<serde_json::Value, DispatchError> {
+        self.default_handler()?.status()
+    }
+
+    fn enable(&mut self) -> Result<(), DispatchError> {
+        self.enable_profile(&self.default_profile_id.clone())
+    }
+
+    fn disable(&mut self) -> Result<(), DispatchError> {
+        self.disable_profile(&self.default_profile_id.clone())
+    }
+
+    fn reload(&mut self) -> Result<(), DispatchError> {
+        self.default_handler()?.reload()
+    }
+
+    fn set_manual_location(&mut self, params: &RequestParams) -> Result<(), DispatchError> {
+        self.default_handler()?.set_manual_location(params)
+    }
+
+    fn clear_manual_location(&mut self) -> Result<(), DispatchError> {
+        self.default_handler()?.clear_manual_location()
+    }
+
+    fn search_location(&mut self, query: &str) -> Result<serde_json::Value, DispatchError> {
+        self.default_handler()?.search_location(query)
+    }
+
+    fn refresh_periodic(&mut self) {
+        for handler in self.handlers.values_mut() {
+            handler.refresh_periodic();
+        }
+    }
+
+    fn refresh_evidence(&mut self) -> Result<(), DispatchError> {
+        self.default_handler()?.refresh_evidence()
+    }
+}
+
+fn map_profile_runtime_error(error: ProfileRuntimeError) -> DispatchError {
+    match error {
+        ProfileRuntimeError::EngineStart => DispatchError::RuntimeFailure,
+        ProfileRuntimeError::EngineUnhealthy => DispatchError::EngineUnhealthy,
+        ProfileRuntimeError::RedirectInstall => DispatchError::RuntimeFailure,
+        ProfileRuntimeError::RedirectStillPresent => DispatchError::RedirectPresent,
+        ProfileRuntimeError::CleanupUnsafe => DispatchError::CleanupUnsafe,
+        ProfileRuntimeError::UnsupportedDevice | ProfileRuntimeError::ProfileDisabled => {
+            DispatchError::InvalidConfig
+        }
+        ProfileRuntimeError::UnknownProfile => DispatchError::InvalidConfig,
+    }
+}
+
 /// Stub exit probe: reports the configured exit and WAN addresses.
 struct StubProbe {
     exit_ip: IpAddr,
@@ -317,6 +506,75 @@ impl GeoProviderRuntime for StubGeo {
             },
         )))
     }
+}
+
+fn build_geo_provider(geo_provider: &str) -> Box<dyn GeoProviderRuntime> {
+    if geo_provider == "stub" {
+        Box::new(StubGeo {
+            country_code: env_or("WLOC_STUB_COUNTRY", "US".to_owned()),
+            latitude: env_or("WLOC_STUB_LAT", 37.77_f64),
+            longitude: env_or("WLOC_STUB_LON", -122.41_f64),
+        })
+    } else {
+        Box::new(GeoHttpClient::ip_api_default())
+    }
+}
+
+fn build_profile_handler(
+    profile: &DeviceProfile,
+    uci: &WlocUciConfig,
+    config_valid: bool,
+    geo_provider: &str,
+    router: &std::sync::Arc<ProfilePatchRouter>,
+) -> Result<BoxedProfileService, String> {
+    let assigned_device = profile.assigned_device.clone().unwrap_or_default();
+    let assigned_ip = assigned_device
+        .parse::<IpAddr>()
+        .map_err(|_| "profile device is not an IP address".to_owned())?;
+    let sink = router
+        .profile_sink(&profile.id)
+        .map_err(|_| "profile patch sink is unavailable".to_owned())?;
+    let state_dir = std::env::var("WLOC_PROFILE_STATE_DIR")
+        .unwrap_or_else(|_| "/var/run/wloc-service/profiles".to_owned());
+    let profile_dir = Path::new(&state_dir).join(&profile.id);
+    let mut service = WlocService::new(
+        ProfileServiceRuntime,
+        build_probe(&assigned_device, uci.probe_port),
+        build_geo_provider(geo_provider),
+        WlocServiceConfig {
+            node_ref: NodeRef::new(&profile.node_ref)
+                .map_err(|_| "invalid profile node reference".to_owned())?,
+            providers: vec![ProviderRef::new("http").expect("static provider ref is valid")],
+            probe_limits: ProbeLimits {
+                max_observation_age: Duration::from_secs(uci.probe_interval_secs),
+            },
+            scope_valid: config_valid && matches!(assigned_ip, IpAddr::V4(_)),
+            ipv6_ready: true,
+            assigned_device_configured: true,
+            assigned_device: Some(assigned_device),
+            reverse_geo_lookup: Some(("nominatim.openstreetmap.org".to_owned(), 443)),
+        },
+    )
+    .with_patch_sink(sink)
+    .with_state_files(
+        profile_dir.join("status.json"),
+        profile_dir.join("events.jsonl"),
+    );
+
+    if profile.location_mode == LocationMode::Manual {
+        let (Some(latitude), Some(longitude)) = (profile.manual_latitude, profile.manual_longitude)
+        else {
+            return Err("manual profile is missing coordinates".to_owned());
+        };
+        service
+            .set_manual_location(&RequestParams {
+                query: None,
+                latitude: Some(latitude),
+                longitude: Some(longitude),
+            })
+            .map_err(|_| "manual profile coordinates were rejected".to_owned())?;
+    }
+    Ok(Box::new(service))
 }
 
 /// Short-lived proxy handshake health for the admin UI.
@@ -424,45 +682,83 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     );
 
+    let profile_model = uci.profile_model().ok();
+    let profile_router = match profile_model.as_ref() {
+        Some(model) if model.profiles().len() > 1 => Some(std::sync::Arc::new(
+            ProfilePatchRouter::new(model)
+                .map_err(|_| "multiple profiles require IPv4 device bindings")?,
+        )),
+        Some(model) => ProfilePatchRouter::new(model).ok().map(std::sync::Arc::new),
+        None => None,
+    };
+    let patch_state = profile_router
+        .as_ref()
+        .and_then(|router| router.profile_sink(&runtime_profile.id).ok())
+        .unwrap_or_else(|| std::sync::Arc::new(std::sync::Mutex::new(None::<PatchTarget>)));
+
     // Default to the real Geo HTTP provider; geo_provider=stub (UCI or
     // WLOC_GEO_PROVIDER) forces the deterministic stub for offline work.
     let geo_provider: String =
         std::env::var("WLOC_GEO_PROVIDER").unwrap_or_else(|_| uci.geo_provider.clone());
-    let geo: Box<dyn GeoProviderRuntime> = if geo_provider == "stub" {
-        Box::new(StubGeo {
-            country_code: env_or("WLOC_STUB_COUNTRY", "US".to_owned()),
-            latitude: env_or("WLOC_STUB_LAT", 37.77_f64),
-            longitude: env_or("WLOC_STUB_LON", -122.41_f64),
-        })
+    let mut service: Box<dyn ServiceDispatch> = if let (Some(model), true) = (
+        profile_model.clone(),
+        profile_model
+            .as_ref()
+            .is_some_and(|m| m.profiles().len() > 1),
+    ) {
+        let router = profile_router
+            .as_ref()
+            .ok_or("profile router is unavailable")?;
+        let mut handlers = HashMap::with_capacity(model.profiles().len());
+        for profile in model.profiles() {
+            let handler =
+                build_profile_handler(profile, &uci, config_valid, &geo_provider, router)?;
+            handlers.insert(profile.id.clone(), handler);
+        }
+        let mut group = ProfileServiceGroup::new(
+            model,
+            std::sync::Arc::clone(router),
+            handlers,
+            OpenWrtRuntime::from_env(),
+        );
+        group.activate_enabled_profiles();
+        Box::new(group)
     } else {
-        Box::new(GeoHttpClient::ip_api_default())
+        let service = WlocService::new(
+            OpenWrtRuntime::from_env(),
+            build_probe(&assigned_device, uci.probe_port),
+            build_geo_provider(&geo_provider),
+            WlocServiceConfig {
+                node_ref: NodeRef::new(&runtime_profile.node_ref)
+                    .unwrap_or_else(|_| NodeRef::new("default").expect("static node ref is valid")),
+                providers: vec![ProviderRef::new("http").expect("static provider ref is valid")],
+                probe_limits: ProbeLimits {
+                    max_observation_age: Duration::from_secs(uci.probe_interval_secs),
+                },
+                scope_valid: runtime_scope_valid(config_valid, &runtime_profile),
+                ipv6_ready: true,
+                assigned_device_configured: !assigned_device.is_empty(),
+                assigned_device: if assigned_device.is_empty() {
+                    None
+                } else {
+                    Some(assigned_device)
+                },
+                reverse_geo_lookup: Some(("nominatim.openstreetmap.org".to_owned(), 443)),
+            },
+        )
+        .with_patch_sink(std::sync::Arc::clone(&patch_state))
+        .with_state_files(
+            std::path::PathBuf::from(
+                std::env::var("WLOC_STATUS_FILE")
+                    .unwrap_or_else(|_| "/var/run/wloc-service/status.json".into()),
+            ),
+            std::path::PathBuf::from(
+                std::env::var("WLOC_EVENTS_FILE")
+                    .unwrap_or_else(|_| "/var/run/wloc-service/events.jsonl".into()),
+            ),
+        );
+        Box::new(service)
     };
-
-    let service = WlocService::new(
-        OpenWrtRuntime::from_env(),
-        build_probe(&assigned_device, uci.probe_port),
-        geo,
-        WlocServiceConfig {
-            node_ref: NodeRef::new(&runtime_profile.node_ref)
-                .unwrap_or_else(|_| NodeRef::new("default").expect("static node ref is valid")),
-            providers: vec![ProviderRef::new("http").expect("static provider ref is valid")],
-            probe_limits: ProbeLimits {
-                max_observation_age: Duration::from_secs(uci.probe_interval_secs),
-            },
-            scope_valid: runtime_scope_valid(config_valid, &runtime_profile),
-            ipv6_ready: true,
-            assigned_device_configured: !assigned_device.is_empty(),
-            assigned_device: if assigned_device.is_empty() {
-                None
-            } else {
-                Some(assigned_device)
-            },
-            // Background manual place-info lookups use the public Nominatim
-            // TLS endpoint; a strict connect/read timeout keeps them off the
-            // control path.
-            reverse_geo_lookup: Some(("nominatim.openstreetmap.org".to_owned(), 443)),
-        },
-    );
 
     // MITM proxy: load the persisted root CA or generate one and persist it.
     // The private key stays in root-only on-device storage so iPhone trust
@@ -553,25 +849,15 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let proxy = std::sync::Arc::new(proxy);
     let proxy_port: u16 = env_or("WLOC_PROXY_PORT", 8443_u16);
 
-    let patch_state = std::sync::Arc::new(std::sync::Mutex::new(None::<PatchTarget>));
-    let mut service = service
-        .with_patch_sink(std::sync::Arc::clone(&patch_state))
-        .with_state_files(
-            std::path::PathBuf::from(
-                std::env::var("WLOC_STATUS_FILE")
-                    .unwrap_or_else(|_| "/var/run/wloc-service/status.json".into()),
-            ),
-            std::path::PathBuf::from(
-                std::env::var("WLOC_EVENTS_FILE")
-                    .unwrap_or_else(|_| "/var/run/wloc-service/events.jsonl".into()),
-            ),
-        );
-
     // Apply the persisted configuration to the control plane before serving:
     // manual location preset first (so a manual target is already fresh), then
     // the desired enabled state. Failures are logged, not fatal: the daemon
     // still serves status and can be steered through the control API.
-    if runtime_profile.location_mode == LocationMode::Manual {
+    if profile_model
+        .as_ref()
+        .is_none_or(|model| model.profiles().len() <= 1)
+        && runtime_profile.location_mode == LocationMode::Manual
+    {
         if let (Some(latitude), Some(longitude)) = (
             runtime_profile.manual_latitude,
             runtime_profile.manual_longitude,
@@ -590,7 +876,11 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             );
         }
     }
-    if runtime_profile.enabled {
+    if profile_model
+        .as_ref()
+        .is_none_or(|model| model.profiles().len() <= 1)
+        && runtime_profile.enabled
+    {
         if let Err(error) = service.enable() {
             eprintln!("wloc-service: enable failed: {error:?}");
         }
@@ -629,11 +919,19 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             if let Ok((stream, _)) = proxy_listener.accept().await {
                 let proxy = proxy.clone();
                 let patch_state = std::sync::Arc::clone(&patch_state);
+                let profile_router = profile_router.clone();
                 let proxy_health = std::sync::Arc::clone(&proxy_health);
                 let health_path = health_path.clone();
                 tokio::spawn(async move {
-                    let patch = patch_state.lock().ok().and_then(|guard| *guard);
-                    match proxy.handle_connection(stream, patch.as_ref()).await {
+                    let result = if let Some(router) = profile_router.as_ref() {
+                        proxy
+                            .handle_connection_routed(stream, router.as_ref())
+                            .await
+                    } else {
+                        let patch = patch_state.lock().ok().and_then(|guard| *guard);
+                        proxy.handle_connection(stream, patch.as_ref()).await
+                    };
+                    match result {
                         Ok(()) => {
                             record_proxy_health(
                                 &proxy_health,

--- a/src/bin/wloc-service.rs
+++ b/src/bin/wloc-service.rs
@@ -1246,10 +1246,7 @@ mod tests {
             Ok(())
         }
 
-        fn search_location(
-            &mut self,
-            query: &str,
-        ) -> Result<serde_json::Value, DispatchError> {
+        fn search_location(&mut self, query: &str) -> Result<serde_json::Value, DispatchError> {
             Ok(serde_json::json!({"query": query}))
         }
 
@@ -1349,7 +1346,10 @@ mod tests {
             })
             .unwrap();
         group.clear_manual_location().unwrap();
-        assert_eq!(group.search_location("Singapore").unwrap()["query"], "Singapore");
+        assert_eq!(
+            group.search_location("Singapore").unwrap()["query"],
+            "Singapore"
+        );
         group.refresh_periodic();
         group.refresh_evidence().unwrap();
 

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -8,6 +8,7 @@
 //! unchanged; a malformed WLOC response is never replaced.
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -20,6 +21,19 @@ use crate::wloc::{patch_wloc_response, PatchTarget};
 
 /// The Apple WLOC endpoint path intercepted for patching.
 pub const WLOC_PATH: &str = "/clls/wloc";
+
+/// Resolves a patch target from the source address of an accepted client
+/// connection. Implementations must return `None` for unknown, disabled, or
+/// degraded profiles; the proxy then forwards the original response.
+pub trait PatchTargetResolver: Send + Sync {
+    fn resolve_patch_target(&self, source: IpAddr) -> Option<PatchTarget>;
+}
+
+impl PatchTargetResolver for crate::service::profile_dispatch::ProfilePatchRouter {
+    fn resolve_patch_target(&self, source: IpAddr) -> Option<PatchTarget> {
+        self.resolve_ip(source)
+    }
+}
 /// Upper bound for a single forwarded response body.
 const MAX_FORWARD_BODY_BYTES: usize = 512 * 1024;
 /// Concurrent upstream streams per client connection.
@@ -103,6 +117,28 @@ impl MitmProxy {
         client_tcp: TcpStream,
         patch: Option<&PatchTarget>,
     ) -> Result<(), MitmProxyError> {
+        self.handle_connection_with_target(client_tcp, patch.copied())
+            .await
+    }
+
+    /// Serve one connection and select its patch target from the original
+    /// client source address. No default profile is used when resolution
+    /// fails.
+    pub async fn handle_connection_routed(
+        &self,
+        client_tcp: TcpStream,
+        resolver: &dyn PatchTargetResolver,
+    ) -> Result<(), MitmProxyError> {
+        let source = client_tcp.peer_addr().ok().map(|address| address.ip());
+        let patch = source.and_then(|address| resolver.resolve_patch_target(address));
+        self.handle_connection_with_target(client_tcp, patch).await
+    }
+
+    async fn handle_connection_with_target(
+        &self,
+        client_tcp: TcpStream,
+        patch: Option<PatchTarget>,
+    ) -> Result<(), MitmProxyError> {
         let client_addr = client_tcp
             .peer_addr()
             .ok()
@@ -127,9 +163,12 @@ impl MitmProxy {
                 Err(_) => break,
             };
             let (request, mut respond) = request;
-            match self.forward_upstream(request, patch, &client_addr).await {
+            match self
+                .forward_upstream(request, patch.as_ref(), &client_addr)
+                .await
+            {
                 Ok((original_len, patched_body)) => {
-                    self.append_rewrite_event(patch, original_len, patched_body.len());
+                    self.append_rewrite_event(patch.as_ref(), original_len, patched_body.len());
                     let mut send = respond
                         .send_response(Response::new(()), patched_body.is_empty())
                         .map_err(|error| MitmProxyError::H2(error.to_string()))?;

--- a/src/service/dispatch.rs
+++ b/src/service/dispatch.rs
@@ -94,6 +94,44 @@ pub trait ServiceDispatch {
     }
 }
 
+impl ServiceDispatch for Box<dyn ServiceDispatch> {
+    fn status(&mut self) -> Result<Value, DispatchError> {
+        (**self).status()
+    }
+
+    fn enable(&mut self) -> Result<(), DispatchError> {
+        (**self).enable()
+    }
+
+    fn disable(&mut self) -> Result<(), DispatchError> {
+        (**self).disable()
+    }
+
+    fn reload(&mut self) -> Result<(), DispatchError> {
+        (**self).reload()
+    }
+
+    fn set_manual_location(&mut self, params: &RequestParams) -> Result<(), DispatchError> {
+        (**self).set_manual_location(params)
+    }
+
+    fn clear_manual_location(&mut self) -> Result<(), DispatchError> {
+        (**self).clear_manual_location()
+    }
+
+    fn search_location(&mut self, query: &str) -> Result<Value, DispatchError> {
+        (**self).search_location(query)
+    }
+
+    fn refresh_periodic(&mut self) {
+        (**self).refresh_periodic();
+    }
+
+    fn refresh_evidence(&mut self) -> Result<(), DispatchError> {
+        (**self).refresh_evidence()
+    }
+}
+
 /// Route a decoded request to its handler and return an encoded response frame.
 ///
 /// Success wraps the handler result (an empty object for control methods);

--- a/src/service/dispatch.rs
+++ b/src/service/dispatch.rs
@@ -68,6 +68,10 @@ impl DispatchError {
 /// Abstract service handlers behind the control methods. Production adapters
 /// implement this against the real OpenWrt runtime; tests use mocks.
 pub trait ServiceDispatch {
+    /// Admit enabled profile redirects after the shared proxy/listener
+    /// readiness gate. Singleton handlers keep the no-op default.
+    fn activate_profiles(&mut self) {}
+
     /// Return a coordinate-free status snapshot as a JSON value.
     fn status(&mut self) -> Result<Value, DispatchError>;
     /// Start interception behind the transactional safety ordering.
@@ -95,6 +99,10 @@ pub trait ServiceDispatch {
 }
 
 impl ServiceDispatch for Box<dyn ServiceDispatch> {
+    fn activate_profiles(&mut self) {
+        (**self).activate_profiles();
+    }
+
     fn status(&mut self) -> Result<Value, DispatchError> {
         (**self).status()
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -12,6 +12,7 @@ use crate::APPROVED_WLOC_HOSTS;
 pub mod api;
 pub mod control;
 pub mod dispatch;
+pub mod profile_dispatch;
 pub mod profile_runtime;
 #[cfg(unix)]
 pub mod server;

--- a/src/service/profile_dispatch.rs
+++ b/src/service/profile_dispatch.rs
@@ -59,7 +59,10 @@ impl ProfilePatchRouter {
                 profile.id.clone(),
                 ProfileRoute {
                     assigned_device: ip,
-                    enabled: Arc::new(Mutex::new(profile.enabled)),
+                    // UCI enablement is intent only. The route becomes live
+                    // after the runtime manager installs and verifies the
+                    // profile redirect.
+                    enabled: Arc::new(Mutex::new(false)),
                     target: Arc::new(Mutex::new(None)),
                 },
             );

--- a/src/service/profile_dispatch.rs
+++ b/src/service/profile_dispatch.rs
@@ -1,0 +1,182 @@
+//! Source-device routing for per-profile WLOC patch targets.
+//!
+//! The router is deliberately independent from the shared Gateway lifecycle.
+//! It maps one validated LAN IP to one profile and reads only that profile's
+//! current target. There is no default profile, first-match fallback, or
+//! cross-profile target reuse when a route is missing, disabled, or degraded.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+
+use crate::config::ProfileModel;
+use crate::wloc::PatchTarget;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProfilePatchRouterError {
+    UnknownProfile,
+    UnsupportedDevice,
+    InvalidTarget,
+    StatePoisoned,
+}
+
+#[derive(Clone)]
+struct ProfileRoute {
+    assigned_device: IpAddr,
+    enabled: Arc<Mutex<bool>>,
+    target: Arc<Mutex<Option<PatchTarget>>>,
+}
+
+/// A bounded, immutable route table with mutable per-profile state.
+#[derive(Clone)]
+pub struct ProfilePatchRouter {
+    routes: Arc<HashMap<String, ProfileRoute>>,
+    by_device: Arc<HashMap<IpAddr, String>>,
+}
+
+impl ProfilePatchRouter {
+    /// Build a route table from the validated profile model. Runtime routing
+    /// currently accepts only IPv4 device bindings because the OpenWrt
+    /// profile redirect helper is IPv4-scoped; MAC bindings are not silently
+    /// interpreted as a different device.
+    pub fn new(model: &ProfileModel) -> Result<Self, ProfilePatchRouterError> {
+        let mut routes = HashMap::with_capacity(model.profiles().len());
+        let mut by_device = HashMap::with_capacity(model.profiles().len());
+        for profile in model.profiles() {
+            let Some(address) = profile.assigned_device.as_deref() else {
+                return Err(ProfilePatchRouterError::UnsupportedDevice);
+            };
+            let ip = address
+                .parse::<IpAddr>()
+                .map_err(|_| ProfilePatchRouterError::UnsupportedDevice)?;
+            if !matches!(ip, IpAddr::V4(_)) {
+                return Err(ProfilePatchRouterError::UnsupportedDevice);
+            }
+            if by_device.insert(ip, profile.id.clone()).is_some() {
+                return Err(ProfilePatchRouterError::UnsupportedDevice);
+            }
+            routes.insert(
+                profile.id.clone(),
+                ProfileRoute {
+                    assigned_device: ip,
+                    enabled: Arc::new(Mutex::new(profile.enabled)),
+                    target: Arc::new(Mutex::new(None)),
+                },
+            );
+        }
+        Ok(Self {
+            routes: Arc::new(routes),
+            by_device: Arc::new(by_device),
+        })
+    }
+
+    pub fn profile_sink(
+        &self,
+        profile_id: &str,
+    ) -> Result<Arc<Mutex<Option<PatchTarget>>>, ProfilePatchRouterError> {
+        self.route(profile_id)
+            .map(|route| Arc::clone(&route.target))
+    }
+
+    pub fn set_enabled(
+        &self,
+        profile_id: &str,
+        enabled: bool,
+    ) -> Result<(), ProfilePatchRouterError> {
+        let route = self.route(profile_id)?;
+        *route
+            .enabled
+            .lock()
+            .map_err(|_| ProfilePatchRouterError::StatePoisoned)? = enabled;
+        if !enabled {
+            self.clear_target(profile_id)?;
+        }
+        Ok(())
+    }
+
+    pub fn set_target(
+        &self,
+        profile_id: &str,
+        target: Option<PatchTarget>,
+    ) -> Result<(), ProfilePatchRouterError> {
+        let route = self.route(profile_id)?;
+        if let Some(target) = target {
+            validate_target(target)?;
+            *route
+                .target
+                .lock()
+                .map_err(|_| ProfilePatchRouterError::StatePoisoned)? = Some(target);
+        } else {
+            self.clear_target(profile_id)?;
+        }
+        Ok(())
+    }
+
+    pub fn clear_target(&self, profile_id: &str) -> Result<(), ProfilePatchRouterError> {
+        let route = self.route(profile_id)?;
+        *route
+            .target
+            .lock()
+            .map_err(|_| ProfilePatchRouterError::StatePoisoned)? = None;
+        Ok(())
+    }
+
+    /// Resolve a textual source address from the accepted TCP connection.
+    /// Invalid input and unknown addresses intentionally return no target.
+    pub fn resolve_source(&self, source: &str) -> Option<PatchTarget> {
+        source
+            .parse::<IpAddr>()
+            .ok()
+            .and_then(|ip| self.resolve_ip(ip))
+    }
+
+    pub fn resolve_ip(&self, source: IpAddr) -> Option<PatchTarget> {
+        let profile_id = self.by_device.get(&source)?;
+        let route = self.routes.get(profile_id)?;
+        if !*route.enabled.lock().ok()? {
+            return None;
+        }
+        *route.target.lock().ok()?
+    }
+
+    pub fn profile_for_ip(&self, source: IpAddr) -> Option<&str> {
+        self.by_device.get(&source).map(String::as_str)
+    }
+
+    pub fn assigned_device(&self, profile_id: &str) -> Result<Ipv4Addr, ProfilePatchRouterError> {
+        match self.route(profile_id)?.assigned_device {
+            IpAddr::V4(ip) => Ok(ip),
+            IpAddr::V6(_) => Err(ProfilePatchRouterError::UnsupportedDevice),
+        }
+    }
+
+    fn route(&self, profile_id: &str) -> Result<&ProfileRoute, ProfilePatchRouterError> {
+        self.routes
+            .get(profile_id)
+            .ok_or(ProfilePatchRouterError::UnknownProfile)
+    }
+}
+
+fn validate_target(target: PatchTarget) -> Result<(), ProfilePatchRouterError> {
+    if target.latitude.is_finite()
+        && target.longitude.is_finite()
+        && (-90.0..=90.0).contains(&target.latitude)
+        && (-180.0..=180.0).contains(&target.longitude)
+    {
+        Ok(())
+    } else {
+        Err(ProfilePatchRouterError::InvalidTarget)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_target;
+    use crate::wloc::PatchTarget;
+
+    #[test]
+    fn target_validation_rejects_non_finite_coordinates() {
+        assert!(validate_target(PatchTarget::new(f64::NAN, 0.0)).is_err());
+        assert!(validate_target(PatchTarget::new(0.0, f64::INFINITY)).is_err());
+    }
+}

--- a/tests/profile_dispatch.rs
+++ b/tests/profile_dispatch.rs
@@ -35,6 +35,8 @@ fn source_device_selects_only_its_profile_target() {
     ])
     .unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_enabled("phone", true).unwrap();
+    router.set_enabled("tablet", true).unwrap();
     router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
     router.set_target("tablet", Some(target(3.0, 4.0))).unwrap();
 
@@ -57,6 +59,8 @@ fn disabling_one_profile_withdraws_only_its_target() {
     ])
     .unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_enabled("phone", true).unwrap();
+    router.set_enabled("tablet", true).unwrap();
     router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
     router.set_target("tablet", Some(target(3.0, 4.0))).unwrap();
     router.set_enabled("phone", false).unwrap();
@@ -72,6 +76,7 @@ fn disabling_one_profile_withdraws_only_its_target() {
 fn manual_clear_withdraws_target_until_auto_refreshes() {
     let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_enabled("phone", true).unwrap();
     router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
     router.clear_target("phone").unwrap();
     assert_eq!(router.resolve_source("192.168.1.10"), None);
@@ -92,6 +97,7 @@ fn invalid_source_and_unsupported_mac_never_fall_back() {
 
     let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_enabled("phone", true).unwrap();
     router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
     assert_eq!(router.resolve_source("not-an-ip"), None);
     assert_eq!(router.resolve_source("192.168.1.11"), None);
@@ -113,6 +119,7 @@ fn device_addresses_are_canonicalized_before_lookup() {
 
     let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_enabled("phone", true).unwrap();
     router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
     let source: IpAddr = "192.168.1.10".parse().unwrap();
     assert_eq!(router.resolve_ip(source).unwrap(), target(1.0, 2.0));

--- a/tests/profile_dispatch.rs
+++ b/tests/profile_dispatch.rs
@@ -1,0 +1,116 @@
+use std::net::IpAddr;
+
+use wificalling_location_gateway::config::{
+    DeviceProfile, LocationMode, NodeSelectionMode, ProfileModel,
+};
+use wificalling_location_gateway::service::profile_dispatch::{
+    ProfilePatchRouter, ProfilePatchRouterError,
+};
+use wificalling_location_gateway::wloc::PatchTarget;
+
+fn profile(id: &str, assigned_device: &str, enabled: bool) -> DeviceProfile {
+    DeviceProfile {
+        id: id.to_owned(),
+        label: id.to_owned(),
+        assigned_device: Some(assigned_device.to_owned()),
+        node_ref: format!("node-{id}"),
+        node_mode: NodeSelectionMode::Fixed,
+        location_mode: LocationMode::Auto,
+        manual_latitude: None,
+        manual_longitude: None,
+        manual_location_ref: None,
+        enabled,
+    }
+}
+
+fn target(latitude: f64, longitude: f64) -> PatchTarget {
+    PatchTarget::new(latitude, longitude)
+}
+
+#[test]
+fn source_device_selects_only_its_profile_target() {
+    let model = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10", true),
+        profile("tablet", "192.168.1.11", true),
+    ])
+    .unwrap();
+    let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
+    router.set_target("tablet", Some(target(3.0, 4.0))).unwrap();
+
+    assert_eq!(
+        router.resolve_source("192.168.1.10").unwrap(),
+        target(1.0, 2.0)
+    );
+    assert_eq!(
+        router.resolve_source("192.168.1.11").unwrap(),
+        target(3.0, 4.0)
+    );
+    assert_eq!(router.resolve_source("192.168.1.12"), None);
+}
+
+#[test]
+fn disabling_one_profile_withdraws_only_its_target() {
+    let model = ProfileModel::new(vec![
+        profile("phone", "192.168.1.10", true),
+        profile("tablet", "192.168.1.11", true),
+    ])
+    .unwrap();
+    let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
+    router.set_target("tablet", Some(target(3.0, 4.0))).unwrap();
+    router.set_enabled("phone", false).unwrap();
+
+    assert_eq!(router.resolve_source("192.168.1.10"), None);
+    assert_eq!(
+        router.resolve_source("192.168.1.11").unwrap(),
+        target(3.0, 4.0)
+    );
+}
+
+#[test]
+fn manual_clear_withdraws_target_until_auto_refreshes() {
+    let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
+    let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
+    router.clear_target("phone").unwrap();
+    assert_eq!(router.resolve_source("192.168.1.10"), None);
+    router.set_target("phone", Some(target(5.0, 6.0))).unwrap();
+    assert_eq!(
+        router.resolve_source("192.168.1.10").unwrap(),
+        target(5.0, 6.0)
+    );
+}
+
+#[test]
+fn invalid_source_and_unsupported_mac_never_fall_back() {
+    let model = ProfileModel::new(vec![profile("phone", "aa:bb:cc:dd:ee:ff", true)]);
+    assert!(model.is_err());
+
+    let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
+    let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
+    assert_eq!(router.resolve_source("not-an-ip"), None);
+    assert_eq!(router.resolve_source("192.168.1.11"), None);
+}
+
+#[test]
+fn router_rejects_non_ipv4_runtime_binding_explicitly() {
+    let model = ProfileModel::new(vec![profile("phone", "fd00::10", true)]).unwrap();
+    assert_eq!(
+        ProfilePatchRouter::new(&model),
+        Err(ProfilePatchRouterError::UnsupportedDevice)
+    );
+}
+
+#[test]
+fn device_addresses_are_canonicalized_before_lookup() {
+    let model = ProfileModel::new(vec![profile("phone", "192.168.001.010", true)]);
+    assert!(model.is_err());
+
+    let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
+    let router = ProfilePatchRouter::new(&model).unwrap();
+    router.set_target("phone", Some(target(1.0, 2.0))).unwrap();
+    let source: IpAddr = "192.168.1.10".parse().unwrap();
+    assert_eq!(router.resolve_ip(source).unwrap(), target(1.0, 2.0));
+}

--- a/tests/profile_dispatch.rs
+++ b/tests/profile_dispatch.rs
@@ -84,8 +84,11 @@ fn manual_clear_withdraws_target_until_auto_refreshes() {
 
 #[test]
 fn invalid_source_and_unsupported_mac_never_fall_back() {
-    let model = ProfileModel::new(vec![profile("phone", "aa:bb:cc:dd:ee:ff", true)]);
-    assert!(model.is_err());
+    let model = ProfileModel::new(vec![profile("phone", "aa:bb:cc:dd:ee:ff", true)]).unwrap();
+    assert!(matches!(
+        ProfilePatchRouter::new(&model),
+        Err(ProfilePatchRouterError::UnsupportedDevice)
+    ));
 
     let model = ProfileModel::new(vec![profile("phone", "192.168.1.10", true)]).unwrap();
     let router = ProfilePatchRouter::new(&model).unwrap();
@@ -97,10 +100,10 @@ fn invalid_source_and_unsupported_mac_never_fall_back() {
 #[test]
 fn router_rejects_non_ipv4_runtime_binding_explicitly() {
     let model = ProfileModel::new(vec![profile("phone", "fd00::10", true)]).unwrap();
-    assert_eq!(
+    assert!(matches!(
         ProfilePatchRouter::new(&model),
         Err(ProfilePatchRouterError::UnsupportedDevice)
-    );
+    ));
 }
 
 #[test]

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -20,6 +20,10 @@ if [ "$*" = 'list table inet wloc_service' ]; then
 fi
 exit 0
 EOF
+cat > "$tmp/bin/ip" <<'EOF'
+#!/bin/sh
+printf 'ip %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
 cat > "$tmp/bin/uci" <<'EOF'
 #!/bin/sh
 case "$2" in
@@ -39,7 +43,7 @@ cat > "$tmp/bin/nslookup" <<'EOF'
 #!/bin/sh
 printf '%s\n' 'Address: 59.82.17.33'
 EOF
-chmod 0755 "$tmp/bin/nft" "$tmp/bin/uci" "$tmp/bin/nslookup"
+chmod 0755 "$tmp/bin/nft" "$tmp/bin/ip" "$tmp/bin/uci" "$tmp/bin/nslookup"
 : > "$tmp/commands.log"
 
 PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
@@ -58,8 +62,11 @@ if grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev
 fi
 grep -F 'ip saddr 192.168.1.10 tcp dport 443' "$tmp/commands.log" >/dev/null
 grep -F 'ip daddr @apple_hosts' "$tmp/commands.log" >/dev/null
+grep -F 'ip rule add fwmark 1 lookup 100' "$tmp/commands.log" >/dev/null
+grep -F 'ip route add local 0.0.0.0/0 dev lo table 100' "$tmp/commands.log" >/dev/null
 
 PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" "$refresh"
+grep -F 'nft delete table inet wloc_service' "$tmp/commands.log" >/dev/null
 grep -F 'nft flush set inet wloc_profile_phone apple_hosts' "$tmp/commands.log" >/dev/null
 grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null
 if grep -F 'nft flush set inet wloc_profile_tablet apple_hosts' "$tmp/commands.log" >/dev/null; then
@@ -71,6 +78,7 @@ fi
 PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" "$helper" stop-all
 grep -F 'nft delete table inet wloc_profile_phone' "$tmp/commands.log" >/dev/null
 grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null
+grep -F 'ip rule del fwmark 1 lookup 100' "$tmp/commands.log" >/dev/null
 
 if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
   "$helper" start '../phone' 192.168.1.12; then

--- a/tests/scripts/test-profile-redirect.sh
+++ b/tests/scripts/test-profile-redirect.sh
@@ -22,7 +22,18 @@ exit 0
 EOF
 cat > "$tmp/bin/uci" <<'EOF'
 #!/bin/sh
-printf '%s\n' '192.168.1.1'
+case "$2" in
+  show)
+    printf '%s\n' 'wloc-service.phone=device' 'wloc-service.tablet=device'
+    ;;
+  get)
+    case "$3" in
+      network.lan.ipaddr) printf '%s\n' '192.168.1.1' ;;
+      wloc-service.phone.enabled) printf '%s\n' '1' ;;
+      wloc-service.tablet.enabled) printf '%s\n' '0' ;;
+    esac
+    ;;
+esac
 EOF
 cat > "$tmp/bin/nslookup" <<'EOF'
 #!/bin/sh
@@ -50,7 +61,16 @@ grep -F 'ip daddr @apple_hosts' "$tmp/commands.log" >/dev/null
 
 PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" "$refresh"
 grep -F 'nft flush set inet wloc_profile_phone apple_hosts' "$tmp/commands.log" >/dev/null
-grep -F 'nft flush set inet wloc_profile_tablet apple_hosts' "$tmp/commands.log" >/dev/null
+grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null
+if grep -F 'nft flush set inet wloc_profile_tablet apple_hosts' "$tmp/commands.log" >/dev/null; then
+  printf '%s\n' 'disabled profile tables must not be refreshed' >&2
+  exit 1
+fi
+
+: > "$tmp/commands.log"
+PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" "$helper" stop-all
+grep -F 'nft delete table inet wloc_profile_phone' "$tmp/commands.log" >/dev/null
+grep -F 'nft delete table inet wloc_profile_tablet' "$tmp/commands.log" >/dev/null
 
 if PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
   "$helper" start '../phone' 192.168.1.12; then

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -24,6 +24,11 @@ grep -F 'PROFILE_REDIRECT_HELPER' "$supervisor" >/dev/null
 grep -F 'stop-all' "$supervisor" >/dev/null
 grep -F 'legacy-stop' "$supervisor" "$redirect" >/dev/null
 grep -F 'multiple_profiles_configured' "$redirect" >/dev/null
+grep -F 'PROFILE_PROXY_READY_FILE' "$supervisor" >/dev/null
+grep -F 'PROFILE_ACTIVATE_FILE' "$supervisor" >/dev/null
+grep -F 'PROFILE_READY_FILE' "$supervisor" >/dev/null
+grep -F 'WLOC_PROFILE_ACTIVATE_FILE' "$repo_root/src/bin/wloc-service.rs" >/dev/null
+grep -F 'service.activate_profiles()' "$repo_root/src/bin/wloc-service.rs" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -20,13 +20,16 @@ grep -F 'procd_add_reload_trigger wloc-service' "$init" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 WLOC_DEFER_REDIRECT=1 WLOC_SKIP_REDIRECT=1 "$WLOC_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
+grep -F 'PROFILE_REDIRECT_HELPER' "$supervisor" >/dev/null
+grep -F 'stop-all' "$supervisor" >/dev/null
+grep -F 'multiple_profiles_configured' "$redirect" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
 
 gateway_start=$(grep -n '"$GATEWAY_INIT" start' "$supervisor" | cut -d: -f1)
 wloc_start=$(grep -n '"$WLOC_INIT" start' "$supervisor" | cut -d: -f1)
 health=$(grep -n 'if ! wait_for_health' "$supervisor" | head -n 1 | cut -d: -f1)
-redirect_start=$(grep -n '"$REDIRECT_HELPER" start' "$supervisor" | cut -d: -f1)
+redirect_start=$(grep -n '^[[:space:]]*if ! install_redirect' "$supervisor" | cut -d: -f1)
 [ "$gateway_start" -lt "$wloc_start" ]
 [ "$wloc_start" -lt "$health" ]
 [ "$health" -lt "$redirect_start" ]
@@ -41,6 +44,26 @@ grep -F 'START_TIMEOUT' "$supervisor" >/dev/null
 if grep -E 'udp[[:space:]]+500|udp[[:space:]]+4500|wificalling_gateway' "$supervisor" "$redirect" >/dev/null; then
 	printf '%s\n' 'unified supervisor must not own Gateway nftables or UDP 500/4500' >&2
 	exit 1
+fi
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/uci" <<'EOF'
+#!/bin/sh
+if [ "$2" = show ]; then
+  printf '%s\n' 'wloc-service.phone=device' 'wloc-service.tablet=device'
+fi
+EOF
+chmod 0755 "$tmp/bin/uci"
+: > "$tmp/commands.log"
+if ! PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  "$redirect" start; then
+
+  printf '%s\n' 'legacy redirect helper must fail closed only on invalid input, not profile mode' >&2
+  exit 1
+fi
+if grep -E '^nft |^ip ' "$tmp/commands.log" >/dev/null; then
+  printf '%s\n' 'multi-profile mode must not install the legacy all-device redirect' >&2
+  exit 1
 fi
 if grep -E 'gs-loc-corpa|apple\.com\.cn|bluedot' "$redirect" "$wloc_refresh" >/dev/null; then
 	printf '%s\n' 'WLOC scope must remain limited to the two exact Apple hostnames' >&2

--- a/tests/scripts/test-unified-supervisor.sh
+++ b/tests/scripts/test-unified-supervisor.sh
@@ -22,6 +22,7 @@ grep -F 'WLOC_SUPERVISED=1 "$GATEWAY_INIT" start' "$supervisor" >/dev/null
 grep -F 'WLOC_DEFER_REDIRECT=1' "$supervisor" >/dev/null
 grep -F 'PROFILE_REDIRECT_HELPER' "$supervisor" >/dev/null
 grep -F 'stop-all' "$supervisor" >/dev/null
+grep -F 'legacy-stop' "$supervisor" "$redirect" >/dev/null
 grep -F 'multiple_profiles_configured' "$redirect" >/dev/null
 grep -F 'WLOC_SKIP_REDIRECT' "$wloc_init" >/dev/null
 grep -F 'WLOC_SUPERVISED' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null
@@ -54,15 +55,29 @@ if [ "$2" = show ]; then
 fi
 EOF
 chmod 0755 "$tmp/bin/uci"
+cat > "$tmp/bin/nft" <<'EOF'
+#!/bin/sh
+printf 'nft %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+cat > "$tmp/bin/ip" <<'EOF'
+#!/bin/sh
+printf 'ip %s\n' "$*" >> "$WLOC_TEST_LOG"
+EOF
+chmod 0755 "$tmp/bin/nft" "$tmp/bin/ip"
 : > "$tmp/commands.log"
 if ! PATH="$tmp/bin:$PATH" WLOC_TEST_LOG="$tmp/commands.log" \
+  WLOC_NFT_BINARY="$tmp/bin/nft" WLOC_IP_BINARY="$tmp/bin/ip" \
+  WLOC_PROFILE_REDIRECT_HELPER="$repo_root/openwrt/files/usr/sbin/wloc-profile-redirect.sh" \
   "$redirect" start; then
 
-  printf '%s\n' 'legacy redirect helper must fail closed only on invalid input, not profile mode' >&2
+  printf '%s\n' 'profile mode must preserve the shared TPROXY route' >&2
   exit 1
 fi
-if grep -E '^nft |^ip ' "$tmp/commands.log" >/dev/null; then
-  printf '%s\n' 'multi-profile mode must not install the legacy all-device redirect' >&2
+grep -F 'nft delete table inet wloc_service' "$tmp/commands.log" >/dev/null
+grep -F 'ip rule add fwmark 1 lookup 100' "$tmp/commands.log" >/dev/null
+grep -F 'ip route add local 0.0.0.0/0 dev lo table 100' "$tmp/commands.log" >/dev/null
+if grep -F 'nft add table inet wloc_service' "$tmp/commands.log" >/dev/null; then
+  printf '%s\n' 'multi-profile mode must not install the legacy all-device table' >&2
   exit 1
 fi
 if grep -E 'gs-loc-corpa|apple\.com\.cn|bluedot' "$redirect" "$wloc_refresh" >/dev/null; then


### PR DESCRIPTION
## Summary

- Add bounded source-device profile dispatch with one independent WLOC probe/Geo handler per profile and one shared Gateway/WLOC runtime.
- Enforce profile-scoped redirect ownership, shared TPROXY route setup, stale global/profile table cleanup, and fail-open no-fallback behavior.
- Gate profile redirect activation on proxy listener readiness and supervisor activation, with bounded readiness markers.
- Add Rust lifecycle/coverage tests, shell integration tests, and update the Issue #36 verification record.

## Scope boundary

Live v2 profile CRUD/mutation dispatch and the unified LuCI device management UI remain Issue #37. Component update/rollback, AX6S real-device evidence, and final migration/release rehearsal remain Issues #39-#41.

## Verification

- `./scripts/ci/verify.sh` passed.
- Rust line coverage passed at 80.17% on the final full run.
- Independent review: APPROVE; no P0/P1/P2 findings.

Closes #36

Handoff capsule: `.handoffs/issue-36.md`
