### PR TITLE
feat: add bounded structured diagnostics and support bundle

### DIFF
--- a/.handoffs/issue-38.md
+++ b/.handoffs/issue-38.md
@@ -1,0 +1,137 @@
+# Agent handoff: Issue 38
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: openwrt,test,security,docs
+- Branch: codex/issue-38-v2-logs-support-codex-v2-lead-20260821091436-dbe9e0a4
+- Final local checkpoint before handoff: 4c9a481
+- Credentials included: no
+
+## Objective
+
+Implement V2 bounded structured diagnostics for the unified Gateway/WLOC
+service: one privacy-safe event envelope, bounded recent-history logs,
+diagnostic support bundle generation, normal/debug observability controls, and
+packaging/UI integration suitable for small OpenWrt gateways.
+
+## Completed
+
+- Unified WLOC service, MITM rewrite, and Gateway diagnostic events around the
+  documented JSONL envelope with timestamp, component, profile scope, severity,
+  event code, stable message, and bounded fields.
+- Added one shared Rust event writer with 64 KiB file and 2 KiB record limits;
+  rotation keeps newest complete records and drops oversized events.
+- Removed precise coordinates and device material from WLOC rewrite history;
+  rewrite events retain only response byte counters.
+- Kept Gateway legacy pipe compatibility while making JSON event retention
+  schema-aware; JSON events are globally bounded because they intentionally
+  contain no device key.
+- Added privacy-safe support bundle collection through root-only rpcd method:
+  manifest and availability booleans plus whitelisted event codes only; raw
+  health/status/config/log material is not copied.
+- Added support-bundle storage cap (default 64 KiB, hard maximum 128 KiB),
+  mode 0600 output, collection lock, private temporary archive, failure-safe
+  replacement, symlink rejection, and a 600-second operational expiry field.
+- Added the helper to canonical Makefile, standalone AX6S/LuCI package, and
+  release package paths.
+- Added LuCI health-page support bundle action, structured event parsing, ACL
+  separation, shell regression coverage, packaging contract coverage, and
+  operations documentation.
+
+## Files changed
+
+- `src/diagnostics.rs`
+- `src/lib.rs`
+- `src/app.rs`
+- `src/mitm/proxy.rs`
+- `openwrt/files/usr/libexec/wificalling-gateway/monitor.sh`
+- `openwrt/files/usr/sbin/wloc-support-bundle.sh`
+- `openwrt/Makefile`
+- `scripts/build-luci-ipk.sh`
+- `docs/operations/V2_STRUCTURED_DIAGNOSTICS.md`
+- `tests/mitm_proxy.rs`
+- `tests/scripts/test-support-bundle.sh`
+- `tests/test_v2_diagnostics_contract.py`
+
+The LuCI, rpcd, ACL, release-copy, and verification changes from the initial
+V2-06 implementation are included in the parent commit `bf4a0bf`.
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./scripts/ci/verify.sh` | Passed | 78 Python tests, all Rust targets, OpenWrt/AX6S/release packaging, structured logs, support bundle, secret scan, cargo audit |
+| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed | 80.11% total Rust line coverage |
+| `cargo clippy --all-targets --all-features -- -D warnings` | Passed | No warnings |
+| `cargo test --test mitm_proxy wloc_response_is_patched_through_the_proxy` | Passed | Rewrite event schema and privacy assertions |
+| `sh tests/scripts/test-structured-logs.sh` | Passed | Gateway schema, privacy, and byte cap |
+| `sh tests/scripts/test-support-bundle.sh` | Passed | Privacy, cap, and symlink rejection |
+| `python3 tests/test_v2_diagnostics_contract.py` | Passed | RPC/ACL/UI and all package-path contract |
+| `git diff --check` | Passed | No whitespace errors |
+
+## Failed attempts
+
+- The first implementation left MITM rewrite events on the old unbounded
+  `type/time/latitude/longitude` path; independent review caught it. The fix
+  moved bounded writing into `src/diagnostics.rs`, removed coordinates, and
+  updated the integration test.
+- The first support-bundle implementation streamed tar output directly to the
+  final path and could leave partial output on archive failure. It now builds
+  privately and moves only a verified bounded archive into place.
+- The first packaging pass updated release packaging but missed the canonical
+  OpenWrt Makefile and standalone AX6S/LuCI package path. Both are now covered
+  by code and contract tests.
+- Commit hook reported `lefthook` unavailable in PATH; the commit itself
+  succeeded and the repository verification script passed all required gates.
+
+## Warnings and non-blocking notes
+
+- `cargo audit` reports existing duplicate `socket2` and `windows-sys` lockfile
+  entries; advisories, bans, licenses, and sources all pass.
+- Gateway JSON diagnostic events intentionally do not contain a device key, so
+  their record-count retention is global; legacy pipe records retain the
+  existing per-device behavior.
+- The support bundle uses a fixed default path for LuCI compatibility and
+  serializes generation with `/tmp/wloc-support-bundle.lock`; a stale lock
+  after an abnormal power loss requires manual cleanup on the device.
+
+## Unresolved decisions and blockers
+
+- Component update, compatibility gate, and rollback: Issue #39.
+- AX6S memory/storage/CPU gates and real-device evidence: Issue #40.
+- Migration rehearsal, complete integration acceptance, and V2 release: Issue #41.
+
+## Capabilities required for the next Agent
+
+- `openwrt`, `test`, `security`, `docs`, and independent review of shell
+  packaging and root-only rpcd boundaries.
+
+## Environment assumptions
+
+- The two OpenWrt source trees are packaged separately and both remain covered
+  by contract tests.
+- `/tmp` exists and supports `mktemp`, directory locks, gzip tar, and atomic
+  rename on the target OpenWrt image.
+- `wloc-health.sh` is an optional local producer; an unavailable or failed
+  producer is reported as unavailable rather than healthy.
+
+## Security and privacy notes
+
+- No credentials, tokens, private keys, raw traffic, device addresses, or
+  precise coordinates are emitted in structured event history or support
+  bundle content.
+- Runtime interception scope remains one assigned device, the two exact Apple
+  WLOC hostnames, and TCP 443; UDP 500/4500 and the stable Gateway nftables
+  namespace remain untouched.
+- `support_bundle` is write-only in both ACL sources; status/health remains
+  read-only.
+
+## Next executable steps
+
+1. Run `scripts/agent-handoff.sh 38 codex-v2-lead openwrt,test,security,docs`.
+2. Push the branch and open a PR against `main` with `Closes #38`, this handoff
+   capsule, verification evidence, risk, and rollback notes.
+3. Require independent review and all GitHub checks before merge.
+4. After merge, take Issue #39 for component update, compatibility gating, and
+   rollback, then continue through AX6S resource evidence and final V2 release.

--- a/docs/operations/V2_STRUCTURED_DIAGNOSTICS.md
+++ b/docs/operations/V2_STRUCTURED_DIAGNOSTICS.md
@@ -2,7 +2,7 @@
 
 ## Event contract
 
-Gateway and WLOC activity logs use one JSONL envelope:
+Gateway, WLOC, and the WLOC interception path use one JSONL envelope:
 
 ```json
 {
@@ -10,7 +10,7 @@ Gateway and WLOC activity logs use one JSONL envelope:
   "component": "wloc|gateway",
   "profile_scope": "service|device-policy",
   "severity": "info|warning|error",
-  "event_code": "target_updated|handshake_success|handshake_failed|sustained_traffic",
+  "event_code": "target_updated|response_rewritten|handshake_success|handshake_failed|sustained_traffic",
   "message": "stable non-sensitive summary",
   "fields": {}
 }
@@ -22,9 +22,12 @@ status projection, but event history is deliberately less sensitive.
 
 ## Bounds and retention
 
-- WLOC events are capped at 64 KiB and 2 KiB per JSON line.
-- Gateway events default to 64 KiB and are also constrained by the existing
-  per-device event count setting.
+- Rust WLOC events, including response-rewrite events, are capped at 64 KiB
+  and 2 KiB per JSON line. Rewrite events contain byte counters only; they do
+  not contain target coordinates or device addresses.
+- Gateway events default to 64 KiB. Legacy pipe records retain the existing
+  per-device event count setting; privacy-safe JSON events have no device key,
+  so their retention is bounded globally by the same recent-record limit.
 - Rotation keeps complete newest records and never leaves a partial first
   record for LuCI parsing.
 - Debug output is not enabled by the structured event path; normal operation
@@ -35,9 +38,11 @@ status projection, but event history is deliberately less sensitive.
 The `support_bundle` rpcd method invokes `/usr/sbin/wloc-support-bundle.sh`.
 The helper writes a mode-0600 archive to `/tmp/wloc-support-bundle.tar.gz`,
 with a default 64 KiB cap (hard maximum 128 KiB) and a 600-second operational
-expiry expectation. It includes only a manifest, health availability summary,
-and whitelisted event envelope fields. It does not copy UCI, status JSON,
-profile records, raw logs, CA material, node configuration, or coordinates.
+expiry expectation. Collection is serialized with a lock and the archive is
+built in a private temporary directory before an atomic move. It includes only
+a manifest, health availability summary, and whitelisted event envelope
+fields. It does not copy UCI, status JSON, profile records, raw logs, CA
+material, node configuration, or coordinates.
 
 When storage pressure prevents a full event collection, the helper drops the
 event files and preserves the manifest/health summary; it never emits an

--- a/docs/operations/V2_STRUCTURED_DIAGNOSTICS.md
+++ b/docs/operations/V2_STRUCTURED_DIAGNOSTICS.md
@@ -1,0 +1,53 @@
+# V2 structured diagnostics
+
+## Event contract
+
+Gateway and WLOC activity logs use one JSONL envelope:
+
+```json
+{
+  "timestamp": 1710000000,
+  "component": "wloc|gateway",
+  "profile_scope": "service|device-policy",
+  "severity": "info|warning|error",
+  "event_code": "target_updated|handshake_success|handshake_failed|sustained_traffic",
+  "message": "stable non-sensitive summary",
+  "fields": {}
+}
+```
+
+Messages and fields must not contain credentials, keys, raw traffic, device
+addresses, or precise coordinates. Local LuCI views may show the existing
+status projection, but event history is deliberately less sensitive.
+
+## Bounds and retention
+
+- WLOC events are capped at 64 KiB and 2 KiB per JSON line.
+- Gateway events default to 64 KiB and are also constrained by the existing
+  per-device event count setting.
+- Rotation keeps complete newest records and never leaves a partial first
+  record for LuCI parsing.
+- Debug output is not enabled by the structured event path; normal operation
+  emits only state transitions and bounded counters.
+
+## Support bundle
+
+The `support_bundle` rpcd method invokes `/usr/sbin/wloc-support-bundle.sh`.
+The helper writes a mode-0600 archive to `/tmp/wloc-support-bundle.tar.gz`,
+with a default 64 KiB cap (hard maximum 128 KiB) and a 600-second operational
+expiry expectation. It includes only a manifest, health availability summary,
+and whitelisted event envelope fields. It does not copy UCI, status JSON,
+profile records, raw logs, CA material, node configuration, or coordinates.
+
+When storage pressure prevents a full event collection, the helper drops the
+event files and preserves the manifest/health summary; it never emits an
+oversized archive or a partially written tar stream.
+
+## Failure handling
+
+- Missing health/log inputs produce an explicit availability flag, not a fake
+  healthy state.
+- Malformed/legacy pipe log records are ignored by support-bundle collection.
+- A failed bundle generation returns an rpc error and leaves no partial output.
+- `support_bundle` is write-only in both packaged ACL sources because it
+  creates a file; `health` remains the read-only observation method.

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -51,6 +51,7 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-redirect.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-status.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-health.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-support-bundle.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/

--- a/openwrt/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/files/usr/libexec/rpcd/luci.wloc
@@ -61,6 +61,8 @@ list)
 	json_close_object
 	json_add_object health
 	json_close_object
+	json_add_object support_bundle
+	json_close_object
 	json_add_object node_test
 	json_close_object
 	json_dump
@@ -243,6 +245,14 @@ call)
 		fi
 		/usr/sbin/wloc-health.sh
 		exit 0
+		;;
+	support_bundle)
+		if [ ! -x /usr/sbin/wloc-support-bundle.sh ]; then
+			echo '{"error":"support bundle helper is not installed"}'
+			exit 1
+		fi
+		/usr/sbin/wloc-support-bundle.sh
+		exit $?
 		;;
 	node_test)
 		# Manual connection test for a single node. WireGuard nodes get a

--- a/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
@@ -112,8 +112,18 @@ END {
 
 cat "$event_tmp" >> "$events"
 awk -F '|' -v limit="$max_events" '
-FNR==NR { count[$2 FS $3]++; next }
-{ key=$2 FS $3; seen[key]++; if (seen[key] > count[key]-limit) print }
+FNR==NR {
+  if ($0 ~ /^\{/) { structured_count++; next }
+  count[$2 FS $3]++; next
+}
+{
+  if ($0 ~ /^\{/) {
+    structured_seen++
+    if (structured_seen > structured_count-limit) print
+    next
+  }
+  key=$2 FS $3; seen[key]++; if (seen[key] > count[key]-limit) print
+}
 ' "$events" "$events" > "$trim_tmp"
 mv "$trim_tmp" "$events"
 
@@ -124,7 +134,7 @@ mv "$trim_tmp" "$events"
 event_bytes=$(wc -c < "$events" | tr -d ' ')
 if [ "$event_bytes" -gt "$max_event_bytes" ]; then
 	tail -c "$max_event_bytes" "$events" \
-		| awk -F '|' 'NR == 1 && NF != 8 { next } { print }' > "$trim_tmp"
+		| awk -F '|' 'NR == 1 && $0 !~ /^\{/ && NF != 8 { next } { print }' > "$trim_tmp"
 	mv "$trim_tmp" "$events"
 fi
 chmod 644 "$tmp" "$events"

--- a/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh
@@ -88,19 +88,19 @@ END {
     printf "\"sent_packets\":%d,\"reply_packets\":%d,\"delta_sent\":%d,\"delta_reply\":%d,\"last_activity\":%d,\"activity_evidence\":%s}", sent[i]+0,reply[i]+0,ds,dr,last,q(activity)
     if (log_enabled) {
       if (handshake_success && now-old_event[i]>=15) {
-        print now "|" label[i] "|" ip[i] "|handshake_success|" ds "|" dr "|call_or_sms_unknown|" wfc > event_out
+        printf "{\"timestamp\":%d,\"component\":\"gateway\",\"profile_scope\":\"device-policy\",\"severity\":\"info\",\"event_code\":\"handshake_success\",\"message\":\"Wi-Fi Calling handshake succeeded\",\"fields\":{\"state\":\"%s\",\"delta_sent\":%d,\"delta_reply\":%d}}\n", now, wfc, ds, dr > event_out
         old_event[i]=now; acc_sent=0; acc_reply=0
       } else if (handshake_failed && now-old_event[i]>=15) {
         # A flapping device state (registered <-> not_detected within a
         # second) used to write a handshake event on every flip, flooding
         # the log. Debounce to at most one handshake event per 15s.
-        print now "|" label[i] "|" ip[i] "|handshake_failed|" ds "|" dr "|call_or_sms_unknown|" wfc > event_out
+        printf "{\"timestamp\":%d,\"component\":\"gateway\",\"profile_scope\":\"device-policy\",\"severity\":\"warning\",\"event_code\":\"handshake_failed\",\"message\":\"Wi-Fi Calling handshake was not detected\",\"fields\":{\"state\":\"%s\",\"delta_sent\":%d,\"delta_reply\":%d}}\n", now, wfc, ds, dr > event_out
         old_event[i]=now; acc_sent=0; acc_reply=0
       } else if (sustained) {
         # Sustained bidirectional traffic after registration is the
         # signature of a voice call (ringing or in-call RTP); the tunnel
         # content stays encrypted, so this is an inference, not a decode.
-        print now "|" label[i] "|" ip[i] "|sustained_traffic|" acc_sent "|" acc_reply "|likely_call|" wfc > event_out
+        printf "{\"timestamp\":%d,\"component\":\"gateway\",\"profile_scope\":\"device-policy\",\"severity\":\"info\",\"event_code\":\"sustained_traffic\",\"message\":\"Sustained encrypted traffic observed\",\"fields\":{\"state\":\"%s\",\"delta_sent\":%d,\"delta_reply\":%d}}\n", now, wfc, acc_sent, acc_reply > event_out
         old_event[i]=now; acc_sent=0; acc_reply=0
       }
     }

--- a/openwrt/files/usr/sbin/wloc-support-bundle.sh
+++ b/openwrt/files/usr/sbin/wloc-support-bundle.sh
@@ -9,6 +9,7 @@ HEALTH=${WLOC_SUPPORT_HEALTH:-/var/run/wloc-service/health.json}
 WLOC_LOG=${WLOC_SUPPORT_WLOC_LOG:-/var/run/wloc-service/events.jsonl}
 GATEWAY_LOG=${WLOC_SUPPORT_GATEWAY_LOG:-/var/run/wificalling-gateway/events.log}
 MAX_BYTES=${WLOC_SUPPORT_MAX_BYTES:-65536}
+LOCK=/tmp/wloc-support-bundle.lock
 
 case "$MAX_BYTES" in
 	''|*[!0-9]*) MAX_BYTES=65536 ;;
@@ -16,8 +17,12 @@ esac
 [ "$MAX_BYTES" -ge 4096 ] 2>/dev/null || MAX_BYTES=4096
 [ "$MAX_BYTES" -le 131072 ] 2>/dev/null || MAX_BYTES=131072
 
+if ! mkdir "$LOCK" 2>/dev/null; then
+	echo '{"error":"support bundle collection already in progress"}' >&2
+	exit 1
+fi
 work=$(mktemp -d /tmp/wloc-support.XXXXXX)
-trap 'rm -rf "$work"' EXIT HUP INT TERM
+trap 'rm -rf "$work" "$LOCK"' EXIT HUP INT TERM
 mkdir -p "$work/wloc-support"
 
 safe_token() {
@@ -52,8 +57,13 @@ write_events() {
 }
 
 health_available=false
-[ -r "$HEALTH" ] && health_available=true
-[ -x /usr/sbin/wloc-health.sh ] && health_available=true
+if [ -r "$HEALTH" ]; then
+	health_available=true
+elif [ -x /usr/sbin/wloc-health.sh ]; then
+	if /usr/sbin/wloc-health.sh > "$work/health.generated" 2>/dev/null; then
+		health_available=true
+	fi
+fi
 gateway_available=false
 [ -r "$GATEWAY_LOG" ] && gateway_available=true
 wloc_available=false
@@ -75,15 +85,32 @@ printf '{"schema":"wificalling-location-gateway.support.v1","health_available":%
 write_events "$WLOC_LOG" "$work/wloc-support/events.jsonl"
 write_events "$GATEWAY_LOG" "$work/wloc-support/gateway-events.jsonl"
 
-tar -czf "$OUTPUT" -C "$work" wloc-support
-size=$(wc -c < "$OUTPUT" | tr -d ' ')
+output_dir=${OUTPUT%/*}
+[ "$output_dir" = "$OUTPUT" ] && output_dir=.
+[ -d "$output_dir" ] || { echo '{"error":"support bundle output directory is unavailable"}' >&2; exit 1; }
+[ ! -L "$OUTPUT" ] || { echo '{"error":"support bundle output must not be a symlink"}' >&2; exit 1; }
+archive="$work/wloc-support-bundle.tar.gz"
+if ! tar -czf "$archive" -C "$work" wloc-support; then
+	rm -f "$archive"
+	echo '{"error":"support bundle archive creation failed"}' >&2
+	exit 1
+fi
+size=$(wc -c < "$archive" | tr -d ' ')
 if [ "$size" -gt "$MAX_BYTES" ]; then
 	# Preserve the manifest and health summary under pressure; never emit an
 	# over-cap bundle or silently truncate a tar stream.
 	rm -f "$work/wloc-support/events.jsonl" "$work/wloc-support/gateway-events.jsonl"
-	tar -czf "$OUTPUT" -C "$work" wloc-support
-	size=$(wc -c < "$OUTPUT" | tr -d ' ')
+	rm -f "$archive"
+	if ! tar -czf "$archive" -C "$work" wloc-support; then
+		rm -f "$archive"
+		echo '{"error":"support bundle archive creation failed"}' >&2
+		exit 1
+	fi
+	size=$(wc -c < "$archive" | tr -d ' ')
 fi
-[ "$size" -le "$MAX_BYTES" ] || { rm -f "$OUTPUT"; echo '{"error":"support bundle exceeds storage cap"}' >&2; exit 1; }
+[ "$size" -le "$MAX_BYTES" ] || { rm -f "$archive"; echo '{"error":"support bundle exceeds storage cap"}' >&2; exit 1; }
+chmod 600 "$archive"
+[ ! -L "$OUTPUT" ] || { rm -f "$archive"; echo '{"error":"support bundle output became a symlink"}' >&2; exit 1; }
+mv -f "$archive" "$OUTPUT"
 chmod 600 "$OUTPUT"
 printf '{"path":"%s","bytes":%s,"expires_seconds":600}\n' "$OUTPUT" "$size"

--- a/openwrt/files/usr/sbin/wloc-support-bundle.sh
+++ b/openwrt/files/usr/sbin/wloc-support-bundle.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+# Create a small, privacy-safe diagnostics archive. This deliberately collects
+# health summaries and event codes rather than UCI, status JSON, packet data,
+# node material, device addresses, or coordinates.
+OUTPUT=${WLOC_SUPPORT_OUTPUT:-/tmp/wloc-support-bundle.tar.gz}
+HEALTH=${WLOC_SUPPORT_HEALTH:-/var/run/wloc-service/health.json}
+WLOC_LOG=${WLOC_SUPPORT_WLOC_LOG:-/var/run/wloc-service/events.jsonl}
+GATEWAY_LOG=${WLOC_SUPPORT_GATEWAY_LOG:-/var/run/wificalling-gateway/events.log}
+MAX_BYTES=${WLOC_SUPPORT_MAX_BYTES:-65536}
+
+case "$MAX_BYTES" in
+	''|*[!0-9]*) MAX_BYTES=65536 ;;
+esac
+[ "$MAX_BYTES" -ge 4096 ] 2>/dev/null || MAX_BYTES=4096
+[ "$MAX_BYTES" -le 131072 ] 2>/dev/null || MAX_BYTES=131072
+
+work=$(mktemp -d /tmp/wloc-support.XXXXXX)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+mkdir -p "$work/wloc-support"
+
+safe_token() {
+	printf '%s' "$1" | tr -cd 'A-Za-z0-9_.-' | cut -c1-64
+}
+
+write_events() {
+	input=$1
+	output=$2
+	: > "$output"
+	[ -r "$input" ] || return 0
+	# Re-emit only stable, non-sensitive event envelope fields. This also
+	# drops legacy pipe records instead of guessing whether their label/IP is
+	# identifying information.
+	while IFS= read -r line; do
+		case "$line" in
+			\{*\})
+				timestamp=$(printf '%s' "$line" | sed -n 's/.*"timestamp"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | cut -c1-16)
+				component=$(printf '%s' "$line" | sed -n 's/.*"component"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+				severity=$(printf '%s' "$line" | sed -n 's/.*"severity"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+				event_code=$(printf '%s' "$line" | sed -n 's/.*"event_code"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+				[ -n "$event_code" ] || continue
+				[ -n "$timestamp" ] || timestamp=0
+				component=$(safe_token "$component"); severity=$(safe_token "$severity"); event_code=$(safe_token "$event_code")
+				printf '{"timestamp":%s,"component":"%s","profile_scope":"redacted","severity":"%s","event_code":"%s","message":"redacted diagnostic event"}\n' \
+					"$timestamp" "$component" "$severity" "$event_code" >> "$output"
+				;;
+		esac
+	done < "$input"
+	tail -c 16384 "$output" > "$output.tmp"
+	mv "$output.tmp" "$output"
+}
+
+health_available=false
+[ -r "$HEALTH" ] && health_available=true
+[ -x /usr/sbin/wloc-health.sh ] && health_available=true
+gateway_available=false
+[ -r "$GATEWAY_LOG" ] && gateway_available=true
+wloc_available=false
+[ -r "$WLOC_LOG" ] && wloc_available=true
+
+cat > "$work/wloc-support/manifest.txt" <<EOF
+schema=wificalling-location-gateway.support.v1
+privacy=redacted-no-credentials-no-device-identifiers-no-precise-location
+health_available=$health_available
+gateway_log_available=$gateway_available
+wloc_log_available=$wloc_available
+EOF
+
+# The raw health document is intentionally not copied: it can contain profile
+# labels, IDs, addresses, and effective coordinates. These booleans are enough
+# to tell whether collection reached the local service.
+printf '{"schema":"wificalling-location-gateway.support.v1","health_available":%s,"gateway_log_available":%s,"wloc_log_available":%s}\n' \
+	"$health_available" "$gateway_available" "$wloc_available" > "$work/wloc-support/health.json"
+write_events "$WLOC_LOG" "$work/wloc-support/events.jsonl"
+write_events "$GATEWAY_LOG" "$work/wloc-support/gateway-events.jsonl"
+
+tar -czf "$OUTPUT" -C "$work" wloc-support
+size=$(wc -c < "$OUTPUT" | tr -d ' ')
+if [ "$size" -gt "$MAX_BYTES" ]; then
+	# Preserve the manifest and health summary under pressure; never emit an
+	# over-cap bundle or silently truncate a tar stream.
+	rm -f "$work/wloc-support/events.jsonl" "$work/wloc-support/gateway-events.jsonl"
+	tar -czf "$OUTPUT" -C "$work" wloc-support
+	size=$(wc -c < "$OUTPUT" | tr -d ' ')
+fi
+[ "$size" -le "$MAX_BYTES" ] || { rm -f "$OUTPUT"; echo '{"error":"support bundle exceeds storage cap"}' >&2; exit 1; }
+chmod 600 "$OUTPUT"
+printf '{"path":"%s","bytes":%s,"expires_seconds":600}\n' "$OUTPUT" "$size"

--- a/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -45,6 +45,7 @@
           "regen_ca",
           "restart_service",
           "restart_unified",
+          "support_bundle",
           "verify_fingerprint",
           "node_test",
           "restart_gateway",

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/events.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/events.js
@@ -18,6 +18,13 @@ return view.extend({
 		var logEnabled = uci.get('wificalling-gateway', 'main', 'log_enabled');
 		function when(epoch) { return epoch ? new Date(epoch * 1000).toLocaleString() : '-'; }
 		function lines(value) { return value.trim() ? value.trim().split('\n').reverse() : []; }
+		function eventFields(line) {
+			try {
+				var event = JSON.parse(line), fields = event.fields || {};
+				if (event.event_code) return [event.timestamp || 0, event.profile_scope || '-', '-', event.event_code, fields.delta_sent || 0, fields.delta_reply || 0, 'call_or_sms_unknown', fields.state || '-'];
+			} catch (e) {}
+			return line.split('|');
+		}
 		function wfcLabel(v) {
 			switch (v) {
 				case 'registered': return _('Registered');
@@ -42,7 +49,7 @@ return view.extend({
 		}
 		function rows(value) {
 			return lines(value).map(function(line) {
-				var f = line.split('|');
+				var f = eventFields(line);
 				return E('tr', { class: 'tr' }, [when(Number(f[0])), f[1], f[2], wfcLabel(f[7]), activityLabel(f[3]), (f[4] || '0') + ' ↑ / ' + (f[5] || '0') + ' ↓', meaningLabel(f[6])].map(function(x) { return E('td', { class: 'td' }, String(x)); }));
 			});
 		}

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
@@ -54,6 +54,13 @@ return view.extend({
 			}
 		}
 		function lines(value) { return value.trim() ? value.trim().split('\n').reverse() : []; }
+		function eventFields(line) {
+			try {
+				var event = JSON.parse(line), fields = event.fields || {};
+				if (event.event_code) return [event.timestamp || 0, event.profile_scope || '-', '-', event.event_code, fields.delta_sent || 0, fields.delta_reply || 0, 'call_or_sms_unknown', fields.state || '-'];
+			} catch (e) {}
+			return line.split('|');
+		}
 
 		/* ---------- 设备隧道状态 ---------- */
 		var statusBody = E('tbody', {}, []);
@@ -72,7 +79,7 @@ return view.extend({
 		var logBody = E('tbody', {}, []);
 		function logRows(value) {
 			return lines(value).map(function(line) {
-				var f = line.split('|');
+				var f = eventFields(line);
 				return E('tr', { class: 'tr' }, [when(Number(f[0])), f[1], f[2], wfcLabel(f[7]), activityLabel(f[3]), (f[4] || '0') + ' ↑ / ' + (f[5] || '0') + ' ↓', meaningLabel(f[6])].map(function(x) { return E('td', { class: 'td' }, String(x)); }));
 			});
 		}

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -25,6 +25,11 @@ var restartGateway = rpc.declare({
 	method: 'restart_gateway'
 });
 
+var createSupportBundle = rpc.declare({
+	object: 'luci.wloc',
+	method: 'support_bundle'
+});
+
 function notify(title, message, kind) {
 	ui.addNotification(null, E('p', [ E('strong', title + ': '), message ]), kind);
 }
@@ -166,6 +171,22 @@ return view.extend({
 			};
 		}
 
+		var supportButton = E('button', {
+			'class': 'cbi-button cbi-button-apply',
+			click: function() {
+				if (this.disabled) return;
+				this.disabled = true;
+				createSupportBundle().then(function(result) {
+					if (result && result.error) throw new Error(result.error);
+					notify(wlocI18n.t('Support bundle ready'),
+						(result && result.path ? result.path : '/tmp/wloc-support-bundle.tar.gz') +
+						' (' + ((result && result.bytes) || '?') + ' bytes)', 'info');
+				}).catch(function(error) {
+					notify(wlocI18n.t('Support bundle failed'), String(error), 'error');
+				}).then(function() { this.disabled = false; }.bind(this));
+			}
+		}, wlocI18n.t('Generate support bundle'));
+
 		var restartButtons = E('div', { 'class': 'cbi-section', style: 'margin-top:16px' }, [
 			E('h3', { style: 'margin-top:0' }, wlocI18n.t('Restart services')),
 			E('div', {}, [
@@ -186,7 +207,9 @@ return view.extend({
 				}, wlocI18n.t('Restart WLOC service'))
 			]),
 			E('p', { style: 'color:#666;font-size:12px;margin-bottom:0' },
-				wlocI18n.t('Restarting the gateway regenerates the proxy config and briefly interrupts device proxying.'))
+				wlocI18n.t('Restarting the gateway regenerates the proxy config and briefly interrupts device proxying.')),
+			E('p', { style: 'color:#666;font-size:12px;margin-bottom:0' },
+				wlocI18n.t('Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.'), ' ', supportButton)
 		]);
 
 		return E([], [

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
@@ -43,10 +43,10 @@ function sourceLabel(v) {
 	return v === 'manual' ? wlocI18n.t('Manual') : (v === 'auto' ? wlocI18n.t('Auto') : (v || '-'));
 }
 
-function eventLabel(v) {
-	switch (v) {
-		case 'target_updated': return wlocI18n.t('Target updated');
-		case 'rewritten': return wlocI18n.t('WLOC response rewritten');
+		function eventLabel(v) {
+			switch (v) {
+				case 'target_updated': return wlocI18n.t('Target updated');
+				case 'rewritten': return wlocI18n.t('WLOC response rewritten');
 		default: return v || '-';
 	}
 }
@@ -136,18 +136,17 @@ return view.extend({
 			});
 			return rows.slice(-20).reverse();
 		}
+		function eventTime(event) { return event.timestamp || event.time; }
 		function logRows(events) {
 			return events.map(function(ev) {
-				var where = '-';
-				if (ev.city || ev.country_code)
-					where = (ev.city || '') + (ev.country_code ? ' (' + ev.country_code + ')' : '');
-				else if (ev.latitude != null && ev.longitude != null)
-					where = ev.latitude.toFixed(4) + ', ' + ev.longitude.toFixed(4);
+				var fields = ev.fields || {};
+				var where = fields.city || fields.country_code
+					? (fields.city || '') + (fields.country_code ? ' (' + fields.country_code + ')' : '') : '-';
 				return E('tr', { class: 'tr' }, [
-					E('td', { class: 'td' }, fmtTime(ev.time)),
-					E('td', { class: 'td' }, eventLabel(ev.type)),
+					E('td', { class: 'td' }, fmtTime(eventTime(ev))),
+					E('td', { class: 'td' }, eventLabel(ev.event_code || ev.type)),
 					E('td', { class: 'td' }, where),
-					E('td', { class: 'td' }, sourceLabel(ev.source))
+					E('td', { class: 'td' }, sourceLabel(fields.source || ev.source))
 				]);
 			});
 		}

--- a/openwrt/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
+++ b/openwrt/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
@@ -87,6 +87,11 @@ var ZH = {
 	'WLOC service': 'WLOC 服务',
 	'Wi-Fi Calling Gateway': 'Wi-Fi 通话网关',
 	'Patches and node health': '补丁与节点健康',
+	'Support bundle ready': '支持包已生成',
+	'Support bundle failed': '支持包生成失败',
+	'Generate support bundle': '生成支持包',
+	'Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.':
+		'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
 
 	/* ---- wloc settings ---- */
 	'WLOC location interception: spoofs the Apple WLOC response so the test device reports the gateway-chosen location. GPS values stay on this router.':

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
@@ -63,6 +63,8 @@ list)
 	json_close_object
 	json_add_object health
 	json_close_object
+	json_add_object support_bundle
+	json_close_object
 	json_add_object node_test
 	json_close_object
 	json_dump
@@ -244,6 +246,14 @@ call)
 		fi
 		/usr/sbin/wloc-health.sh
 		exit 0
+		;;
+	support_bundle)
+		if [ ! -x /usr/sbin/wloc-support-bundle.sh ]; then
+			echo '{"error":"support bundle helper is not installed"}'
+			exit 1
+		fi
+		/usr/sbin/wloc-support-bundle.sh
+		exit $?
 		;;
 	clear_log)
 		# Truncate a usage log immediately with a shell redirect (O_TRUNC).

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -45,6 +45,7 @@
           "regen_ca",
           "restart_service",
           "restart_unified",
+          "support_bundle",
           "verify_fingerprint",
           "node_test",
           "restart_gateway",

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
@@ -61,6 +61,13 @@ return view.extend({
 			}
 		}
 		function lines(value) { return value.trim() ? value.trim().split('\n').reverse() : []; }
+		function eventFields(line) {
+			try {
+				var event = JSON.parse(line), fields = event.fields || {};
+				if (event.event_code) return [event.timestamp || 0, event.profile_scope || '-', '-', event.event_code, fields.delta_sent || 0, fields.delta_reply || 0, 'call_or_sms_unknown', fields.state || '-'];
+			} catch (e) {}
+			return line.split('|');
+		}
 
 		/* ---------- 设备隧道状态 ---------- */
 		var statusBody = E('tbody', {}, []);
@@ -79,7 +86,7 @@ return view.extend({
 		var logBody = E('tbody', {}, []);
 		function logRows(value) {
 			return lines(value).map(function(line) {
-				var f = line.split('|');
+				var f = eventFields(line);
 				return E('tr', { class: 'tr' }, [when(Number(f[0])), f[1], f[2], wfcLabel(f[7]), activityLabel(f[3]), (f[4] || '0') + ' ↑ / ' + (f[5] || '0') + ' ↓', meaningLabel(f[6])].map(function(x) { return E('td', { class: 'td' }, String(x)); }));
 			});
 		}

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -25,6 +25,11 @@ var restartGateway = rpc.declare({
 	method: 'restart_gateway'
 });
 
+var createSupportBundle = rpc.declare({
+	object: 'luci.wloc',
+	method: 'support_bundle'
+});
+
 function notify(title, message, kind) {
 	ui.addNotification(null, E('p', [ E('strong', title + ': '), message ]), kind);
 }
@@ -172,6 +177,22 @@ return view.extend({
 			};
 		}
 
+		var supportButton = E('button', {
+			'class': 'cbi-button cbi-button-apply',
+			click: function() {
+				if (this.disabled) return;
+				this.disabled = true;
+				createSupportBundle().then(function(result) {
+					if (result && result.error) throw new Error(result.error);
+					notify(wlocI18n.t('Support bundle ready'),
+						(result && result.path ? result.path : '/tmp/wloc-support-bundle.tar.gz') +
+						' (' + ((result && result.bytes) || '?') + ' bytes)', 'info');
+				}).catch(function(error) {
+					notify(wlocI18n.t('Support bundle failed'), String(error), 'error');
+				}).then(function() { this.disabled = false; }.bind(this));
+			}
+		}, wlocI18n.t('Generate support bundle'));
+
 		var restartButtons = E('div', { 'class': 'cbi-section', style: 'margin-top:16px' }, [
 			E('h3', { style: 'margin-top:0' }, wlocI18n.t('Restart services')),
 			E('div', {}, [
@@ -192,7 +213,9 @@ return view.extend({
 				}, wlocI18n.t('Restart WLOC service'))
 			]),
 			E('p', { style: 'color:#666;font-size:12px;margin-bottom:0' },
-				wlocI18n.t('Restarting the gateway regenerates the proxy config and briefly interrupts device proxying.'))
+				wlocI18n.t('Restarting the gateway regenerates the proxy config and briefly interrupts device proxying.')),
+			E('p', { style: 'color:#666;font-size:12px;margin-bottom:0' },
+				wlocI18n.t('Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.'), ' ', supportButton)
 		]);
 
 		return E([], [

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
@@ -49,7 +49,7 @@ function sourceLabel(v) {
 	return v === 'manual' ? wlocI18n.t('Manual') : (v === 'auto' ? wlocI18n.t('Auto') : (v || '-'));
 }
 
-function eventLabel(v) {
+		function eventLabel(v) {
 	switch (v) {
 		case 'target_updated': return wlocI18n.t('Target updated');
 		case 'rewritten': return wlocI18n.t('WLOC response rewritten');
@@ -155,18 +155,17 @@ return view.extend({
 			});
 			return rows.slice(-20).reverse();
 		}
+		function eventTime(event) { return event.timestamp || event.time; }
 		function logRows(events) {
 			return events.map(function(ev) {
-				var where = '-';
-				if (ev.city || ev.country_code)
-					where = (ev.city || '') + (ev.country_code ? ' (' + ev.country_code + ')' : '');
-				else if (ev.latitude != null && ev.longitude != null)
-					where = ev.latitude.toFixed(4) + ', ' + ev.longitude.toFixed(4);
+				var fields = ev.fields || {};
+				var where = fields.city || fields.country_code
+					? (fields.city || '') + (fields.country_code ? ' (' + fields.country_code + ')' : '') : '-';
 				return E('tr', { class: 'tr' }, [
-					E('td', { class: 'td' }, fmtTime(ev.time)),
-					E('td', { class: 'td' }, eventLabel(ev.type)),
+					E('td', { class: 'td' }, fmtTime(eventTime(ev))),
+					E('td', { class: 'td' }, eventLabel(ev.event_code || ev.type)),
 					E('td', { class: 'td' }, where),
-					E('td', { class: 'td' }, sourceLabel(ev.source))
+					E('td', { class: 'td' }, sourceLabel(fields.source || ev.source))
 				]);
 			});
 		}

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
@@ -87,6 +87,11 @@ var ZH = {
 	'WLOC service': 'WLOC 服务',
 	'Wi-Fi Calling Gateway': 'Wi-Fi 通话网关',
 	'Patches and node health': '补丁与节点健康',
+	'Support bundle ready': '支持包已生成',
+	'Support bundle failed': '支持包生成失败',
+	'Generate support bundle': '生成支持包',
+	'Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.':
+		'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
 
 	/* ---- wloc settings ---- */
 	'WLOC location interception: spoofs the Apple WLOC response so the test device reports the gateway-chosen location. GPS values stay on this router.':

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -177,6 +177,7 @@ PY
 			cp "$root/openwrt/files/usr/sbin/wloc-profile-redirect.sh" "$stage/data/usr/sbin/wloc-profile-redirect.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-profile-status.sh" "$stage/data/usr/sbin/wloc-profile-status.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
+			cp "$root/openwrt/files/usr/sbin/wloc-support-bundle.sh" "$stage/data/usr/sbin/wloc-support-bundle.sh"
 			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
 			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"
 			cp "$root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -25,6 +25,8 @@ done
 ./tests/scripts/test-unified-supervisor.sh
 ./tests/scripts/test-profile-redirect.sh
 ./tests/scripts/test-profile-status.sh
+./tests/scripts/test-structured-logs.sh
+./tests/scripts/test-support-bundle.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -141,7 +141,7 @@ mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
 cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
 	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
-for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-profile-status.sh wloc-health.sh; do
+for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-profile-status.sh wloc-health.sh wloc-support-bundle.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
 chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \

--- a/src/app.rs
+++ b/src/app.rs
@@ -312,13 +312,18 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
             ),
         };
         let event = serde_json::json!({
-            "type": "target_updated",
-            "time": current_unix(),
-            "source": source,
-            "country_code": country,
-            "city": city,
-            "latitude": target.map(|t| t.latitude),
-            "longitude": target.map(|t| t.longitude),
+            "timestamp": current_unix(),
+            "component": "wloc",
+            "profile_scope": "service",
+            "severity": "info",
+            "event_code": "target_updated",
+            "message": "WLOC target state updated",
+            "fields": {
+                "source": source,
+                "country_code": country,
+                "city": city,
+                "target_present": target.is_some(),
+            },
         });
         append_line(events_file, &event);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::Value;
 
+use crate::diagnostics::append_json_line as append_line;
 use crate::exitprobe::runtime::{observe_exit, ExitProbeRuntime};
 use crate::exitprobe::{NodeRef, ProbeLimits};
 use crate::georesolver::runtime::{resolve_geo, GeoProviderRuntime};
@@ -26,11 +27,6 @@ use crate::service::status::{
 };
 use crate::service::supervisor::{SupervisorError, UnifiedSupervisor};
 use crate::wloc::PatchTarget;
-
-/// Upper bounds for the root-local structured event log. These are small
-/// enough for AX6S-class gateways while retaining recent diagnostic history.
-pub(crate) const MAX_EVENT_LOG_BYTES: usize = 64 * 1024;
-pub(crate) const MAX_EVENT_LINE_BYTES: usize = 2048;
 
 fn current_unix() -> u64 {
     std::time::SystemTime::now()
@@ -725,50 +721,6 @@ fn probe_needed(
     !fresh || current_fingerprint != last_fingerprint
 }
 
-/// Append one JSON line to an append-only log file (bounded to avoid
-/// unbounded growth).
-fn append_line(path: &std::path::Path, value: &serde_json::Value) {
-    let mut line = serde_json::to_string(value).unwrap_or_default();
-    line.push('\n');
-    if line.len() > MAX_EVENT_LINE_BYTES {
-        return;
-    }
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    let existing = std::fs::read(path).unwrap_or_default();
-    if existing.len().saturating_add(line.len()) <= MAX_EVENT_LOG_BYTES {
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-        {
-            use std::io::Write as _;
-            let _ = file.write_all(line.as_bytes());
-        }
-        return;
-    }
-
-    let keep_bytes = MAX_EVENT_LOG_BYTES.saturating_sub(line.len());
-    let mut retained = if existing.len() > keep_bytes {
-        let start = existing.len() - keep_bytes;
-        let boundary = existing[start..]
-            .iter()
-            .position(|byte| *byte == b'\n')
-            .map(|offset| start + offset + 1)
-            .unwrap_or(existing.len());
-        existing[boundary..].to_vec()
-    } else {
-        existing
-    };
-    retained.extend_from_slice(line.as_bytes());
-    let temporary = path.with_extension(format!("log.tmp.{}", std::process::id()));
-    if std::fs::write(&temporary, retained).is_ok() {
-        let _ = std::fs::rename(temporary, path);
-    }
-}
-
 #[cfg(test)]
 mod probe_needed_tests {
     use super::probe_needed;
@@ -800,7 +752,8 @@ mod probe_needed_tests {
 
 #[cfg(test)]
 mod bounded_log_tests {
-    use super::{append_line, MAX_EVENT_LINE_BYTES, MAX_EVENT_LOG_BYTES};
+    use super::append_line;
+    use crate::diagnostics::{MAX_EVENT_LINE_BYTES, MAX_EVENT_LOG_BYTES};
     use serde_json::json;
 
     #[test]

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,51 @@
+//! Small, bounded structured diagnostic log primitives shared by WLOC and the
+//! interception path.  The log is intentionally a recent-history buffer: it
+//! is not an audit trail and must remain safe on small gateway storage.
+
+use std::path::Path;
+
+pub(crate) const MAX_EVENT_LOG_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_EVENT_LINE_BYTES: usize = 2048;
+
+/// Append one JSON event while retaining only complete, newest records.
+pub(crate) fn append_json_line(path: &Path, value: &serde_json::Value) {
+    let mut line = serde_json::to_string(value).unwrap_or_default();
+    line.push('\n');
+    if line.len() > MAX_EVENT_LINE_BYTES {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let existing = std::fs::read(path).unwrap_or_default();
+    if existing.len().saturating_add(line.len()) <= MAX_EVENT_LOG_BYTES {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+        {
+            use std::io::Write as _;
+            let _ = file.write_all(line.as_bytes());
+        }
+        return;
+    }
+
+    let keep_bytes = MAX_EVENT_LOG_BYTES.saturating_sub(line.len());
+    let mut retained = if existing.len() > keep_bytes {
+        let start = existing.len() - keep_bytes;
+        let boundary = existing[start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|offset| start + offset + 1)
+            .unwrap_or(existing.len());
+        existing[boundary..].to_vec()
+    } else {
+        existing
+    };
+    retained.extend_from_slice(line.as_bytes());
+    let temporary = path.with_extension(format!("log.tmp.{}", std::process::id()));
+    if std::fs::write(&temporary, retained).is_ok() {
+        let _ = std::fs::rename(temporary, path);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use tokio_rustls::{TlsAcceptor, TlsConnector};
 
 pub mod app;
 pub mod config;
+pub(crate) mod diagnostics;
 pub mod exitprobe;
 pub mod georesolver;
 pub mod mitm;

--- a/src/mitm/proxy.rs
+++ b/src/mitm/proxy.rs
@@ -16,6 +16,7 @@ use http::{HeaderValue, Request, Response};
 use tokio::net::TcpStream;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
+use crate::diagnostics::append_json_line;
 use crate::mitm::{CaBundle, MitmCertResolver, MitmError};
 use crate::wloc::{patch_wloc_response, PatchTarget};
 
@@ -168,7 +169,7 @@ impl MitmProxy {
                 .await
             {
                 Ok((original_len, patched_body)) => {
-                    self.append_rewrite_event(patch.as_ref(), original_len, patched_body.len());
+                    self.append_rewrite_event(original_len, patched_body.len());
                     let mut send = respond
                         .send_response(Response::new(()), patched_body.is_empty())
                         .map_err(|error| MitmProxyError::H2(error.to_string()))?;
@@ -307,7 +308,7 @@ impl MitmProxy {
     }
 
     /// Append one rewrite event per patched WLOC response.
-    fn append_rewrite_event(&self, patch: Option<&PatchTarget>, before: usize, after: usize) {
+    fn append_rewrite_event(&self, before: usize, after: usize) {
         let Some(events_file) = &self.events_file else {
             return;
         };
@@ -315,29 +316,21 @@ impl MitmProxy {
             return;
         }
         let event = serde_json::json!({
-            "type": "rewritten",
-            "time": std::time::SystemTime::now()
+            "timestamp": std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0),
-            "latitude": patch.map(|t| t.latitude),
-            "longitude": patch.map(|t| t.longitude),
-            "bytes_before": before,
-            "bytes_after": after,
+            "component": "wloc",
+            "profile_scope": "device-policy",
+            "severity": "info",
+            "event_code": "response_rewritten",
+            "message": "WLOC response rewritten",
+            "fields": {
+                "bytes_before": before,
+                "bytes_after": after,
+            },
         });
-        use std::io::Write as _;
-        let mut line = serde_json::to_string(&event).unwrap_or_default();
-        line.push('\n');
-        if let Some(parent) = events_file.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(events_file)
-        {
-            let _ = file.write_all(line.as_bytes());
-        }
+        append_json_line(events_file, &event);
     }
 }
 

--- a/tests/app_service.rs
+++ b/tests/app_service.rs
@@ -832,6 +832,19 @@ fn status_file_and_target_events_are_written() {
         events_text.contains("target_updated"),
         "events must record target updates"
     );
+    let event: serde_json::Value = events_text
+        .lines()
+        .rfind(|line| !line.trim().is_empty())
+        .and_then(|line| serde_json::from_str(line).ok())
+        .expect("target event must be valid JSON");
+    assert_eq!(event["component"], "wloc");
+    assert_eq!(event["profile_scope"], "service");
+    assert_eq!(event["severity"], "info");
+    assert_eq!(event["event_code"], "target_updated");
+    assert!(event["message"].is_string());
+    assert!(event.get("latitude").is_none());
+    assert!(event.get("longitude").is_none());
+    assert!(event.get("assigned_device").is_none());
 
     let _ = std::fs::remove_file(&status_path);
     let _ = std::fs::remove_file(&events_path);

--- a/tests/mitm_proxy.rs
+++ b/tests/mitm_proxy.rs
@@ -219,9 +219,12 @@ async fn wloc_response_is_patched_through_the_proxy() {
     // The rewrite event must be appended to the events file.
     let events_text = std::fs::read_to_string(&events_path).unwrap_or_default();
     assert!(
-        events_text.contains("\"type\":\"rewritten\""),
+        events_text.contains("\"event_code\":\"response_rewritten\""),
         "rewrite must be logged"
     );
+    assert!(events_text.contains("\"profile_scope\":\"device-policy\""));
+    assert!(!events_text.contains("latitude"));
+    assert!(!events_text.contains("longitude"));
     let _ = std::fs::remove_file(&events_path);
 }
 

--- a/tests/scripts/test-structured-logs.sh
+++ b/tests/scripts/test-structured-logs.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-structured-log.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+clients="$tmp/clients"
+conntrack="$tmp/conntrack"
+status="$tmp/status.json"
+events="$tmp/events.log"
+state="$tmp/state"
+printf 'Phone|192.168.1.100|node-a\n' > "$clients"
+: > "$conntrack"
+
+WFC_NOW=1000 WFC_MAX_EVENT_LOG_BYTES=2048 \
+  sh "$repo_root/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh" \
+  "$clients" "$conntrack" "$status" "$state" "$events" 30 20 1
+
+if [ -s "$events" ]; then
+  echo "unexpected event without a transition" >&2
+  exit 1
+fi
+
+cat > "$conntrack" <<'EOF'
+ipv4 src=192.168.1.100 dst=10.0.0.2 sport=4500 dport=4500 packets=100 packets=100 [ASSURED]
+EOF
+WFC_NOW=1016 WFC_MAX_EVENT_LOG_BYTES=2048 \
+  sh "$repo_root/openwrt/files/usr/libexec/wificalling-gateway/monitor.sh" \
+  "$clients" "$conntrack" "$status" "$state" "$events" 30 20 1
+
+line=$(tail -n 1 "$events")
+printf '%s\n' "$line" | grep '"component":"gateway"' >/dev/null
+printf '%s\n' "$line" | grep '"profile_scope":"device-policy"' >/dev/null
+printf '%s\n' "$line" | grep '"severity":"info"' >/dev/null
+printf '%s\n' "$line" | grep '"event_code":"handshake_success"' >/dev/null
+if printf '%s\n' "$line" | grep -E '192\.168\.1\.100|Phone|"ip"|"label"' >/dev/null; then
+  echo "structured event leaked device material" >&2
+  exit 1
+fi
+
+bytes=$(wc -c < "$events" | tr -d ' ')
+[ "$bytes" -le 2048 ]
+echo 'structured logs tests passed'

--- a/tests/scripts/test-support-bundle.sh
+++ b/tests/scripts/test-support-bundle.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-support-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+cat > "$tmp/health.json" <<'EOF'
+{"services":{"wloc":{"running":true},"gateway":{"running":true}},"profiles":[{"id":"phone","label":"Alice phone","assigned_device":"192.168.1.100"}],"geo":{"latitude":1.2,"longitude":3.4}}
+EOF
+cat > "$tmp/wloc.jsonl" <<'EOF'
+{"timestamp":1000,"component":"wloc","profile_scope":"service","severity":"info","event_code":"target_updated","message":"secret 192.168.1.100","latitude":1.2,"longitude":3.4}
+EOF
+cat > "$tmp/gateway.jsonl" <<'EOF'
+{"timestamp":1001,"component":"gateway","profile_scope":"device-policy","severity":"info","event_code":"handshake_success","message":"Alice phone 192.168.1.100","device":"Alice phone"}
+EOF
+
+output="$tmp/support.tar.gz"
+WLOC_SUPPORT_OUTPUT="$output" \
+WLOC_SUPPORT_HEALTH="$tmp/health.json" \
+WLOC_SUPPORT_WLOC_LOG="$tmp/wloc.jsonl" \
+WLOC_SUPPORT_GATEWAY_LOG="$tmp/gateway.jsonl" \
+WLOC_SUPPORT_MAX_BYTES=32768 \
+  sh "$repo_root/openwrt/files/usr/sbin/wloc-support-bundle.sh"
+
+[ -s "$output" ]
+bytes=$(wc -c < "$output" | tr -d ' ')
+[ "$bytes" -le 32768 ]
+tar -tzf "$output" | grep '^wloc-support/' >/dev/null
+tar -xOzf "$output" wloc-support/events.jsonl | grep '"event_code":"target_updated"' >/dev/null
+if tar -xOzf "$output" wloc-support/events.jsonl | grep -E 'Alice|192\.168\.1\.100|latitude|longitude|secret' >/dev/null; then
+  echo 'support bundle leaked private event material' >&2
+  exit 1
+fi
+if tar -xOzf "$output" wloc-support/health.json | grep -E 'Alice|192\.168\.1\.100|profiles|latitude|longitude' >/dev/null; then
+  echo 'support bundle leaked private health material' >&2
+  exit 1
+fi
+echo 'support bundle tests passed'

--- a/tests/scripts/test-support-bundle.sh
+++ b/tests/scripts/test-support-bundle.sh
@@ -36,4 +36,17 @@ if tar -xOzf "$output" wloc-support/health.json | grep -E 'Alice|192\.168\.1\.10
   echo 'support bundle leaked private health material' >&2
   exit 1
 fi
+
+victim="$tmp/victim"
+printf 'do not replace this file\n' > "$victim"
+ln -s "$victim" "$tmp/symlink.tar.gz"
+if WLOC_SUPPORT_OUTPUT="$tmp/symlink.tar.gz" \
+   WLOC_SUPPORT_HEALTH="$tmp/health.json" \
+   WLOC_SUPPORT_WLOC_LOG="$tmp/wloc.jsonl" \
+   WLOC_SUPPORT_GATEWAY_LOG="$tmp/gateway.jsonl" \
+   sh "$repo_root/openwrt/files/usr/sbin/wloc-support-bundle.sh"; then
+  echo 'support bundle accepted a symlink output' >&2
+  exit 1
+fi
+grep 'do not replace this file' "$victim" >/dev/null
 echo 'support bundle tests passed'

--- a/tests/test_v2_diagnostics_contract.py
+++ b/tests/test_v2_diagnostics_contract.py
@@ -1,0 +1,52 @@
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class V2DiagnosticsContractTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(__file__).resolve().parents[1]
+
+    def test_support_bundle_is_bounded_and_privacy_safe(self):
+        script = self.root / "openwrt/files/usr/sbin/wloc-support-bundle.sh"
+        source = script.read_text(encoding="utf-8")
+        self.assertIn("MAX_BYTES", source)
+        self.assertIn("no-credentials-no-device-identifiers-no-precise-location", source)
+        self.assertIn("redacted diagnostic event", source)
+        self.assertIn("tar -czf", source)
+
+    def test_diagnostics_rpc_acl_and_ui_are_present_in_both_package_sources(self):
+        for prefix in (
+            self.root / "openwrt/files",
+            self.root / "openwrt/luci-app-wificalling-location-gateway/files",
+        ):
+            rpc = (prefix / "usr/libexec/rpcd/luci.wloc").read_text(encoding="utf-8")
+            self.assertIn("support_bundle", rpc)
+            acl = json.loads(
+                (prefix / "usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json").read_text(
+                    encoding="utf-8"
+                )
+            )["luci-app-wificalling-location-gateway"]
+            read_methods = acl["read"]["ubus"]["luci.wloc"]
+            write_methods = acl["write"]["ubus"]["luci.wloc"]
+            self.assertNotIn("support_bundle", read_methods)
+            self.assertIn("support_bundle", write_methods)
+            health = (prefix / "www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js").read_text(encoding="utf-8")
+            self.assertIn("Generate support bundle", health)
+            monitor = (prefix / "www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js").read_text(encoding="utf-8")
+            self.assertIn("eventFields", monitor)
+
+    def test_support_bundle_shell_and_log_regression_scripts_pass(self):
+        for name in ("test-support-bundle.sh", "test-structured-logs.sh"):
+            result = subprocess.run(
+                ["sh", str(self.root / "tests/scripts" / name)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v2_diagnostics_contract.py
+++ b/tests/test_v2_diagnostics_contract.py
@@ -15,6 +15,15 @@ class V2DiagnosticsContractTests(unittest.TestCase):
         self.assertIn("no-credentials-no-device-identifiers-no-precise-location", source)
         self.assertIn("redacted diagnostic event", source)
         self.assertIn("tar -czf", source)
+        self.assertIn("wloc-support-bundle.lock", source)
+
+    def test_support_bundle_is_installed_by_all_openwrt_package_paths(self):
+        makefile = (self.root / "openwrt/Makefile").read_text(encoding="utf-8")
+        standalone = (self.root / "scripts/build-luci-ipk.sh").read_text(encoding="utf-8")
+        release = (self.root / "scripts/openwrt/build-release-packages.sh").read_text(encoding="utf-8")
+        self.assertIn("files/usr/sbin/wloc-support-bundle.sh", makefile)
+        self.assertIn("wloc-support-bundle.sh", standalone)
+        self.assertIn("wloc-support-bundle.sh", release)
 
     def test_diagnostics_rpc_acl_and_ui_are_present_in_both_package_sources(self):
         for prefix in (


### PR DESCRIPTION
Closes #38

## Summary
- unify Gateway, WLOC service, and MITM rewrite diagnostics around bounded privacy-safe JSONL events
- add shared 64 KiB/2 KiB Rust log retention and schema-aware Gateway rotation
- add root-only support bundle collection with redaction, cap, lock, private archive, atomic replacement, and symlink rejection
- integrate the helper into canonical, standalone AX6S, and release package paths
- add LuCI action, ACL coverage, shell regression tests, package-path contract tests, and operations documentation

## Verification
- `./scripts/ci/verify.sh` passed
- 78 Python tests passed
- Rust line coverage 80.11% (threshold 80%)
- OpenWrt/AX6S/release packaging passed
- structured-log/support-bundle privacy and cap tests passed
- cargo audit advisories/bans/licenses/sources passed; existing duplicate lock entries remain warnings only

## Risk and rollback
- Support bundle generation is serialized by a `/tmp` directory lock and keeps the existing fixed output path for LuCI compatibility.
- Event history is recent bounded diagnostics, not an audit trail; raw status/config/traffic remains excluded.
- Rollback is a package/commit rollback to the parent V2-06 implementation; the previous stable Gateway nftables namespace is untouched.

Handoff capsule: `.handoffs/issue-38.md`
