### PR TITLE
feat: add component update compatibility and rollback

### DIFF
--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -5,7 +5,7 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test,security,docs
 - Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
-- Final local checkpoint before handoff: 029f53b
+- Final local checkpoint before handoff: 659930a
 - Credentials included: no
 
 ## Objective
@@ -101,6 +101,9 @@ transaction.
   manifest and release signing is supplied through `WFC_UPDATE_SIGNING_KEY`.
 - `ax6s-existing` now packages the V2 helper/supervisor adapter and has an
   actual build-and-unpack regression test.
+- The update-manifest and AX6S package tests accept both canonical GNU tar
+  member names and `./`-prefixed BSD tar names; the existing-package test also
+  verifies the support-bundle helper.
 - GitHub run `32471646456` exposed a pre-existing nondeterministic sing-box
   stderr fixture; it now emits one deterministic diagnostic and `exec`s a
   long-lived process, with five repeated local runs passing.

--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -1,0 +1,135 @@
+# Agent handoff: Issue 39
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: openwrt,test,security,docs
+- Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
+- Final local checkpoint before handoff: 2463ce9
+- Credentials included: no
+
+## Objective
+
+Add a low-storage-safe component update center for the unified Gateway/WLOC
+package: validate identity/compatibility/architecture/version/source/space,
+preserve configuration, install without remove-first behavior, gate activation
+on supervisor health, and automatically roll back a failed or interrupted
+transaction.
+
+## Completed
+
+- Added root-only `wloc-component-update.sh` with `preflight`, `apply`,
+  `recover`, and `status` actions.
+- Validates regular local IPK, archive paths, package identity, V2 product
+  metadata, Gateway 1.7, WLOC v2 API, target architecture, semantic package
+  version, free space, downgrade authorization, and known-good rollback package.
+- Serializes updates with a persistent lock and transaction directory; stores
+  previous package and both legacy component UCI files with mode-restricted
+  state.
+- Preserves configuration after opkg install; restarts only the unified
+  supervisor and runs health validation. Install/restart/health failures restore
+  the known-good package and configuration. A simulated power-loss marker is
+  recoverable by `recover`.
+- Explicitly contains no `opkg remove`, `nft`, UDP 500/4500 handling, or stable
+  Gateway table manipulation.
+- Added compatibility metadata to both package source trees and builder control
+  fields; helper is installed by canonical Makefile, standalone AX6S builder,
+  and release package builder.
+- Added RPC/ACL methods `update_status`, `update_preflight`, `update_apply`,
+  and `update_recover`, restricted package paths to `/tmp/wloc-update/*`, and
+  added LuCI Health-page controls/status for preflight, apply, and recovery.
+- Added update operations documentation and TDD evidence.
+
+## Files changed
+
+- `openwrt/files/usr/sbin/wloc-component-update.sh`
+- `openwrt/files/usr/libexec/rpcd/luci.wloc`
+- `openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc`
+- both package ACL JSON files
+- both LuCI health views and i18n sources
+- `openwrt/Makefile`
+- `scripts/build-luci-ipk.sh`
+- `scripts/openwrt/build-release-packages.sh`
+- `scripts/ci/verify.sh`
+- compatibility metadata files under both package source trees
+- `tests/scripts/test-component-update.sh`
+- `tests/test_v2_diagnostics_contract.py`
+- `docs/operations/V2_COMPONENT_UPDATE.md`
+- `docs/testing/V2_COMPONENT_UPDATE.tdd.md`
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./scripts/ci/verify.sh` | Passed | 80 Python tests, all Rust targets, OpenWrt/AX6S/release packaging, update transaction, secret scan, cargo audit |
+| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed | 80.11% total Rust line coverage |
+| `sh tests/scripts/test-component-update.sh` | Passed | architecture rejection, unauthorized/authorized downgrade, config preservation, health rollback, interrupted recovery, low-space preflight |
+| `python3 -m unittest tests.test_v2_diagnostics_contract` | Passed | 6 contract tests covering helper/package/RPC/ACL/UI |
+| `sh tests/scripts/test-standalone-ax6s-package.sh` | Passed | standalone package path |
+| `sh tests/scripts/test-openwrt-release-packaging.sh` | Passed | release package path |
+| `node --check` on both health views | Passed | mirrored LuCI syntax |
+| `git diff --check` | Passed | no whitespace errors |
+
+## Failed attempts
+
+- The initial RED test correctly failed because the update helper was absent;
+  this is recorded in TDD evidence.
+- The first version key used a 32-digit numeric string and overflowed BusyBox
+  integer comparison; it was reduced to a bounded 12-digit key and strict
+  version regex.
+- The first rollback path ignored package restore failure and could report
+  `rolled_back` falsely; it now restarts and health-checks the restored package
+  and reports `rollback_failed` when recovery is incomplete.
+- Release package control metadata is not assumed to support arbitrary custom
+  control fields; the package also ships a compatibility file, and the updater
+  validates that fallback.
+- Commit hooks report `lefthook` unavailable in PATH; repository verification
+  completed successfully.
+
+## Warnings and non-blocking notes
+
+- Existing cargo audit duplicate `socket2` and `windows-sys` lock entries remain
+  warnings; advisories, bans, licenses, and sources pass.
+- The LuCI surface expects the operator to stage the IPK locally under
+  `/tmp/wloc-update`; it intentionally does not fetch arbitrary URLs or upload
+  packages. Hardware flash-full and hard-power-cut evidence is Issue #40.
+- The updater requires a known-good rollback IPK. First installation must
+  establish `current.ipk` before transactional upgrades are enabled.
+
+## Unresolved decisions and blockers
+
+- AX6S memory/storage/CPU measurement and real-device update/rollback evidence:
+  Issue #40.
+- Full migration rehearsal, release matrix, and V2 publication: Issue #41.
+
+## Capabilities required for the next Agent
+
+- `openwrt`, `test`, `security`, `docs`, and independent review of root-only
+  package and rollback boundaries.
+
+## Environment assumptions
+
+- `opkg`, `tar`, `df`, `grep -E`, `sed`, and `awk` are available in the target
+  OpenWrt image.
+- `/tmp/wloc-update` is writable for explicit local staging; persistent state
+  under `/var/lib/wificalling-location-gateway/update` is writable by root.
+- The unified supervisor is the only permitted lifecycle restart boundary.
+
+## Security and privacy notes
+
+- Package input is local-only, path-bounded by rpcd, archive-traversal checked,
+  and never streamed from an untrusted URL.
+- No credentials, CA private keys, raw traffic, precise locations, or device
+  identifiers are included in transaction status or error output.
+- Update operations never manipulate the stable Gateway nftables namespace or
+  UDP 500/4500 handling; failed activation remains passthrough via supervisor
+  rollback.
+
+## Next executable steps
+
+1. Run `scripts/agent-handoff.sh 39 codex-v2-lead openwrt,test,security,docs`.
+2. Push the branch and open a PR with `Closes #39`, this handoff capsule, test
+   evidence, rollback notes, and known hardware-test gap.
+3. Require independent security/test review and all GitHub checks before merge.
+4. After merge, take Issue #40 for AX6S resource profiling and real-device
+   upgrade/rollback evidence.

--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -5,7 +5,7 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test,security,docs
 - Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
-- Final local checkpoint before handoff: 659930a
+- Final local checkpoint before handoff: pending final CI commit
 - Credentials included: no
 
 ## Objective
@@ -104,6 +104,8 @@ transaction.
 - The update-manifest and AX6S package tests accept both canonical GNU tar
   member names and `./`-prefixed BSD tar names; the existing-package test also
   verifies the support-bundle helper.
+- The manifest builder uses explicit regular-file validation so ShellCheck
+  does not permit ambiguous `&& ... ||` control flow.
 - GitHub run `32471646456` exposed a pre-existing nondeterministic sing-box
   stderr fixture; it now emits one deterministic diagnostic and `exec`s a
   long-lived process, with five repeated local runs passing.

--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -5,7 +5,7 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test,security,docs
 - Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
-- Final local checkpoint before handoff: e5eaf9a
+- Final local checkpoint before handoff: 029f53b
 - Credentials included: no
 
 ## Objective
@@ -22,7 +22,8 @@ transaction.
   `recover`, and `status` actions.
 - Validates regular local IPK, archive paths, package identity, V2 product
   metadata, Gateway 1.7, WLOC v2 API, target architecture, semantic package
-  version, free space, downgrade authorization, and known-good rollback package.
+  version, signed SHA-256 manifest, free space, downgrade authorization, and
+  known-good rollback package.
 - Serializes updates with a persistent lock and transaction directory; stores
   previous package and both legacy component UCI files with mode-restricted
   state.
@@ -53,6 +54,8 @@ transaction.
 - `scripts/ci/verify.sh`
 - compatibility metadata files under both package source trees
 - `tests/scripts/test-component-update.sh`
+- `tests/scripts/test-existing-ax6s-package.sh`
+- `scripts/create-update-manifest.sh`
 - `tests/test_v2_diagnostics_contract.py`
 - `docs/operations/V2_COMPONENT_UPDATE.md`
 - `docs/testing/V2_COMPONENT_UPDATE.tdd.md`
@@ -62,8 +65,9 @@ transaction.
 | Command | Result | Evidence |
 |---|---|---|
 | `./scripts/ci/verify.sh` | Passed | 80 Python tests, all Rust targets, OpenWrt/AX6S/release packaging, update transaction, secret scan, cargo audit |
-| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed | 80.11% total Rust line coverage |
+| `cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80` | Passed | 80.16% total Rust line coverage |
 | `sh tests/scripts/test-component-update.sh` | Passed | architecture rejection, unauthorized/authorized downgrade, config preservation, health rollback, interrupted recovery, low-space preflight |
+| `sh tests/scripts/test-existing-ax6s-package.sh` | Passed | actual legacy AX6S package build and helper/supervisor extraction |
 | `python3 -m unittest tests.test_v2_diagnostics_contract` | Passed | 6 contract tests covering helper/package/RPC/ACL/UI |
 | `sh tests/scripts/test-standalone-ax6s-package.sh` | Passed | standalone package path |
 | `sh tests/scripts/test-openwrt-release-packaging.sh` | Passed | release package path |
@@ -88,6 +92,15 @@ transaction.
 - Validation and low-space failure paths now remove their temporary unpack
   directories; the shell regression test asserts that no check workspace is
   leaked.
+- Rollback failures retain the transaction for a later `recover`; stale PID
+  locks from hard power loss are reclaimed only when the owner is dead.
+- Both persistent state and `/tmp` free space are checked, commit-copy errors
+  trigger rollback, and state/transaction files are root-only.
+- Update packages require a signed sidecar manifest with outer-package,
+  control-archive, and data-archive SHA-256 values. The builder emits the
+  manifest and release signing is supplied through `WFC_UPDATE_SIGNING_KEY`.
+- `ax6s-existing` now packages the V2 helper/supervisor adapter and has an
+  actual build-and-unpack regression test.
 - GitHub run `32471646456` exposed a pre-existing nondeterministic sing-box
   stderr fixture; it now emits one deterministic diagnostic and `exec`s a
   long-lived process, with five repeated local runs passing.

--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -5,7 +5,7 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test,security,docs
 - Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
-- Final local checkpoint before handoff: 2463ce9
+- Final local checkpoint before handoff: adbae03
 - Credentials included: no
 
 ## Objective
@@ -83,6 +83,8 @@ transaction.
 - Release package control metadata is not assumed to support arbitrary custom
   control fields; the package also ships a compatibility file, and the updater
   validates that fallback.
+- Rollback now passes `--force-downgrade` to opkg and the test stub parses
+  option-bearing invocations, matching OpenWrt downgrade behavior.
 - Commit hooks report `lefthook` unavailable in PATH; repository verification
   completed successfully.
 

--- a/.handoffs/issue-39.md
+++ b/.handoffs/issue-39.md
@@ -5,7 +5,7 @@
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test,security,docs
 - Branch: codex/issue-39-v2-update-rollback-codex-v2-lead-20260821095228-1bc1507b
-- Final local checkpoint before handoff: adbae03
+- Final local checkpoint before handoff: e5eaf9a
 - Credentials included: no
 
 ## Objective
@@ -85,13 +85,21 @@ transaction.
   validates that fallback.
 - Rollback now passes `--force-downgrade` to opkg and the test stub parses
   option-bearing invocations, matching OpenWrt downgrade behavior.
+- Validation and low-space failure paths now remove their temporary unpack
+  directories; the shell regression test asserts that no check workspace is
+  leaked.
+- GitHub run `32471646456` exposed a pre-existing nondeterministic sing-box
+  stderr fixture; it now emits one deterministic diagnostic and `exec`s a
+  long-lived process, with five repeated local runs passing.
 - Commit hooks report `lefthook` unavailable in PATH; repository verification
   completed successfully.
 
 ## Warnings and non-blocking notes
 
 - Existing cargo audit duplicate `socket2` and `windows-sys` lock entries remain
-  warnings; advisories, bans, licenses, and sources pass.
+  warnings; advisories, bans, licenses, and sources pass when the cached
+  advisory database is used. The final local online audit refresh was blocked
+  by a transient RustSec TLS error.
 - The LuCI surface expects the operator to stage the IPK locally under
   `/tmp/wloc-update`; it intentionally does not fetch arbitrary URLs or upload
   packages. Hardware flash-full and hard-power-cut evidence is Issue #40.

--- a/docs/operations/V2_COMPONENT_UPDATE.md
+++ b/docs/operations/V2_COMPONENT_UPDATE.md
@@ -12,6 +12,9 @@ Before `opkg install` is called, the helper validates:
 - regular local IPK and safe `control.tar.gz`/`data.tar.gz` members;
 - unified package identity, version, architecture, Gateway `1.7`, and
   `wloc.service/v2` compatibility metadata;
+- a sidecar `PACKAGE.ipk.manifest` containing package/control/data SHA-256
+  values and a detached `PACKAGE.ipk.sig` verified with the router's
+  `/etc/wificalling-location-gateway/update.pub` `usign` key;
 - free space for the package plus a bounded transaction reserve;
 - current-version ordering, including explicit authorization for downgrade;
 - a known-good rollback IPK.
@@ -31,11 +34,16 @@ existing fail-open withdrawal/restart boundary.
 ## State and resource policy
 
 Persistent state is stored under
-`/var/lib/wificalling-location-gateway/update` with mode `0600` files and a
-directory lock. `current.ipk`, `current.version`, and `status.json` retain the
-last known-good update record. A second update is rejected while a transaction
-or lock exists. On AX6S the preflight reserve prevents an update from starting
-when flash space is too low; no large duplicate root filesystem is created.
+`/var/lib/wificalling-location-gateway/update` with a `0700` directory, `0600`
+files, and a PID-bearing directory lock. A dead lock from a hard power cut is
+reclaimed safely; a live or unreadable lock is not removed automatically.
+`current.ipk`, `current.version`, and `status.json` retain the last known-good
+update record. A second update is rejected while a transaction or live lock
+exists. Preflight checks the smaller of the persistent-state and temporary
+filesystems and reserves space for the package, rollback copy, commit copy,
+and transaction overhead. On AX6S this prevents an update from starting when
+flash or `/tmp` space is too low; no large duplicate root filesystem is
+created.
 
 Package metadata emitted by the builder includes:
 
@@ -44,6 +52,20 @@ X-WFC-Product: wificalling-location-gateway/v2
 X-WFC-Gateway: 1.7
 X-WFC-Wloc-Api: wloc.service/v2
 ```
+
+`scripts/build-luci-ipk.sh` also writes the unsigned manifest sidecar. Release
+automation must sign it before staging:
+
+```sh
+for package in dist/wificalling-location-gateway_*.ipk; do
+  WFC_UPDATE_SIGNING_KEY=/secure/release.sec \
+    scripts/create-update-manifest.sh "$package"
+done
+```
+
+Keep the resulting `.manifest` and `.sig` beside the IPK under
+`/tmp/wloc-update/`; the update UI deliberately accepts only this local
+staging workflow.
 
 ## LuCI behavior
 

--- a/docs/operations/V2_COMPONENT_UPDATE.md
+++ b/docs/operations/V2_COMPONENT_UPDATE.md
@@ -1,0 +1,57 @@
+# V2 component update and rollback
+
+## Update contract
+
+The root-only `/usr/sbin/wloc-component-update.sh` is the single update
+boundary for the unified Gateway/WLOC package. LuCI may only reference an IPK
+already staged under `/tmp/wloc-update/`; it cannot provide a URL or an
+arbitrary filesystem path.
+
+Before `opkg install` is called, the helper validates:
+
+- regular local IPK and safe `control.tar.gz`/`data.tar.gz` members;
+- unified package identity, version, architecture, Gateway `1.7`, and
+  `wloc.service/v2` compatibility metadata;
+- free space for the package plus a bounded transaction reserve;
+- current-version ordering, including explicit authorization for downgrade;
+- a known-good rollback IPK.
+
+The install is never remove-first. The helper takes a persistent transaction
+snapshot of the two component configuration files and the previous package,
+invokes the package manager, restores configuration, restarts only the unified
+supervisor, and runs the bounded health command. Any install, restart, or
+health failure restores the known-good package and configuration. A simulated
+power loss or process interruption leaves the transaction marker; the LuCI
+Recover action calls `recover` to complete the rollback.
+
+The update path does not call `nft`, edit nftables rules, disable UDP 500/4500,
+or stop the stable Gateway data-plane owner directly. The supervisor owns the
+existing fail-open withdrawal/restart boundary.
+
+## State and resource policy
+
+Persistent state is stored under
+`/var/lib/wificalling-location-gateway/update` with mode `0600` files and a
+directory lock. `current.ipk`, `current.version`, and `status.json` retain the
+last known-good update record. A second update is rejected while a transaction
+or lock exists. On AX6S the preflight reserve prevents an update from starting
+when flash space is too low; no large duplicate root filesystem is created.
+
+Package metadata emitted by the builder includes:
+
+```text
+X-WFC-Product: wificalling-location-gateway/v2
+X-WFC-Gateway: 1.7
+X-WFC-Wloc-Api: wloc.service/v2
+```
+
+## LuCI behavior
+
+The Health and Monitor page exposes update phase, current/target versions,
+reason code, package preflight, apply, and interrupted-transaction recovery.
+The UI does not upload or fetch packages; staging remains an explicit local
+router operation so the update source is observable and bounded.
+
+An update status of `rollback_failed` is actionable and must not be presented
+as a successful update. The operator should keep the router in passthrough,
+restore the known-good IPK from local storage, and run `recover` again.

--- a/docs/testing/V2_COMPONENT_UPDATE.tdd.md
+++ b/docs/testing/V2_COMPONENT_UPDATE.tdd.md
@@ -1,0 +1,38 @@
+# V2-07 component update TDD evidence
+
+## Source plan
+
+Journeys were derived from GitHub Issue #39: validate a package before mutation,
+preserve configuration, reject low storage, support downgrade only when
+explicitly authorized, and recover automatically after failed activation or
+interruption.
+
+## RED/GREEN checkpoints
+
+- `90288e7 test: define component update rollback contract` — RED: the new
+  executable test ran and failed because the update helper did not exist.
+- `a8d3e70 fix: add transactional component update and rollback` — GREEN: the
+  same test passed for successful update, health rollback, interrupted recovery,
+  and low-space preflight.
+
+## Test specification
+
+| Guarantee | Test | Result |
+|---|---|---|
+| A valid compatible IPK is installed without removing first | `tests/scripts/test-component-update.sh` | PASS |
+| Configuration survives package overwrite | `tests/scripts/test-component-update.sh` | PASS |
+| Wrong architecture and unauthorized downgrade are rejected before opkg | `tests/scripts/test-component-update.sh` | PASS |
+| Explicit downgrade is supported | `tests/scripts/test-component-update.sh` | PASS |
+| Failed health activation restores the known-good package and config | `tests/scripts/test-component-update.sh` | PASS |
+| Interrupted transaction is recoverable | `tests/scripts/test-component-update.sh` | PASS |
+| Low storage fails before package mutation | `tests/scripts/test-component-update.sh` | PASS |
+| RPC, ACL, UI, package paths, and compatibility metadata remain aligned | `tests/test_v2_diagnostics_contract.py` | PASS |
+
+## Coverage and known gaps
+
+The shell transaction contract is deterministic and runs through the full
+repository gate. Real AX6S power-loss timing, opkg database recovery after a
+hard power cut, and an on-device flash-full fault still require Issue #40
+hardware evidence. The helper deliberately requires a known-good rollback IPK;
+first installation is outside the update transaction and must establish that
+baseline before upgrades are enabled.

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -52,6 +52,7 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-profile-status.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-health.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-support-bundle.sh $(1)/usr/sbin/
+	$(INSTALL_BIN) ./files/usr/sbin/wloc-component-update.sh $(1)/usr/sbin/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/

--- a/openwrt/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/files/usr/libexec/rpcd/luci.wloc
@@ -10,6 +10,7 @@
 
 CTL=/usr/sbin/wloc-ctl
 EXPORT=/usr/sbin/export-mobileconfig.sh
+UPDATE=/usr/sbin/wloc-component-update.sh
 
 ctl_live() {
 	out="$("$CTL" "$@" 2>&1)" && return 0
@@ -62,6 +63,14 @@ list)
 	json_add_object health
 	json_close_object
 	json_add_object support_bundle
+	json_close_object
+	json_add_object update_status
+	json_close_object
+	json_add_object update_preflight
+	json_close_object
+	json_add_object update_apply
+	json_close_object
+	json_add_object update_recover
 	json_close_object
 	json_add_object node_test
 	json_close_object
@@ -271,6 +280,42 @@ call)
 			exit 0
 		fi
 		/usr/libexec/wificalling-gateway/node-test.sh "$id"
+		exit 0
+		;;
+	update_status)
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		"$UPDATE" status
+		exit $?
+		;;
+	update_preflight|update_apply)
+		read -r input
+		json_load "$input"
+		json_get_var path path
+		case "$path" in
+			/tmp/wloc-update/*) ;;
+			*) echo '{"error":"update package must be staged under /tmp/wloc-update"}'; exit 1 ;;
+		esac
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		if out="$($UPDATE "${2#update_}" "$path" 2>&1)"; then
+			printf '%s\n' "$out"
+		else
+			json_init
+			json_add_string error "$out"
+			json_dump
+			exit 1
+		fi
+		exit 0
+		;;
+	update_recover)
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		if out="$($UPDATE recover 2>&1)"; then
+			printf '%s\n' "$out"
+		else
+			json_init
+			json_add_string error "$out"
+			json_dump
+			exit 1
+		fi
 		exit 0
 		;;
 	regen_ca)

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -15,6 +15,7 @@ HEALTH=${WLOC_UPDATE_HEALTH:-/usr/sbin/wloc-health.sh}
 STATUS=$STATE_DIR/status.json
 TXN=$STATE_DIR/transaction
 LOCK=$STATE_DIR/.lock
+WORK=
 
 die() {
 	printf '%s\n' "$1" >&2
@@ -36,9 +37,19 @@ write_status() {
 	mv -f "$temporary" "$STATUS"
 }
 
+cleanup_work() {
+	if [ -n "${WORK:-}" ]; then
+		rm -rf "$WORK"
+		WORK=
+	fi
+}
+
 cleanup_lock() {
+	cleanup_work
 	rmdir "$LOCK" 2>/dev/null || true
 }
+
+trap 'cleanup_work' EXIT HUP INT TERM
 
 acquire_lock() {
 	mkdir -p "$STATE_DIR"
@@ -177,8 +188,8 @@ rollback_transaction() {
 
 preflight() {
 	package=$1
-	work=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
-	version=$(package_info "$package" "$work")
+	WORK=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
+	version=$(package_info "$package" "$WORK")
 	bytes=$(wc -c < "$package" | tr -d ' ')
 	available=$(free_kb)
 	case "$available" in ''|*[!0-9]*) die 'free-space check is unavailable' ;; esac
@@ -192,15 +203,15 @@ preflight() {
 		fi
 	fi
 	printf '{"ok":true,"target_version":"%s","current_version":"%s","free_kb":%s}\n' "$version" "$current" "$available"
-	rm -rf "$work"
+	cleanup_work
 }
 
 apply_update() {
 	package=$1
 	acquire_lock
 	[ ! -e "$TXN" ] || die 'an interrupted update must be recovered before another update'
-	work=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
-	version=$(package_info "$package" "$work")
+	WORK=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
+	version=$(package_info "$package" "$WORK")
 	bytes=$(wc -c < "$package" | tr -d ' ')
 	available=$(free_kb)
 	case "$available" in ''|*[!0-9]*) die 'free-space check is unavailable' ;; esac
@@ -248,7 +259,8 @@ apply_update() {
 	chmod 0600 "$STATE_DIR/current.ipk"
 	printf '%s\n' "$version" > "$STATE_DIR/current.version"
 	write_status applied ready "$version" "$version"
-	rm -rf "$TXN" "$work"
+	rm -rf "$TXN"
+	cleanup_work
 }
 
 recover_update() {

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -152,7 +152,7 @@ rollback_transaction() {
 	write_status rolling_back "$reason" "$target_version" "$old_version"
 	rollback_ok=1
 	if [ -f "$TXN/rollback.ipk" ]; then
-		"$OPKG" install "$TXN/rollback.ipk" >/dev/null 2>&1 || rollback_ok=0
+		"$OPKG" --force-downgrade install "$TXN/rollback.ipk" >/dev/null 2>&1 || rollback_ok=0
 	else
 		rollback_ok=0
 	fi

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+# Transactional updater for the unified Gateway/WLOC component.
+#
+# The package is validated before the first mutation. A known-good package and
+# configuration snapshot are retained until restart and health validation pass;
+# a failed activation or interrupted transaction can therefore be recovered.
+
+set -eu
+
+ROOT=${WLOC_UPDATE_ROOT:-/}
+STATE_DIR=${WLOC_UPDATE_STATE_DIR:-/var/lib/wificalling-location-gateway/update}
+OPKG=${WLOC_UPDATE_OPKG:-/usr/bin/opkg}
+SUPERVISOR=${WLOC_UPDATE_SUPERVISOR:-/etc/init.d/wificalling-location-gateway}
+HEALTH=${WLOC_UPDATE_HEALTH:-/usr/sbin/wloc-health.sh}
+STATUS=$STATE_DIR/status.json
+TXN=$STATE_DIR/transaction
+LOCK=$STATE_DIR/.lock
+
+die() {
+	printf '%s\n' "$1" >&2
+	exit 1
+}
+
+now() { date +%s; }
+
+write_status() {
+	phase=$1
+	reason=$2
+	target=${3:-}
+	current=${4:-}
+	mkdir -p "$STATE_DIR"
+	temporary="$STATE_DIR/status.tmp.$$"
+	printf '{"version":1,"phase":"%s","reason":"%s","target_version":"%s","current_version":"%s","updated_at":%s}\n' \
+		"$phase" "$reason" "$target" "$current" "$(now)" > "$temporary"
+	chmod 0600 "$temporary"
+	mv -f "$temporary" "$STATUS"
+}
+
+cleanup_lock() {
+	rmdir "$LOCK" 2>/dev/null || true
+}
+
+acquire_lock() {
+	mkdir -p "$STATE_DIR"
+	if ! mkdir "$LOCK" 2>/dev/null; then
+		die 'component update is already in progress'
+	fi
+	trap 'cleanup_lock' EXIT HUP INT TERM
+}
+
+field() {
+	key=$1
+	file=$2
+	sed -n "s/^${key}:[[:space:]]*//p" "$file" | head -n 1
+}
+
+archive_safe() {
+	archive=$1
+	tar -tzf "$archive" >/dev/null 2>&1 || return 1
+	tar -tzf "$archive" | awk '
+		/^\// || /(^|\/)\.\.($|\/)/ { bad=1 }
+		END { exit bad ? 1 : 0 }
+	'
+}
+
+version_key() {
+	printf '%s\n' "$1" | awk -F '[.-]' '{printf "%03d%03d%03d%03d", $1+0, $2+0, $3+0, $4+0}'
+}
+
+validate_version() {
+	case "$1" in
+		[0-9]*.[0-9]*.[0-9]*-[0-9A-Za-z]*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+free_kb() {
+	if [ -n "${WLOC_UPDATE_FREE_KB:-}" ]; then
+		printf '%s\n' "$WLOC_UPDATE_FREE_KB"
+		return
+	fi
+	df -Pk "$STATE_DIR" | awk 'NR == 2 { print $4; exit }'
+}
+
+package_info() {
+	package=$1
+	work=$2
+	[ -f "$package" ] && [ ! -L "$package" ] || die 'update package must be a regular local file'
+	if [ "${WLOC_UPDATE_ALLOW_ANY_SOURCE:-0}" != 1 ]; then
+		case "$package" in
+			/tmp/wloc-update/*|$STATE_DIR/incoming/*) ;;
+			*) die 'update source must be under the local update staging directory' ;;
+		esac
+	fi
+	archive_safe "$package" || die 'update package archive is unsafe or corrupt'
+	tar -tzf "$package" | grep -Fx './control.tar.gz' >/dev/null || die 'update package lacks control archive'
+	tar -tzf "$package" | grep -Fx './data.tar.gz' >/dev/null || die 'update package lacks data archive'
+	mkdir -p "$work/control"
+	tar -xzf "$package" -C "$work" ./control.tar.gz
+	archive_safe "$work/control.tar.gz" || die 'control archive is unsafe or corrupt'
+	tar -xzf "$work/control.tar.gz" -C "$work/control" ./control
+	control="$work/control/control"
+	name=$(field Package "$control")
+	version=$(field Version "$control")
+	architecture=$(field Architecture "$control")
+	product=$(field X-WFC-Product "$control")
+	gateway=$(field X-WFC-Gateway "$control")
+	api=$(field X-WFC-Wloc-Api "$control")
+	case "$name" in
+		wificalling-location-gateway|luci-app-wificalling-location-gateway) ;;
+		*) die 'update package identity is not the unified product' ;;
+	esac
+	validate_version "$version" || die 'update package version is invalid'
+	[ "$product" = 'wificalling-location-gateway/v2' ] || die 'update package compatibility metadata is missing'
+	[ "$gateway" = '1.7' ] || die 'update package requires an incompatible Gateway major version'
+	[ "$api" = 'wloc.service/v2' ] || die 'update package requires an incompatible WLOC API'
+	if [ "$architecture" != all ]; then
+		expected=${WLOC_UPDATE_ARCHITECTURE:-}
+		if [ -z "$expected" ] && [ -x "$OPKG" ]; then
+			expected=$($OPKG print-architecture 2>/dev/null | awk '$2 != "all" { print $2; exit }')
+		fi
+		[ -n "$expected" ] && [ "$architecture" = "$expected" ] || die 'update package architecture is incompatible'
+	fi
+	tar -xzf "$package" -C "$work" ./data.tar.gz
+	archive_safe "$work/data.tar.gz" || die 'data archive is unsafe or corrupt'
+	tar -tzf "$work/data.tar.gz" | awk '
+		/^\./ { next }
+		{ bad=1 }
+		END { exit bad ? 1 : 0 }
+	' && true
+	printf '%s\n' "$version"
+}
+
+restore_configs() {
+	for config in wloc-service wificalling-gateway; do
+		if [ -f "$TXN/config.$config" ]; then
+			mkdir -p "$ROOT/etc/config"
+			cp -p "$TXN/config.$config" "$ROOT/etc/config/$config"
+		elif [ -f "$TXN/config.$config.absent" ]; then
+			rm -f "$ROOT/etc/config/$config"
+		fi
+	done
+}
+
+rollback_transaction() {
+	reason=${1:-health_check_failed}
+	old_version=$(cat "$TXN/current.version" 2>/dev/null || true)
+	target_version=$(cat "$TXN/target.version" 2>/dev/null || true)
+	write_status rolling_back "$reason" "$target_version" "$old_version"
+	if [ -f "$TXN/rollback.ipk" ]; then
+		"$OPKG" install "$TXN/rollback.ipk" >/dev/null 2>&1 || true
+	fi
+	restore_configs
+	if [ -n "$old_version" ]; then
+		printf '%s\n' "$old_version" > "$STATE_DIR/current.version"
+	fi
+	if [ -f "$TXN/rollback.ipk" ]; then
+		cp -p "$TXN/rollback.ipk" "$STATE_DIR/current.ipk"
+	fi
+	write_status rolled_back "$reason" "$target_version" "$old_version"
+	rm -rf "$TXN"
+}
+
+preflight() {
+	package=$1
+	work=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
+	version=$(package_info "$package" "$work")
+	bytes=$(wc -c < "$package" | tr -d ' ')
+	available=$(free_kb)
+	case "$available" in ''|*[!0-9]*) die 'free-space check is unavailable' ;; esac
+	required=$(( (bytes / 1024) + 2048 ))
+	[ "$available" -ge "$required" ] || die 'insufficient free space for a transactional update'
+	current=$(cat "$STATE_DIR/current.version" 2>/dev/null || true)
+	if [ -n "$current" ] && validate_version "$current"; then
+		if [ "$(version_key "$version")" -lt "$(version_key "$current")" ] \
+			&& [ "${WLOC_UPDATE_ALLOW_DOWNGRADE:-0}" != 1 ]; then
+			die 'downgrade requires explicit authorization'
+		fi
+	fi
+	printf '{"ok":true,"target_version":"%s","current_version":"%s","free_kb":%s}\n' "$version" "$current" "$available"
+	rm -rf "$work"
+}
+
+apply_update() {
+	package=$1
+	acquire_lock
+	[ ! -e "$TXN" ] || die 'an interrupted update must be recovered before another update'
+	work=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
+	version=$(package_info "$package" "$work")
+	bytes=$(wc -c < "$package" | tr -d ' ')
+	available=$(free_kb)
+	case "$available" in ''|*[!0-9]*) die 'free-space check is unavailable' ;; esac
+	required=$(( (bytes / 1024) + 2048 ))
+	[ "$available" -ge "$required" ] || die 'insufficient free space for a transactional update'
+	current=$(cat "$STATE_DIR/current.version" 2>/dev/null || true)
+	if [ -n "$current" ] && validate_version "$current" \
+		&& [ "$(version_key "$version")" -lt "$(version_key "$current")" ] \
+		&& [ "${WLOC_UPDATE_ALLOW_DOWNGRADE:-0}" != 1 ]; then
+		die 'downgrade requires explicit authorization'
+	fi
+	rollback_package=${WLOC_UPDATE_CURRENT_PACKAGE:-$STATE_DIR/current.ipk}
+	[ -f "$rollback_package" ] && [ ! -L "$rollback_package" ] || die 'known-good rollback package is required'
+	mkdir -p "$TXN"
+	printf '%s\n' "$version" > "$TXN/target.version"
+	printf '%s\n' "$current" > "$TXN/current.version"
+	cp -p "$rollback_package" "$TXN/rollback.ipk"
+	for config in wloc-service wificalling-gateway; do
+		if [ -f "$ROOT/etc/config/$config" ]; then
+			cp -p "$ROOT/etc/config/$config" "$TXN/config.$config"
+		else
+			: > "$TXN/config.$config.absent"
+		fi
+	done
+	write_status applying validating "$version" "$current"
+	"$OPKG" install "$package" >/dev/null 2>&1 || {
+		rollback_transaction package_install_failed
+		exit 1
+	}
+	restore_configs
+	write_status installed awaiting_health "$version" "$current"
+	if [ "${WLOC_UPDATE_INTERRUPT_AFTER_INSTALL:-0}" = 1 ]; then
+		write_status interrupted power_loss_simulation "$version" "$current"
+		exit 75
+	fi
+	"$SUPERVISOR" restart >/dev/null 2>&1 || {
+		rollback_transaction restart_failed
+		exit 1
+	}
+	if ! "$HEALTH" >/dev/null 2>&1; then
+		rollback_transaction health_check_failed
+		exit 1
+	fi
+	cp -p "$package" "$STATE_DIR/current.ipk"
+	chmod 0600 "$STATE_DIR/current.ipk"
+	printf '%s\n' "$version" > "$STATE_DIR/current.version"
+	write_status applied ready "$version" "$version"
+	rm -rf "$TXN" "$work"
+}
+
+recover_update() {
+	acquire_lock
+	[ -d "$TXN" ] || die 'no interrupted update transaction is present'
+	rollback_transaction interrupted_transaction
+}
+
+case "${1:-status}" in
+	preflight) [ "$#" -eq 2 ] || die 'usage: preflight PACKAGE'; preflight "$2" ;;
+	apply) [ "$#" -eq 2 ] || die 'usage: apply PACKAGE'; apply_update "$2" ;;
+	recover) recover_update ;;
+	status) [ -s "$STATUS" ] && cat "$STATUS" || printf '%s\n' '{"version":1,"phase":"unknown","reason":"no_update_state"}' ;;
+	*) die 'usage: {preflight|apply|recover|status} PACKAGE' ;;
+esac

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -162,10 +162,13 @@ package_info() {
 		esac
 	fi
 	archive_safe "$package" || die 'update package archive is unsafe or corrupt'
-	tar -tzf "$package" | grep -Fx './control.tar.gz' >/dev/null || die 'update package lacks control archive'
-	tar -tzf "$package" | grep -Fx './data.tar.gz' >/dev/null || die 'update package lacks data archive'
+	tar -tzf "$package" | awk '$0 == "./control.tar.gz" || $0 == "control.tar.gz" { found=1 } END { exit found ? 0 : 1 }' \
+		|| die 'update package lacks control archive'
+	tar -tzf "$package" | awk '$0 == "./data.tar.gz" || $0 == "data.tar.gz" { found=1 } END { exit found ? 0 : 1 }' \
+		|| die 'update package lacks data archive'
 	mkdir -p "$work/control"
-	tar -xzf "$package" -C "$work" ./control.tar.gz
+	tar -xOf "$package" control.tar.gz > "$work/control.tar.gz" 2>/dev/null \
+		|| tar -xOf "$package" ./control.tar.gz > "$work/control.tar.gz"
 	archive_safe "$work/control.tar.gz" || die 'control archive is unsafe or corrupt'
 	tar -xzf "$work/control.tar.gz" -C "$work/control" ./control
 	control="$work/control/control"
@@ -175,7 +178,8 @@ package_info() {
 	product=$(field X-WFC-Product "$control")
 	gateway=$(field X-WFC-Gateway "$control")
 	api=$(field X-WFC-Wloc-Api "$control")
-	tar -xzf "$package" -C "$work" ./data.tar.gz
+	tar -xOf "$package" data.tar.gz > "$work/data.tar.gz" 2>/dev/null \
+		|| tar -xOf "$package" ./data.tar.gz > "$work/data.tar.gz"
 	archive_safe "$work/data.tar.gz" || die 'data archive is unsafe or corrupt'
 	verify_manifest "$package" "$work/control.tar.gz" "$work/data.tar.gz"
 	if [ -z "$product" ] || [ -z "$gateway" ] || [ -z "$api" ]; then

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -30,6 +30,7 @@ write_status() {
 	target=${3:-}
 	current=${4:-}
 	mkdir -p "$STATE_DIR"
+	chmod 0700 "$STATE_DIR"
 	temporary="$STATE_DIR/status.tmp.$$"
 	printf '{"version":1,"phase":"%s","reason":"%s","target_version":"%s","current_version":"%s","updated_at":%s}\n' \
 		"$phase" "$reason" "$target" "$current" "$(now)" > "$temporary"
@@ -46,6 +47,7 @@ cleanup_work() {
 
 cleanup_lock() {
 	cleanup_work
+	rm -f "$LOCK/pid"
 	rmdir "$LOCK" 2>/dev/null || true
 }
 
@@ -53,9 +55,21 @@ trap 'cleanup_work' EXIT HUP INT TERM
 
 acquire_lock() {
 	mkdir -p "$STATE_DIR"
+	chmod 0700 "$STATE_DIR"
 	if ! mkdir "$LOCK" 2>/dev/null; then
-		die 'component update is already in progress'
+		owner=$(cat "$LOCK/pid" 2>/dev/null || true)
+		case "$owner" in
+			''|*[!0-9]*) die 'component update lock is stale or unreadable; inspect before recovery' ;;
+			esac
+		if kill -0 "$owner" 2>/dev/null; then
+			die 'component update is already in progress'
+		fi
+		rm -f "$LOCK/pid"
+		rmdir "$LOCK" 2>/dev/null || die 'component update lock could not be reclaimed safely'
+		mkdir "$LOCK" 2>/dev/null || die 'component update is already in progress'
 	fi
+	printf '%s\n' "$$" > "$LOCK/pid"
+	chmod 0600 "$LOCK/pid"
 	trap 'cleanup_lock' EXIT HUP INT TERM
 }
 
@@ -63,6 +77,45 @@ field() {
 	key=$1
 	file=$2
 	sed -n "s/^${key}:[[:space:]]*//p" "$file" | head -n 1
+}
+
+sha256_file() {
+	command -v sha256sum >/dev/null 2>&1 || die 'sha256sum is required for update verification'
+	sha256sum "$1" | awk '{print $1}'
+}
+
+verify_manifest() {
+	package=$1
+	control_archive=$2
+	data_archive=$3
+	manifest=${WLOC_UPDATE_MANIFEST:-$package.manifest}
+	signature=${WLOC_UPDATE_SIGNATURE:-$package.sig}
+	public_key=${WLOC_UPDATE_PUBLIC_KEY:-/etc/wificalling-location-gateway/update.pub}
+	usign=${WLOC_UPDATE_USIGN:-/usr/bin/usign}
+	[ -f "$manifest" ] && [ ! -L "$manifest" ] || die 'update manifest is required'
+	[ -f "$signature" ] && [ ! -L "$signature" ] || die 'update manifest signature is required'
+	[ -f "$public_key" ] && [ ! -L "$public_key" ] || die 'update verification key is required'
+	[ -x "$usign" ] || die 'usign is required for update verification'
+	[ "$(wc -c < "$manifest" | tr -d ' ')" -le 4096 ] || die 'update manifest is too large'
+	format=$(field Format "$manifest")
+	manifest_package=$(field Package "$manifest")
+	manifest_version=$(field Version "$manifest")
+	manifest_architecture=$(field Architecture "$manifest")
+	manifest_package_sha256=$(field Package-SHA256 "$manifest")
+	manifest_control_sha256=$(field Control-SHA256 "$manifest")
+	manifest_data_sha256=$(field Data-SHA256 "$manifest")
+	[ "$format" = 'wfc-update-manifest/v1' ] || die 'update manifest format is invalid'
+	[ "$manifest_package" = "$(field Package "$work/control/control")" ] || die 'update manifest package mismatch'
+	[ "$manifest_version" = "$(field Version "$work/control/control")" ] || die 'update manifest version mismatch'
+	[ "$manifest_architecture" = "$(field Architecture "$work/control/control")" ] || die 'update manifest architecture mismatch'
+	printf '%s\n' "$manifest_package_sha256" | grep -Eq '^[0-9a-fA-F]{64}$' || die 'update manifest package hash is invalid'
+	printf '%s\n' "$manifest_control_sha256" | grep -Eq '^[0-9a-fA-F]{64}$' || die 'update manifest control hash is invalid'
+	printf '%s\n' "$manifest_data_sha256" | grep -Eq '^[0-9a-fA-F]{64}$' || die 'update manifest data hash is invalid'
+	[ "$manifest_package_sha256" = "$(sha256_file "$package")" ] || die 'update package hash mismatch'
+	[ "$manifest_control_sha256" = "$(sha256_file "$control_archive")" ] || die 'update control archive hash mismatch'
+	[ "$manifest_data_sha256" = "$(sha256_file "$data_archive")" ] || die 'update data archive hash mismatch'
+	"$usign" -V -p "$public_key" -m "$manifest" -x "$signature" >/dev/null 2>&1 \
+		|| die 'update manifest signature is invalid'
 }
 
 archive_safe() {
@@ -87,7 +140,12 @@ free_kb() {
 		printf '%s\n' "$WLOC_UPDATE_FREE_KB"
 		return
 	fi
-	df -Pk "$STATE_DIR" | awk 'NR == 2 { print $4; exit }'
+	state_free=$(df -Pk "$STATE_DIR" | awk 'NR == 2 { print $4; exit }')
+	tmp_free=$(df -Pk "${TMPDIR:-/tmp}" | awk 'NR == 2 { print $4; exit }')
+	case "$state_free:$tmp_free" in
+		*[!0-9:]*|:*) return 1 ;;
+	esac
+	[ "$state_free" -le "$tmp_free" ] && printf '%s\n' "$state_free" || printf '%s\n' "$tmp_free"
 }
 
 package_info() {
@@ -95,8 +153,11 @@ package_info() {
 	work=$2
 	[ -f "$package" ] && [ ! -L "$package" ] || die 'update package must be a regular local file'
 	if [ "${WLOC_UPDATE_ALLOW_ANY_SOURCE:-0}" != 1 ]; then
-		case "$package" in
-			/tmp/wloc-update/*|$STATE_DIR/incoming/*) ;;
+		stage_root=$(readlink -f /tmp/wloc-update 2>/dev/null || true)
+		incoming_root=$(readlink -f "$STATE_DIR/incoming" 2>/dev/null || true)
+		package_real=$(readlink -f "$package" 2>/dev/null || true)
+		case "$package_real" in
+			"$stage_root"/*|"$incoming_root"/*) ;;
 			*) die 'update source must be under the local update staging directory' ;;
 		esac
 	fi
@@ -116,6 +177,7 @@ package_info() {
 	api=$(field X-WFC-Wloc-Api "$control")
 	tar -xzf "$package" -C "$work" ./data.tar.gz
 	archive_safe "$work/data.tar.gz" || die 'data archive is unsafe or corrupt'
+	verify_manifest "$package" "$work/control.tar.gz" "$work/data.tar.gz"
 	if [ -z "$product" ] || [ -z "$gateway" ] || [ -z "$api" ]; then
 		compatibility=$(tar -xOf "$work/data.tar.gz" ./usr/share/wificalling-location-gateway/compatibility 2>/dev/null || true)
 		[ -n "$product" ] || product=$(printf '%s\n' "$compatibility" | sed -n 's/^X-WFC-Product:[[:space:]]*//p')
@@ -149,9 +211,9 @@ restore_configs() {
 	for config in wloc-service wificalling-gateway; do
 		if [ -f "$TXN/config.$config" ]; then
 			mkdir -p "$ROOT/etc/config"
-			cp -p "$TXN/config.$config" "$ROOT/etc/config/$config"
+			cp -p "$TXN/config.$config" "$ROOT/etc/config/$config" || return 1
 		elif [ -f "$TXN/config.$config.absent" ]; then
-			rm -f "$ROOT/etc/config/$config"
+			rm -f "$ROOT/etc/config/$config" || return 1
 		fi
 	done
 }
@@ -167,27 +229,37 @@ rollback_transaction() {
 	else
 		rollback_ok=0
 	fi
-	restore_configs
+	restore_configs || rollback_ok=0
 	if [ "$rollback_ok" -eq 1 ]; then
 		"$SUPERVISOR" restart >/dev/null 2>&1 || rollback_ok=0
 		"$HEALTH" >/dev/null 2>&1 || rollback_ok=0
 	fi
-	if [ -n "$old_version" ]; then
-		printf '%s\n' "$old_version" > "$STATE_DIR/current.version"
-	fi
-	if [ -f "$TXN/rollback.ipk" ]; then
-		cp -p "$TXN/rollback.ipk" "$STATE_DIR/current.ipk"
+	if [ "$rollback_ok" -eq 1 ]; then
+		if [ -f "$TXN/rollback.ipk" ]; then
+			cp -p "$TXN/rollback.ipk" "$STATE_DIR/current.ipk" || rollback_ok=0
+		fi
+		if [ "$rollback_ok" -eq 1 ] && [ -n "$old_version" ]; then
+			printf '%s\n' "$old_version" > "$STATE_DIR/current.version" || rollback_ok=0
+		fi
 	fi
 	if [ "$rollback_ok" -eq 1 ]; then
 		write_status rolled_back "$reason" "$target_version" "$old_version"
+		rm -rf "$TXN"
+		return 0
 	else
 		write_status rollback_failed rollback_package_install_failed "$target_version" "$old_version"
+		# Keep the transaction and rollback package so an operator can repair
+		# storage/opkg/service state and retry `recover` without losing the only
+		# known-good restoration point.
+		return 1
 	fi
-	rm -rf "$TXN"
 }
 
 preflight() {
 	package=$1
+	mkdir -p "$STATE_DIR"
+	chmod 0700 "$STATE_DIR"
+	mkdir -m 0700 -p "$STATE_DIR/incoming"
 	WORK=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
 	version=$(package_info "$package" "$WORK")
 	bytes=$(wc -c < "$package" | tr -d ' ')
@@ -210,6 +282,7 @@ apply_update() {
 	package=$1
 	acquire_lock
 	[ ! -e "$TXN" ] || die 'an interrupted update must be recovered before another update'
+	mkdir -m 0700 -p "$STATE_DIR/incoming"
 	WORK=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-check.XXXXXX")
 	version=$(package_info "$package" "$WORK")
 	bytes=$(wc -c < "$package" | tr -d ' ')
@@ -225,13 +298,16 @@ apply_update() {
 	fi
 	rollback_package=${WLOC_UPDATE_CURRENT_PACKAGE:-$STATE_DIR/current.ipk}
 	[ -f "$rollback_package" ] && [ ! -L "$rollback_package" ] || die 'known-good rollback package is required'
-	mkdir -p "$TXN"
+	mkdir -m 0700 -p "$TXN"
+	chmod 0700 "$TXN"
 	printf '%s\n' "$version" > "$TXN/target.version"
 	printf '%s\n' "$current" > "$TXN/current.version"
 	cp -p "$rollback_package" "$TXN/rollback.ipk"
+	chmod 0600 "$TXN/rollback.ipk"
 	for config in wloc-service wificalling-gateway; do
 		if [ -f "$ROOT/etc/config/$config" ]; then
 			cp -p "$ROOT/etc/config/$config" "$TXN/config.$config"
+			chmod 0600 "$TXN/config.$config"
 		else
 			: > "$TXN/config.$config.absent"
 		fi
@@ -241,7 +317,10 @@ apply_update() {
 		rollback_transaction package_install_failed
 		exit 1
 	}
-	restore_configs
+	if ! restore_configs; then
+		rollback_transaction config_restore_failed
+		exit 1
+	fi
 	write_status installed awaiting_health "$version" "$current"
 	if [ "${WLOC_UPDATE_INTERRUPT_AFTER_INSTALL:-0}" = 1 ]; then
 		write_status interrupted power_loss_simulation "$version" "$current"
@@ -255,9 +334,12 @@ apply_update() {
 		rollback_transaction health_check_failed
 		exit 1
 	fi
-	cp -p "$package" "$STATE_DIR/current.ipk"
-	chmod 0600 "$STATE_DIR/current.ipk"
-	printf '%s\n' "$version" > "$STATE_DIR/current.version"
+	if ! cp -p "$package" "$STATE_DIR/current.ipk" \
+		|| ! chmod 0600 "$STATE_DIR/current.ipk" \
+		|| ! printf '%s\n' "$version" > "$STATE_DIR/current.version"; then
+		rollback_transaction state_commit_failed
+		exit 1
+	fi
 	write_status applied ready "$version" "$version"
 	rm -rf "$TXN"
 	cleanup_work

--- a/openwrt/files/usr/sbin/wloc-component-update.sh
+++ b/openwrt/files/usr/sbin/wloc-component-update.sh
@@ -64,14 +64,11 @@ archive_safe() {
 }
 
 version_key() {
-	printf '%s\n' "$1" | awk -F '[.-]' '{printf "%03d%03d%03d%03d", $1+0, $2+0, $3+0, $4+0}'
+	printf '%s\n' "$1" | sed 's/-r/-/' | awk -F '[.-]' '{printf "%03d%03d%03d%03d", $1+0, $2+0, $3+0, $4+0}'
 }
 
 validate_version() {
-	case "$1" in
-		[0-9]*.[0-9]*.[0-9]*-[0-9A-Za-z]*) return 0 ;;
-		*) return 1 ;;
-	esac
+	printf '%s\n' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z]+$'
 }
 
 free_kb() {
@@ -106,6 +103,14 @@ package_info() {
 	product=$(field X-WFC-Product "$control")
 	gateway=$(field X-WFC-Gateway "$control")
 	api=$(field X-WFC-Wloc-Api "$control")
+	tar -xzf "$package" -C "$work" ./data.tar.gz
+	archive_safe "$work/data.tar.gz" || die 'data archive is unsafe or corrupt'
+	if [ -z "$product" ] || [ -z "$gateway" ] || [ -z "$api" ]; then
+		compatibility=$(tar -xOf "$work/data.tar.gz" ./usr/share/wificalling-location-gateway/compatibility 2>/dev/null || true)
+		[ -n "$product" ] || product=$(printf '%s\n' "$compatibility" | sed -n 's/^X-WFC-Product:[[:space:]]*//p')
+		[ -n "$gateway" ] || gateway=$(printf '%s\n' "$compatibility" | sed -n 's/^X-WFC-Gateway:[[:space:]]*//p')
+		[ -n "$api" ] || api=$(printf '%s\n' "$compatibility" | sed -n 's/^X-WFC-Wloc-Api:[[:space:]]*//p')
+	fi
 	case "$name" in
 		wificalling-location-gateway|luci-app-wificalling-location-gateway) ;;
 		*) die 'update package identity is not the unified product' ;;
@@ -121,13 +126,11 @@ package_info() {
 		fi
 		[ -n "$expected" ] && [ "$architecture" = "$expected" ] || die 'update package architecture is incompatible'
 	fi
-	tar -xzf "$package" -C "$work" ./data.tar.gz
-	archive_safe "$work/data.tar.gz" || die 'data archive is unsafe or corrupt'
 	tar -tzf "$work/data.tar.gz" | awk '
 		/^\./ { next }
 		{ bad=1 }
 		END { exit bad ? 1 : 0 }
-	' && true
+	' || die 'data archive contains an invalid path'
 	printf '%s\n' "$version"
 }
 
@@ -147,17 +150,28 @@ rollback_transaction() {
 	old_version=$(cat "$TXN/current.version" 2>/dev/null || true)
 	target_version=$(cat "$TXN/target.version" 2>/dev/null || true)
 	write_status rolling_back "$reason" "$target_version" "$old_version"
+	rollback_ok=1
 	if [ -f "$TXN/rollback.ipk" ]; then
-		"$OPKG" install "$TXN/rollback.ipk" >/dev/null 2>&1 || true
+		"$OPKG" install "$TXN/rollback.ipk" >/dev/null 2>&1 || rollback_ok=0
+	else
+		rollback_ok=0
 	fi
 	restore_configs
+	if [ "$rollback_ok" -eq 1 ]; then
+		"$SUPERVISOR" restart >/dev/null 2>&1 || rollback_ok=0
+		"$HEALTH" >/dev/null 2>&1 || rollback_ok=0
+	fi
 	if [ -n "$old_version" ]; then
 		printf '%s\n' "$old_version" > "$STATE_DIR/current.version"
 	fi
 	if [ -f "$TXN/rollback.ipk" ]; then
 		cp -p "$TXN/rollback.ipk" "$STATE_DIR/current.ipk"
 	fi
-	write_status rolled_back "$reason" "$target_version" "$old_version"
+	if [ "$rollback_ok" -eq 1 ]; then
+		write_status rolled_back "$reason" "$target_version" "$old_version"
+	else
+		write_status rollback_failed rollback_package_install_failed "$target_version" "$old_version"
+	fi
 	rm -rf "$TXN"
 }
 

--- a/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -12,7 +12,8 @@
           "verify_fingerprint",
           "health",
           "restart_gateway",
-          "node_test"
+          "node_test",
+          "update_status"
         ],
         "file": [
           "read"
@@ -49,7 +50,10 @@
           "verify_fingerprint",
           "node_test",
           "restart_gateway",
-          "clear_log"
+          "clear_log",
+          "update_preflight",
+          "update_apply",
+          "update_recover"
         ],
         "file": [
           "write"

--- a/openwrt/files/usr/share/wificalling-location-gateway/compatibility
+++ b/openwrt/files/usr/share/wificalling-location-gateway/compatibility
@@ -1,0 +1,3 @@
+X-WFC-Product: wificalling-location-gateway/v2
+X-WFC-Gateway: 1.7
+X-WFC-Wloc-Api: wloc.service/v2

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -30,6 +30,11 @@ var createSupportBundle = rpc.declare({
 	method: 'support_bundle'
 });
 
+var getUpdateStatus = rpc.declare({ object: 'luci.wloc', method: 'update_status' });
+var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: { path: '' } });
+var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: { path: '' } });
+var recoverUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_recover' });
+
 function notify(title, message, kind) {
 	ui.addNotification(null, E('p', [ E('strong', title + ': '), message ]), kind);
 }
@@ -60,6 +65,17 @@ return view.extend({
 		var gwBody = E('div', {}, []);
 		var extraBody = E('div', {}, []);
 		var profileBody = E('tbody', {}, []);
+		var updateBody = E('div', {}, []);
+		var updatePath = E('input', { 'class': 'cbi-input-text', 'style': 'min-width:360px', 'placeholder': '/tmp/wloc-update/package.ipk' });
+
+		function renderUpdateStatus(status) {
+			updateBody.innerHTML = '';
+			status = status || {};
+			var text = (status.phase || '-') + ' / ' + (status.reason || '-');
+			if (status.current_version || status.target_version)
+				text += ' (' + (status.current_version || '-') + ' → ' + (status.target_version || '-') + ')';
+			updateBody.appendChild(statusDot(status.phase === 'applied', text));
+		}
 
 		function renderHealth(h) {
 			wlocBody.innerHTML = '';
@@ -138,12 +154,14 @@ return view.extend({
 		}
 
 		renderHealth(health);
+		getUpdateStatus().then(renderUpdateStatus).catch(function() { renderUpdateStatus({ reason: wlocI18n.t('Update status unavailable') }); });
 
 		poll.add(function() {
 			return L.resolveDefault(getHealth(), { error: wlocI18n.t('Health check unavailable') }).then(function(h) {
 				renderHealth(h);
+				return getUpdateStatus().then(renderUpdateStatus).catch(function() {});
 			});
-		}, 10);
+		}, 15);
 
 		// One-click service restarts, then refresh the report immediately.
 		function restartAction(call, okText, busyLabel) {
@@ -212,6 +230,27 @@ return view.extend({
 				wlocI18n.t('Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.'), ' ', supportButton)
 		]);
 
+		function updateAction(call, successText) {
+			return function() {
+				if (this.disabled) return;
+				this.disabled = true;
+				call({ path: updatePath.value }).then(function(result) {
+					if (result && result.error) throw new Error(result.error);
+					notify(wlocI18n.t('Component update'), successText, 'info');
+					return getUpdateStatus().then(renderUpdateStatus);
+				}).catch(function(error) {
+					notify(wlocI18n.t('Component update failed'), String(error), 'error');
+				}).then(function() { this.disabled = false; }.bind(this));
+			};
+		}
+
+		var updateSection = E('div', { 'class': 'cbi-section', style: 'margin-top:16px' }, [
+			E('h3', { style: 'margin-top:0' }, wlocI18n.t('Component update')),
+			E('p', {}, wlocI18n.t('Stage a validated IPK under /tmp/wloc-update before checking or applying it.')),
+			E('div', {}, [updatePath, ' ', E('button', { 'class': 'cbi-button', click: updateAction(preflightUpdate, wlocI18n.t('Package preflight passed')) }, wlocI18n.t('Check package')), ' ', E('button', { 'class': 'cbi-button cbi-button-apply', click: updateAction(applyUpdate, wlocI18n.t('Update applied and health checked')) }, wlocI18n.t('Apply update')), ' ', E('button', { 'class': 'cbi-button', click: function() { recoverUpdate().then(function() { notify(wlocI18n.t('Component update'), wlocI18n.t('Interrupted transaction recovered'), 'info'); return getUpdateStatus().then(renderUpdateStatus); }).catch(function(e) { notify(wlocI18n.t('Component update failed'), String(e), 'error'); }); } }, wlocI18n.t('Recover'))]),
+			E('div', { style: 'margin-top:8px' }, updateBody)
+		]);
+
 		return E([], [
 			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
 				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Gateway')),
@@ -232,7 +271,8 @@ return view.extend({
 					profileBody
 				])
 			]),
-			restartButtons
+			restartButtons,
+			updateSection
 		]);
 	}
 });

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -31,8 +31,8 @@ var createSupportBundle = rpc.declare({
 });
 
 var getUpdateStatus = rpc.declare({ object: 'luci.wloc', method: 'update_status' });
-var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: { path: '' } });
-var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: { path: '' } });
+var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: [ 'path' ] });
+var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: [ 'path' ] });
 var recoverUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_recover' });
 
 function notify(title, message, kind) {
@@ -234,7 +234,7 @@ return view.extend({
 			return function() {
 				if (this.disabled) return;
 				this.disabled = true;
-				call({ path: updatePath.value }).then(function(result) {
+				call(updatePath.value).then(function(result) {
 					if (result && result.error) throw new Error(result.error);
 					notify(wlocI18n.t('Component update'), successText, 'info');
 					return getUpdateStatus().then(renderUpdateStatus);

--- a/openwrt/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
+++ b/openwrt/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
@@ -91,7 +91,18 @@ var ZH = {
 	'Support bundle failed': '支持包生成失败',
 	'Generate support bundle': '生成支持包',
 	'Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.':
-		'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
+	'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
+	'Component update': '组件更新',
+	'Component update failed': '组件更新失败',
+	'Update status unavailable': '更新状态不可用',
+	'Stage a validated IPK under /tmp/wloc-update before checking or applying it.':
+		'请先将已验证的 IPK 放入 /tmp/wloc-update，再执行检查或更新。',
+	'Package preflight passed': '软件包预检通过',
+	'Update applied and health checked': '更新已应用并通过健康检查',
+	'Interrupted transaction recovered': '已恢复中断的更新事务',
+	'Check package': '检查软件包',
+	'Apply update': '应用更新',
+	'Recover': '恢复',
 
 	/* ---- wloc settings ---- */
 	'WLOC location interception: spoofs the Apple WLOC response so the test device reports the gateway-chosen location. GPS values stay on this router.':

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
@@ -10,6 +10,7 @@
 
 CTL=/usr/sbin/wloc-ctl
 EXPORT=/usr/sbin/export-mobileconfig.sh
+UPDATE=/usr/sbin/wloc-component-update.sh
 
 ctl_live() {
 	out="$("$CTL" "$@" 2>&1)" && return 0
@@ -64,6 +65,14 @@ list)
 	json_add_object health
 	json_close_object
 	json_add_object support_bundle
+	json_close_object
+	json_add_object update_status
+	json_close_object
+	json_add_object update_preflight
+	json_close_object
+	json_add_object update_apply
+	json_close_object
+	json_add_object update_recover
 	json_close_object
 	json_add_object node_test
 	json_close_object
@@ -288,6 +297,42 @@ call)
 			exit 0
 		fi
 		/usr/libexec/wificalling-gateway/node-test.sh "$id"
+		exit 0
+		;;
+	update_status)
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		"$UPDATE" status
+		exit $?
+		;;
+	update_preflight|update_apply)
+		read -r input
+		json_load "$input"
+		json_get_var path path
+		case "$path" in
+			/tmp/wloc-update/*) ;;
+			*) echo '{"error":"update package must be staged under /tmp/wloc-update"}'; exit 1 ;;
+		esac
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		if out="$($UPDATE "${2#update_}" "$path" 2>&1)"; then
+			printf '%s\n' "$out"
+		else
+			json_init
+			json_add_string error "$out"
+			json_dump
+			exit 1
+		fi
+		exit 0
+		;;
+	update_recover)
+		[ -x "$UPDATE" ] || { echo '{"error":"component update helper is not installed"}'; exit 1; }
+		if out="$($UPDATE recover 2>&1)"; then
+			printf '%s\n' "$out"
+		else
+			json_init
+			json_add_string error "$out"
+			json_dump
+			exit 1
+		fi
 		exit 0
 		;;
 	regen_ca)

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json
@@ -12,7 +12,8 @@
           "verify_fingerprint",
           "health",
           "restart_gateway",
-          "node_test"
+          "node_test",
+          "update_status"
         ],
         "file": [
           "read"
@@ -49,7 +50,10 @@
           "verify_fingerprint",
           "node_test",
           "restart_gateway",
-          "clear_log"
+          "clear_log",
+          "update_preflight",
+          "update_apply",
+          "update_recover"
         ],
         "file": [
           "write"

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/compatibility
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/compatibility
@@ -1,0 +1,3 @@
+X-WFC-Product: wificalling-location-gateway/v2
+X-WFC-Gateway: 1.7
+X-WFC-Wloc-Api: wloc.service/v2

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -31,8 +31,8 @@ var createSupportBundle = rpc.declare({
 });
 
 var getUpdateStatus = rpc.declare({ object: 'luci.wloc', method: 'update_status' });
-var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: { path: '' } });
-var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: { path: '' } });
+var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: [ 'path' ] });
+var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: [ 'path' ] });
 var recoverUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_recover' });
 
 function notify(title, message, kind) {
@@ -240,7 +240,7 @@ return view.extend({
 			return function() {
 				if (this.disabled) return;
 				this.disabled = true;
-				call({ path: updatePath.value }).then(function(result) {
+				call(updatePath.value).then(function(result) {
 					if (result && result.error) throw new Error(result.error);
 					notify(wlocI18n.t('Component update'), successText, 'info');
 					return getUpdateStatus().then(renderUpdateStatus);

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js
@@ -30,6 +30,11 @@ var createSupportBundle = rpc.declare({
 	method: 'support_bundle'
 });
 
+var getUpdateStatus = rpc.declare({ object: 'luci.wloc', method: 'update_status' });
+var preflightUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_preflight', params: { path: '' } });
+var applyUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_apply', params: { path: '' } });
+var recoverUpdate = rpc.declare({ object: 'luci.wloc', method: 'update_recover' });
+
 function notify(title, message, kind) {
 	ui.addNotification(null, E('p', [ E('strong', title + ': '), message ]), kind);
 }
@@ -60,6 +65,17 @@ return view.extend({
 		var gwBody = E('div', {}, []);
 		var extraBody = E('div', {}, []);
 		var profileBody = E('tbody', {}, []);
+		var updateBody = E('div', {}, []);
+		var updatePath = E('input', { 'class': 'cbi-input-text', 'style': 'min-width:360px', 'placeholder': '/tmp/wloc-update/package.ipk' });
+
+		function renderUpdateStatus(status) {
+			updateBody.innerHTML = '';
+			status = status || {};
+			var text = (status.phase || '-') + ' / ' + (status.reason || '-');
+			if (status.current_version || status.target_version)
+				text += ' (' + (status.current_version || '-') + ' → ' + (status.target_version || '-') + ')';
+			updateBody.appendChild(statusDot(status.phase === 'applied', text));
+		}
 
 		function renderHealth(h) {
 			wlocBody.innerHTML = '';
@@ -144,12 +160,14 @@ return view.extend({
 		}
 
 		renderHealth(health);
+		getUpdateStatus().then(renderUpdateStatus).catch(function() { renderUpdateStatus({ reason: wlocI18n.t('Update status unavailable') }); });
 
 		poll.add(function() {
 			return L.resolveDefault(getHealth(), { error: wlocI18n.t('Health check unavailable') }).then(function(h) {
 				renderHealth(h);
+				return getUpdateStatus().then(renderUpdateStatus).catch(function() {});
 			});
-		}, 10);
+		}, 15);
 
 		// One-click service restarts, then refresh the report immediately.
 		function restartAction(call, okText, busyLabel) {
@@ -218,6 +236,27 @@ return view.extend({
 				wlocI18n.t('Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.'), ' ', supportButton)
 		]);
 
+		function updateAction(call, successText) {
+			return function() {
+				if (this.disabled) return;
+				this.disabled = true;
+				call({ path: updatePath.value }).then(function(result) {
+					if (result && result.error) throw new Error(result.error);
+					notify(wlocI18n.t('Component update'), successText, 'info');
+					return getUpdateStatus().then(renderUpdateStatus);
+				}).catch(function(error) {
+					notify(wlocI18n.t('Component update failed'), String(error), 'error');
+				}).then(function() { this.disabled = false; }.bind(this));
+			};
+		}
+
+		var updateSection = E('div', { 'class': 'cbi-section', style: 'margin-top:16px' }, [
+			E('h3', { style: 'margin-top:0' }, wlocI18n.t('Component update')),
+			E('p', {}, wlocI18n.t('Stage a validated IPK under /tmp/wloc-update before checking or applying it.')),
+			E('div', {}, [updatePath, ' ', E('button', { 'class': 'cbi-button', click: updateAction(preflightUpdate, wlocI18n.t('Package preflight passed')) }, wlocI18n.t('Check package')), ' ', E('button', { 'class': 'cbi-button cbi-button-apply', click: updateAction(applyUpdate, wlocI18n.t('Update applied and health checked')) }, wlocI18n.t('Apply update')), ' ', E('button', { 'class': 'cbi-button', click: function() { recoverUpdate().then(function() { notify(wlocI18n.t('Component update'), wlocI18n.t('Interrupted transaction recovered'), 'info'); return getUpdateStatus().then(renderUpdateStatus); }).catch(function(e) { notify(wlocI18n.t('Component update failed'), String(e), 'error'); }); } }, wlocI18n.t('Recover'))]),
+			E('div', { style: 'margin-top:8px' }, updateBody)
+		]);
+
 		return E([], [
 			E('div', { 'class': 'cbi-section', style: 'margin-bottom:12px' }, [
 				E('h3', { style: 'margin-top:0' }, wlocI18n.t('Gateway')),
@@ -238,7 +277,8 @@ return view.extend({
 					profileBody
 				])
 			]),
-			restartButtons
+			restartButtons,
+			updateSection
 		]);
 	}
 });

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
@@ -91,7 +91,18 @@ var ZH = {
 	'Support bundle failed': '支持包生成失败',
 	'Generate support bundle': '生成支持包',
 	'Support bundles contain bounded redacted diagnostics only; copy the generated file from /tmp before it expires.':
-		'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
+	'支持包只包含有上限且已脱敏的诊断信息；请在过期前从 /tmp 复制生成的文件。',
+	'Component update': '组件更新',
+	'Component update failed': '组件更新失败',
+	'Update status unavailable': '更新状态不可用',
+	'Stage a validated IPK under /tmp/wloc-update before checking or applying it.':
+		'请先将已验证的 IPK 放入 /tmp/wloc-update，再执行检查或更新。',
+	'Package preflight passed': '软件包预检通过',
+	'Update applied and health checked': '更新已应用并通过健康检查',
+	'Interrupted transaction recovered': '已恢复中断的更新事务',
+	'Check package': '检查软件包',
+	'Apply update': '应用更新',
+	'Recover': '恢复',
 
 	/* ---- wloc settings ---- */
 	'WLOC location interception: spoofs the Apple WLOC response so the test device reports the gateway-chosen location. GPS values stay on this router.':

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -111,7 +111,6 @@ case "$dependency_mode" in
 			replaces='luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
 		else
 			depends='luci-app-wificalling-gateway, luci-base, rpcd-mod-rpcsys'
-			rm -f "$stage/data/www/luci-static/resources/view/wificalling-gateway/overview.js"
 		fi
 		view_suffix=$(printf '%s' "$version" | tr '.-' '__')
 		view_name="wloc_mode_fix_$view_suffix"
@@ -129,8 +128,13 @@ case "$dependency_mode" in
 			"$stage/data/www/luci-static/resources/view/wificalling-location-gateway/$monitor_name.js"
 		cp "$stage/data/www/luci-static/resources/view/wificalling-location-gateway/faq.js" \
 			"$stage/data/www/luci-static/resources/view/wificalling-location-gateway/$faq_name.js"
-		cp "$stage/data/www/luci-static/resources/view/wificalling-gateway/overview.js" \
-			"$stage/data/www/luci-static/resources/view/wificalling-gateway/$wfc_name.js"
+			cp "$stage/data/www/luci-static/resources/view/wificalling-gateway/overview.js" \
+				"$stage/data/www/luci-static/resources/view/wificalling-gateway/$wfc_name.js"
+		# The external Gateway owns the unversioned view; retain the copied,
+		# versioned integrated view so this package does not duplicate its menu.
+		if [ "$dependency_mode" != ax6s-standalone ]; then
+			rm -f "$stage/data/www/luci-static/resources/view/wificalling-gateway/overview.js"
+		fi
 		cp "$stage/data/www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js" \
 			"$stage/data/www/luci-static/resources/view/wificalling-location-gateway/$health_name.js"
 		python3 - "$stage/data/usr/share/luci/menu.d/luci-app-wificalling-location-gateway.json" "$view_name" "$monitor_name" "$faq_name" "$wfc_name" "$health_name" <<'PY'
@@ -210,6 +214,24 @@ exit 0
 POSTINST
 			chmod 0755 "$stage/control/postinst"
 		fi
+		if [ "$dependency_mode" = ax6s-existing ]; then
+			# The legacy AX6S mode reuses the already-installed Gateway and
+			# wloc-service binaries, but it still needs the same V2 lifecycle
+			# boundary and update/health helpers exposed by the LuCI page.
+			mkdir -p "$stage/data/usr/sbin" "$stage/data/etc/init.d" \
+				"$stage/data/usr/libexec/wificalling-location-gateway"
+			for helper in wloc-health.sh wloc-component-update.sh \
+				wloc-redirect-sync.sh wloc-profile-redirect.sh wloc-profile-status.sh; do
+				cp "$root/openwrt/files/usr/sbin/$helper" "$stage/data/usr/sbin/$helper"
+			done
+			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" \
+				"$stage/data/etc/init.d/wificalling-location-gateway"
+			cp "$root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
+				"$stage/data/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
+			chmod 0755 "$stage/data/etc/init.d/wificalling-location-gateway" \
+				"$stage/data/usr/sbin/"*.sh \
+				"$stage/data/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
+		fi
 		;;
 	*)
 	echo "unsupported dependency mode: $dependency_mode" >&2
@@ -239,5 +261,6 @@ make_archive "$stage/control" "$stage/control.tar.gz" .
 make_archive "$stage/data" "$stage/data.tar.gz" .
 rm -f "$out"
 make_archive "$stage" "$out" debian-binary data.tar.gz control.tar.gz
+"$root/scripts/create-update-manifest.sh" "$out" >/dev/null
 
 echo "$out"

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -220,7 +220,7 @@ POSTINST
 			# boundary and update/health helpers exposed by the LuCI page.
 			mkdir -p "$stage/data/usr/sbin" "$stage/data/etc/init.d" \
 				"$stage/data/usr/libexec/wificalling-location-gateway"
-			for helper in wloc-health.sh wloc-component-update.sh \
+			for helper in wloc-health.sh wloc-support-bundle.sh wloc-component-update.sh \
 				wloc-redirect-sync.sh wloc-profile-redirect.sh wloc-profile-status.sh; do
 				cp "$root/openwrt/files/usr/sbin/$helper" "$stage/data/usr/sbin/$helper"
 			done

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -178,6 +178,7 @@ PY
 			cp "$root/openwrt/files/usr/sbin/wloc-profile-status.sh" "$stage/data/usr/sbin/wloc-profile-status.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-health.sh" "$stage/data/usr/sbin/wloc-health.sh"
 			cp "$root/openwrt/files/usr/sbin/wloc-support-bundle.sh" "$stage/data/usr/sbin/wloc-support-bundle.sh"
+			cp "$root/openwrt/files/usr/sbin/wloc-component-update.sh" "$stage/data/usr/sbin/wloc-component-update.sh"
 			mkdir -p "$stage/data/etc/init.d" "$stage/data/usr/libexec/wificalling-location-gateway"
 			cp "$root/openwrt/files/etc/init.d/wificalling-location-gateway" "$stage/data/etc/init.d/wificalling-location-gateway"
 			cp "$root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
@@ -222,6 +223,9 @@ printf '%s\n' \
 	"Architecture: $architecture" \
 	'Maintainer: wificalling-location-gateway maintainers' \
 	"Depends: $depends" \
+	'X-WFC-Product: wificalling-location-gateway/v2' \
+	'X-WFC-Gateway: 1.7' \
+	'X-WFC-Wloc-Api: wloc.service/v2' \
 	'Section: luci' \
 	'Priority: optional' \
 	'License: MIT' \

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -28,6 +28,7 @@ done
 ./tests/scripts/test-structured-logs.sh
 ./tests/scripts/test-support-bundle.sh
 ./tests/scripts/test-component-update.sh
+./tests/scripts/test-existing-ax6s-package.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -27,6 +27,7 @@ done
 ./tests/scripts/test-profile-status.sh
 ./tests/scripts/test-structured-logs.sh
 ./tests/scripts/test-support-bundle.sh
+./tests/scripts/test-component-update.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/create-update-manifest.sh
+++ b/scripts/create-update-manifest.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Create the signed sidecar manifest consumed by wloc-component-update.sh.
+# The package itself is never modified, so its SHA-256 remains stable.
+
+set -eu
+
+package=${1:-}
+[ -n "$package" ] || { echo "usage: $0 PACKAGE.ipk" >&2; exit 2; }
+[ -f "$package" ] && [ ! -L "$package" ] || { echo 'package must be a regular file' >&2; exit 2; }
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-manifest.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+tar -xOf "$package" ./control.tar.gz > "$tmp/control.tar.gz"
+tar -xOf "$package" ./data.tar.gz > "$tmp/data.tar.gz"
+control=$(tar -xOf "$tmp/control.tar.gz" ./control)
+name=$(printf '%s\n' "$control" | sed -n 's/^Package:[[:space:]]*//p' | head -n 1)
+version=$(printf '%s\n' "$control" | sed -n 's/^Version:[[:space:]]*//p' | head -n 1)
+architecture=$(printf '%s\n' "$control" | sed -n 's/^Architecture:[[:space:]]*//p' | head -n 1)
+sha256_file() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	else
+		shasum -a 256 "$1" | awk '{print $1}'
+	fi
+}
+
+manifest="$package.manifest"
+{
+	printf '%s\n' 'Format: wfc-update-manifest/v1'
+	printf 'Package: %s\nVersion: %s\nArchitecture: %s\n' "$name" "$version" "$architecture"
+	printf 'Package-SHA256: %s\n' "$(sha256_file "$package")"
+	printf 'Control-SHA256: %s\n' "$(sha256_file "$tmp/control.tar.gz")"
+	printf 'Data-SHA256: %s\n' "$(sha256_file "$tmp/data.tar.gz")"
+} > "$manifest"
+chmod 0600 "$manifest"
+
+if [ -n "${WFC_UPDATE_SIGNING_KEY:-}" ]; then
+	usign=${WFC_UPDATE_USIGN:-/usr/bin/usign}
+	[ -x "$usign" ] || { echo 'configured WFC_UPDATE_SIGNING_KEY requires usign' >&2; exit 2; }
+	"$usign" -S -m "$manifest" -s "$WFC_UPDATE_SIGNING_KEY" -x "$package.sig"
+	chmod 0600 "$package.sig"
+fi
+
+printf '%s\n' "$manifest"

--- a/scripts/create-update-manifest.sh
+++ b/scripts/create-update-manifest.sh
@@ -6,7 +6,10 @@ set -eu
 
 package=${1:-}
 [ -n "$package" ] || { echo "usage: $0 PACKAGE.ipk" >&2; exit 2; }
-[ -f "$package" ] && [ ! -L "$package" ] || { echo 'package must be a regular file' >&2; exit 2; }
+if [ ! -f "$package" ] || [ -L "$package" ]; then
+	echo 'package must be a regular file' >&2
+	exit 2
+fi
 
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-manifest.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM

--- a/scripts/create-update-manifest.sh
+++ b/scripts/create-update-manifest.sh
@@ -11,8 +11,10 @@ package=${1:-}
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-manifest.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
-tar -xOf "$package" ./control.tar.gz > "$tmp/control.tar.gz"
-tar -xOf "$package" ./data.tar.gz > "$tmp/data.tar.gz"
+tar -xOf "$package" control.tar.gz > "$tmp/control.tar.gz" 2>/dev/null \
+	|| tar -xOf "$package" ./control.tar.gz > "$tmp/control.tar.gz"
+tar -xOf "$package" data.tar.gz > "$tmp/data.tar.gz" 2>/dev/null \
+	|| tar -xOf "$package" ./data.tar.gz > "$tmp/data.tar.gz"
 control=$(tar -xOf "$tmp/control.tar.gz" ./control)
 name=$(printf '%s\n' "$control" | sed -n 's/^Package:[[:space:]]*//p' | head -n 1)
 version=$(printf '%s\n' "$control" | sed -n 's/^Version:[[:space:]]*//p' | head -n 1)

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -141,7 +141,7 @@ mkdir -p "$package_dir/files/usr/libexec/wificalling-location-gateway"
 cp "$repo_root/openwrt/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh" \
 	"$package_dir/files/usr/libexec/wificalling-location-gateway/unified-supervisor.sh"
 cp "$repo_root/openwrt/files/etc/config/wloc-service" "$package_dir/files/etc/config/wloc-service"
-for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-profile-status.sh wloc-health.sh wloc-support-bundle.sh; do
+for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh wloc-profile-redirect.sh wloc-profile-status.sh wloc-health.sh wloc-support-bundle.sh wloc-component-update.sh; do
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
 chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"* \

--- a/src/exitprobe/singbox.rs
+++ b/src/exitprobe/singbox.rs
@@ -921,7 +921,7 @@ config device
         let fake_bin = dir.join("wloc-fake-singbox.sh");
         std::fs::write(
             &fake_bin,
-            "#!/bin/sh\nwhile true; do echo 'lookup bad-node.invalid: empty result' >&2; sleep 1; done\n",
+            "#!/bin/sh\nprintf '%s\\n' 'lookup bad-node.invalid: empty result' >&2\nexec sleep 30\n",
         )
         .unwrap();
         let mut perms = std::fs::metadata(&fake_bin).unwrap().permissions();

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -116,6 +116,20 @@ printf 'ok\n' > "$tmp/health"
 
 script="$repo_root/openwrt/files/usr/sbin/wloc-component-update.sh"
 
+cp "$new_package" "$tmp/unsigned.ipk"
+if sh "$script" preflight "$tmp/unsigned.ipk"; then
+    echo 'unsigned update package was accepted' >&2
+    exit 1
+fi
+cp "$new_package.manifest" "$tmp/tampered.manifest"
+sed 's/^Package-SHA256:.*/Package-SHA256: 0000000000000000000000000000000000000000000000000000000000000000/' \
+    "$tmp/tampered.manifest" > "$tmp/tampered.manifest.new"
+mv "$tmp/tampered.manifest.new" "$tmp/tampered.manifest"
+if WLOC_UPDATE_MANIFEST="$tmp/tampered.manifest" sh "$script" preflight "$new_package"; then
+    echo 'tampered update manifest was accepted' >&2
+    exit 1
+fi
+
 WLOC_UPDATE_CURRENT_PACKAGE="$old_package" sh "$script" apply "$new_package"
 grep '^install$' "$tmp/opkg.log" >/dev/null
 grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-update-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+root="$tmp/root"
+state="$tmp/state"
+mkdir -p "$root/etc/config" "$root/usr/share/wificalling-location-gateway" "$state" "$tmp/bin"
+printf 'old-config\n' > "$root/etc/config/wloc-service"
+printf 'old-component\n' > "$root/usr/share/wificalling-location-gateway/component.txt"
+printf '1.0.0-1\n' > "$state/current.version"
+
+cat > "$tmp/bin/opkg" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "${1:-}" != install ]; then
+    exit 2
+fi
+printf '%s\n' install >> "$WLOC_UPDATE_OPKG_LOG"
+package=$2
+data="$WLOC_UPDATE_TEST_TMP/data.tar.gz"
+tar -xOf "$package" ./data.tar.gz > "$data"
+tar -xzf "$data" -C "$WLOC_UPDATE_ROOT"
+EOF
+cat > "$tmp/bin/supervisor" <<'EOF'
+#!/bin/sh
+printf '%s\n' restart >> "$WLOC_UPDATE_SUPERVISOR_LOG"
+EOF
+cat > "$tmp/bin/health" <<'EOF'
+#!/bin/sh
+[ "$(cat "$WLOC_UPDATE_HEALTH_STATE")" = ok ]
+EOF
+chmod 0755 "$tmp/bin/opkg" "$tmp/bin/supervisor" "$tmp/bin/health"
+
+make_ipk() {
+    version=$1
+    component=$2
+    out=$3
+    package_dir="$tmp/package-$version-$component"
+    rm -rf "$package_dir"
+    mkdir -p "$package_dir/control" "$package_dir/data/etc/config" "$package_dir/data/usr/share/wificalling-location-gateway"
+    cat > "$package_dir/control/control" <<EOF
+Package: wificalling-location-gateway
+Version: $version
+Architecture: all
+X-WFC-Product: wificalling-location-gateway/v2
+X-WFC-Gateway: 1.7
+X-WFC-Wloc-Api: wloc.service/v2
+EOF
+    printf '%s\n' "$component" > "$package_dir/data/usr/share/wificalling-location-gateway/component.txt"
+    printf 'new-config\n' > "$package_dir/data/etc/config/wloc-service"
+    (cd "$package_dir/control" && tar -czf "$package_dir/control.tar.gz" ./control)
+    (cd "$package_dir/data" && tar -czf "$package_dir/data.tar.gz" ./etc ./usr)
+    (cd "$package_dir" && tar -czf "$out" ./control.tar.gz ./data.tar.gz)
+}
+
+old_package="$tmp/old.ipk"
+new_package="$tmp/new.ipk"
+make_ipk 1.0.0-1 old-component "$old_package"
+make_ipk 1.1.0-1 new-component "$new_package"
+
+export WLOC_UPDATE_TEST_TMP="$tmp"
+export WLOC_UPDATE_ROOT="$root"
+export WLOC_UPDATE_STATE_DIR="$state"
+export WLOC_UPDATE_OPKG="$tmp/bin/opkg"
+export WLOC_UPDATE_OPKG_LOG="$tmp/opkg.log"
+export WLOC_UPDATE_SUPERVISOR="$tmp/bin/supervisor"
+export WLOC_UPDATE_SUPERVISOR_LOG="$tmp/supervisor.log"
+export WLOC_UPDATE_HEALTH="$tmp/bin/health"
+export WLOC_UPDATE_HEALTH_STATE="$tmp/health"
+export WLOC_UPDATE_FREE_KB=65536
+export WLOC_UPDATE_ALLOW_ANY_SOURCE=1
+printf 'ok\n' > "$tmp/health"
+: > "$tmp/opkg.log"
+: > "$tmp/supervisor.log"
+
+script="$repo_root/openwrt/files/usr/sbin/wloc-component-update.sh"
+
+WLOC_UPDATE_CURRENT_PACKAGE="$old_package" sh "$script" apply "$new_package"
+grep '^install$' "$tmp/opkg.log" >/dev/null
+grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+grep '^old-config$' "$root/etc/config/wloc-service" >/dev/null
+grep '^1.1.0-1$' "$state/current.version" >/dev/null
+
+printf 'fail\n' > "$tmp/health"
+if WLOC_UPDATE_CURRENT_PACKAGE="$new_package" sh "$script" apply "$new_package"; then
+    echo 'health failure was accepted' >&2
+    exit 1
+fi
+grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+grep '^old-config$' "$root/etc/config/wloc-service" >/dev/null
+grep 'rolled_back' "$state/status.json" >/dev/null
+
+printf 'ok\n' > "$tmp/health"
+WLOC_UPDATE_INTERRUPT_AFTER_INSTALL=1 WLOC_UPDATE_CURRENT_PACKAGE="$new_package" \
+    sh "$script" apply "$new_package" || true
+sh "$script" recover
+grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+
+before=$(wc -l < "$tmp/opkg.log" | tr -d ' ')
+if WLOC_UPDATE_FREE_KB=1 sh "$script" apply "$new_package"; then
+    echo 'low storage was accepted' >&2
+    exit 1
+fi
+after=$(wc -l < "$tmp/opkg.log" | tr -d ' ')
+[ "$before" = "$after" ]
+
+echo 'component update tests passed'

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -14,11 +14,11 @@ printf '1.0.0-1\n' > "$state/current.version"
 cat > "$tmp/bin/opkg" <<'EOF'
 #!/bin/sh
 set -eu
-if [ "${1:-}" != install ]; then
-    exit 2
-fi
+while [ "${1:-}" != install ] && [ "$#" -gt 0 ]; do shift; done
+[ "${1:-}" = install ] || exit 2
+shift
 printf '%s\n' install >> "$WLOC_UPDATE_OPKG_LOG"
-package=$2
+package=$1
 data="$WLOC_UPDATE_TEST_TMP/data.tar.gz"
 tar -xOf "$package" ./data.tar.gz > "$data"
 tar -xzf "$data" -C "$WLOC_UPDATE_ROOT"

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -14,9 +14,16 @@ printf '1.0.0-1\n' > "$state/current.version"
 cat > "$tmp/bin/opkg" <<'EOF'
 #!/bin/sh
 set -eu
-while [ "${1:-}" != install ] && [ "$#" -gt 0 ]; do shift; done
+force=0
+while [ "${1:-}" != install ] && [ "$#" -gt 0 ]; do
+    [ "$1" = --force-downgrade ] && force=1
+    shift
+done
 [ "${1:-}" = install ] || exit 2
 shift
+if [ "${WLOC_UPDATE_FAIL_ROLLBACK:-0}" = 1 ] && [ "$force" = 1 ]; then
+    exit 1
+fi
 printf '%s\n' install >> "$WLOC_UPDATE_OPKG_LOG"
 package=$1
 data="$WLOC_UPDATE_TEST_TMP/data.tar.gz"
@@ -33,6 +40,11 @@ cat > "$tmp/bin/health" <<'EOF'
 [ "$(cat "$WLOC_UPDATE_HEALTH_STATE")" = ok ]
 EOF
 chmod 0755 "$tmp/bin/opkg" "$tmp/bin/supervisor" "$tmp/bin/health"
+cat > "$tmp/bin/usign" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod 0755 "$tmp/bin/usign"
 
 make_ipk() {
     version=$1
@@ -57,12 +69,31 @@ EOF
     (cd "$package_dir" && tar -czf "$out" ./control.tar.gz ./data.tar.gz)
 }
 
+make_manifest() {
+    package=$1
+    control="$tmp/manifest-control.tar.gz"
+    data="$tmp/manifest-data.tar.gz"
+    tar -xOf "$package" ./control.tar.gz > "$control"
+    tar -xOf "$package" ./data.tar.gz > "$data"
+    {
+        printf '%s\n' 'Format: wfc-update-manifest/v1'
+        tar -xOf "$control" ./control | sed -n -e '/^Package:/p' -e '/^Version:/p' -e '/^Architecture:/p'
+        printf 'Package-SHA256: %s\n' "$(sha256sum "$package" | awk '{print $1}')"
+        printf 'Control-SHA256: %s\n' "$(sha256sum "$control" | awk '{print $1}')"
+        printf 'Data-SHA256: %s\n' "$(sha256sum "$data" | awk '{print $1}')"
+    } > "$package.manifest"
+    : > "$package.sig"
+}
+
 old_package="$tmp/old.ipk"
 new_package="$tmp/new.ipk"
 bad_arch_package="$tmp/bad-arch.ipk"
 make_ipk 1.0.0-1 old-component "$old_package"
 make_ipk 1.1.0-1 new-component "$new_package"
 make_ipk 1.1.0-1 bad-component "$bad_arch_package" mipsel
+make_manifest "$old_package"
+make_manifest "$new_package"
+make_manifest "$bad_arch_package"
 
 export WLOC_UPDATE_TEST_TMP="$tmp"
 export WLOC_UPDATE_ROOT="$root"
@@ -75,7 +106,10 @@ export WLOC_UPDATE_HEALTH="$tmp/bin/health"
 export WLOC_UPDATE_HEALTH_STATE="$tmp/health"
 export WLOC_UPDATE_FREE_KB=65536
 export WLOC_UPDATE_ALLOW_ANY_SOURCE=1
+export WLOC_UPDATE_USIGN="$tmp/bin/usign"
+export WLOC_UPDATE_PUBLIC_KEY="$tmp/update.pub"
 export TMPDIR="$tmp"
+printf 'test-public-key\n' > "$tmp/update.pub"
 printf 'ok\n' > "$tmp/health"
 : > "$tmp/opkg.log"
 : > "$tmp/supervisor.log"
@@ -115,11 +149,29 @@ grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.t
 grep '^old-config$' "$root/etc/config/wloc-service" >/dev/null
 grep 'rolled_back' "$state/status.json" >/dev/null
 
+printf 'fail-once\n' > "$tmp/health"
+if WLOC_UPDATE_FAIL_ROLLBACK=1 WLOC_UPDATE_CURRENT_PACKAGE="$new_package" \
+    sh "$script" apply "$new_package"; then
+    echo 'rollback failure was accepted' >&2
+    exit 1
+fi
+grep 'rollback_failed' "$state/status.json" >/dev/null
+[ -d "$state/transaction" ]
+WLOC_UPDATE_CURRENT_PACKAGE="$new_package" sh "$script" recover
+grep 'rolled_back' "$state/status.json" >/dev/null
+[ ! -e "$state/transaction" ]
+
 printf 'ok\n' > "$tmp/health"
 WLOC_UPDATE_INTERRUPT_AFTER_INSTALL=1 WLOC_UPDATE_CURRENT_PACKAGE="$new_package" \
     sh "$script" apply "$new_package" || true
+mkdir "$state/.lock"
+printf '999999\n' > "$state/.lock/pid"
 sh "$script" recover
 grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+
+fresh_state="$tmp/fresh-state"
+WLOC_UPDATE_STATE_DIR="$fresh_state" sh "$script" preflight "$new_package" >/dev/null
+[ -d "$fresh_state" ]
 
 before=$(wc -l < "$tmp/opkg.log" | tr -d ' ')
 if WLOC_UPDATE_FREE_KB=1 sh "$script" apply "$new_package"; then

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -29,6 +29,7 @@ printf '%s\n' restart >> "$WLOC_UPDATE_SUPERVISOR_LOG"
 EOF
 cat > "$tmp/bin/health" <<'EOF'
 #!/bin/sh
+[ "$(cat "$WLOC_UPDATE_HEALTH_STATE")" = fail-once ] && { printf 'ok\n' > "$WLOC_UPDATE_HEALTH_STATE"; exit 1; }
 [ "$(cat "$WLOC_UPDATE_HEALTH_STATE")" = ok ]
 EOF
 chmod 0755 "$tmp/bin/opkg" "$tmp/bin/supervisor" "$tmp/bin/health"
@@ -37,13 +38,14 @@ make_ipk() {
     version=$1
     component=$2
     out=$3
+    architecture=${4:-all}
     package_dir="$tmp/package-$version-$component"
     rm -rf "$package_dir"
     mkdir -p "$package_dir/control" "$package_dir/data/etc/config" "$package_dir/data/usr/share/wificalling-location-gateway"
     cat > "$package_dir/control/control" <<EOF
 Package: wificalling-location-gateway
 Version: $version
-Architecture: all
+Architecture: $architecture
 X-WFC-Product: wificalling-location-gateway/v2
 X-WFC-Gateway: 1.7
 X-WFC-Wloc-Api: wloc.service/v2
@@ -57,8 +59,10 @@ EOF
 
 old_package="$tmp/old.ipk"
 new_package="$tmp/new.ipk"
+bad_arch_package="$tmp/bad-arch.ipk"
 make_ipk 1.0.0-1 old-component "$old_package"
 make_ipk 1.1.0-1 new-component "$new_package"
+make_ipk 1.1.0-1 bad-component "$bad_arch_package" mipsel
 
 export WLOC_UPDATE_TEST_TMP="$tmp"
 export WLOC_UPDATE_ROOT="$root"
@@ -83,7 +87,21 @@ grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.t
 grep '^old-config$' "$root/etc/config/wloc-service" >/dev/null
 grep '^1.1.0-1$' "$state/current.version" >/dev/null
 
-printf 'fail\n' > "$tmp/health"
+if sh "$script" apply "$bad_arch_package"; then
+    echo 'incompatible architecture was accepted' >&2
+    exit 1
+fi
+if sh "$script" apply "$old_package"; then
+    echo 'unauthorized downgrade was accepted' >&2
+    exit 1
+fi
+WLOC_UPDATE_ALLOW_DOWNGRADE=1 WLOC_UPDATE_CURRENT_PACKAGE="$new_package" \
+    sh "$script" apply "$old_package"
+grep '^old-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+WLOC_UPDATE_CURRENT_PACKAGE="$old_package" sh "$script" apply "$new_package"
+grep '^new-component$' "$root/usr/share/wificalling-location-gateway/component.txt" >/dev/null
+
+printf 'fail-once\n' > "$tmp/health"
 if WLOC_UPDATE_CURRENT_PACKAGE="$new_package" sh "$script" apply "$new_package"; then
     echo 'health failure was accepted' >&2
     exit 1

--- a/tests/scripts/test-component-update.sh
+++ b/tests/scripts/test-component-update.sh
@@ -75,6 +75,7 @@ export WLOC_UPDATE_HEALTH="$tmp/bin/health"
 export WLOC_UPDATE_HEALTH_STATE="$tmp/health"
 export WLOC_UPDATE_FREE_KB=65536
 export WLOC_UPDATE_ALLOW_ANY_SOURCE=1
+export TMPDIR="$tmp"
 printf 'ok\n' > "$tmp/health"
 : > "$tmp/opkg.log"
 : > "$tmp/supervisor.log"
@@ -89,6 +90,10 @@ grep '^1.1.0-1$' "$state/current.version" >/dev/null
 
 if sh "$script" apply "$bad_arch_package"; then
     echo 'incompatible architecture was accepted' >&2
+    exit 1
+fi
+if find "$tmp" -maxdepth 1 -type d -name 'wloc-update-check.*' -print -quit | grep -q .; then
+    echo 'failed package validation leaked its temporary work directory' >&2
     exit 1
 fi
 if sh "$script" apply "$old_package"; then
@@ -123,5 +128,9 @@ if WLOC_UPDATE_FREE_KB=1 sh "$script" apply "$new_package"; then
 fi
 after=$(wc -l < "$tmp/opkg.log" | tr -d ' ')
 [ "$before" = "$after" ]
+if find "$tmp" -maxdepth 1 -type d -name 'wloc-update-check.*' -print -quit | grep -q .; then
+    echo 'low-space validation leaked its temporary work directory' >&2
+    exit 1
+fi
 
 echo 'component update tests passed'

--- a/tests/scripts/test-existing-ax6s-package.sh
+++ b/tests/scripts/test-existing-ax6s-package.sh
@@ -14,6 +14,7 @@ tar -xOf "$out" ./data.tar.gz > "$data"
 for member in \
 	./usr/sbin/wloc-component-update.sh \
 	./usr/sbin/wloc-health.sh \
+	./usr/sbin/wloc-support-bundle.sh \
 	./etc/init.d/wificalling-location-gateway \
 	./usr/libexec/wificalling-location-gateway/unified-supervisor.sh; do
 	tar -tzf "$data" | grep -Fx "$member" >/dev/null || {

--- a/tests/scripts/test-existing-ax6s-package.sh
+++ b/tests/scripts/test-existing-ax6s-package.sh
@@ -10,7 +10,8 @@ trap 'rm -f "$out" "$out.manifest" "$out.sig" "$data"' EXIT HUP INT TERM
 "$repo_root/scripts/build-luci-ipk.sh" "$version" ax6s-existing >/dev/null
 [ -s "$out.manifest" ]
 grep -E '^Package-SHA256: [0-9a-f]{64}$' "$out.manifest" >/dev/null
-tar -xOf "$out" ./data.tar.gz > "$data"
+tar -xOf "$out" data.tar.gz > "$data" 2>/dev/null \
+	|| tar -xOf "$out" ./data.tar.gz > "$data"
 for member in \
 	./usr/sbin/wloc-component-update.sh \
 	./usr/sbin/wloc-health.sh \

--- a/tests/scripts/test-existing-ax6s-package.sh
+++ b/tests/scripts/test-existing-ax6s-package.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+version="2.0.0-$(date +%s)-$$"
+out="$repo_root/dist/luci-app-wificalling-location-gateway_${version}_all.ipk"
+data=$(mktemp "${TMPDIR:-/tmp}/wloc-existing-package.XXXXXX")
+trap 'rm -f "$out" "$out.manifest" "$out.sig" "$data"' EXIT HUP INT TERM
+
+"$repo_root/scripts/build-luci-ipk.sh" "$version" ax6s-existing >/dev/null
+[ -s "$out.manifest" ]
+grep -E '^Package-SHA256: [0-9a-f]{64}$' "$out.manifest" >/dev/null
+tar -xOf "$out" ./data.tar.gz > "$data"
+for member in \
+	./usr/sbin/wloc-component-update.sh \
+	./usr/sbin/wloc-health.sh \
+	./etc/init.d/wificalling-location-gateway \
+	./usr/libexec/wificalling-location-gateway/unified-supervisor.sh; do
+	tar -tzf "$data" | grep -Fx "$member" >/dev/null || {
+		echo "existing AX6S package is missing $member" >&2
+		exit 1
+	}
+done
+
+echo 'existing AX6S package tests passed'

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -7,7 +7,7 @@ tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-standalone-package-test.XXXXXX")
 built_output=
 cleanup() {
 	rm -rf "$tmp"
-	[ -z "$built_output" ] || rm -f "$built_output"
+	[ -z "$built_output" ] || rm -f "$built_output" "$built_output.manifest" "$built_output.sig"
 }
 trap cleanup EXIT HUP INT TERM
 

--- a/tests/test_v2_diagnostics_contract.py
+++ b/tests/test_v2_diagnostics_contract.py
@@ -25,6 +25,48 @@ class V2DiagnosticsContractTests(unittest.TestCase):
         self.assertIn("wloc-support-bundle.sh", standalone)
         self.assertIn("wloc-support-bundle.sh", release)
 
+    def test_component_update_contract_is_transactional_and_compatible(self):
+        script = self.root / "openwrt/files/usr/sbin/wloc-component-update.sh"
+        source = script.read_text(encoding="utf-8")
+        self.assertIn("known-good rollback package is required", source)
+        self.assertIn("insufficient free space", source)
+        self.assertIn("WLOC_UPDATE_INTERRUPT_AFTER_INSTALL", source)
+        self.assertIn('"$OPKG" install', source)
+        self.assertNotIn("opkg remove", source)
+        self.assertNotIn("nft ", source)
+        builder = (self.root / "scripts/build-luci-ipk.sh").read_text(encoding="utf-8")
+        self.assertIn("X-WFC-Product: wificalling-location-gateway/v2", builder)
+        self.assertIn("X-WFC-Gateway: 1.7", builder)
+        self.assertIn("X-WFC-Wloc-Api: wloc.service/v2", builder)
+        for compatibility in (
+            self.root / "openwrt/files/usr/share/wificalling-location-gateway/compatibility",
+            self.root / "openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/compatibility",
+        ):
+            self.assertIn("X-WFC-Product: wificalling-location-gateway/v2", compatibility.read_text(encoding="utf-8"))
+
+    def test_component_update_is_installed_and_exposed_with_minimum_acl(self):
+        makefile = (self.root / "openwrt/Makefile").read_text(encoding="utf-8")
+        release = (self.root / "scripts/openwrt/build-release-packages.sh").read_text(encoding="utf-8")
+        self.assertIn("files/usr/sbin/wloc-component-update.sh", makefile)
+        self.assertIn("wloc-component-update.sh", release)
+        for prefix in (self.root / "openwrt/files", self.root / "openwrt/luci-app-wificalling-location-gateway/files"):
+            rpc = (prefix / "usr/libexec/rpcd/luci.wloc").read_text(encoding="utf-8")
+            self.assertIn("update_status", rpc)
+            self.assertIn("update_preflight", rpc)
+            self.assertIn("update_apply", rpc)
+            self.assertIn("update_recover", rpc)
+            acl = json.loads((prefix / "usr/share/rpcd/acl.d/luci-app-wificalling-location-gateway.json").read_text(encoding="utf-8"))["luci-app-wificalling-location-gateway"]
+            read_methods = acl["read"]["ubus"]["luci.wloc"]
+            write_methods = acl["write"]["ubus"]["luci.wloc"]
+            self.assertIn("update_status", read_methods)
+            self.assertNotIn("update_apply", read_methods)
+            self.assertIn("update_preflight", write_methods)
+            self.assertIn("update_apply", write_methods)
+            self.assertIn("update_recover", write_methods)
+            health = (prefix / "www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js").read_text(encoding="utf-8")
+            self.assertIn("update_preflight", health)
+            self.assertIn("update_apply", health)
+
     def test_diagnostics_rpc_acl_and_ui_are_present_in_both_package_sources(self):
         for prefix in (
             self.root / "openwrt/files",
@@ -47,7 +89,7 @@ class V2DiagnosticsContractTests(unittest.TestCase):
             self.assertIn("eventFields", monitor)
 
     def test_support_bundle_shell_and_log_regression_scripts_pass(self):
-        for name in ("test-support-bundle.sh", "test-structured-logs.sh"):
+        for name in ("test-support-bundle.sh", "test-structured-logs.sh", "test-component-update.sh"):
             result = subprocess.run(
                 ["sh", str(self.root / "tests/scripts" / name)],
                 check=False,

--- a/tests/test_v2_diagnostics_contract.py
+++ b/tests/test_v2_diagnostics_contract.py
@@ -32,12 +32,16 @@ class V2DiagnosticsContractTests(unittest.TestCase):
         self.assertIn("insufficient free space", source)
         self.assertIn("WLOC_UPDATE_INTERRUPT_AFTER_INSTALL", source)
         self.assertIn('"$OPKG" install', source)
+        self.assertIn("return 1", source)
+        self.assertIn("verify_manifest", source)
+        self.assertIn("usign", source)
         self.assertNotIn("opkg remove", source)
         self.assertNotIn("nft ", source)
         builder = (self.root / "scripts/build-luci-ipk.sh").read_text(encoding="utf-8")
         self.assertIn("X-WFC-Product: wificalling-location-gateway/v2", builder)
         self.assertIn("X-WFC-Gateway: 1.7", builder)
         self.assertIn("X-WFC-Wloc-Api: wloc.service/v2", builder)
+        self.assertIn("create-update-manifest.sh", builder)
         for compatibility in (
             self.root / "openwrt/files/usr/share/wificalling-location-gateway/compatibility",
             self.root / "openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/compatibility",
@@ -66,6 +70,8 @@ class V2DiagnosticsContractTests(unittest.TestCase):
             health = (prefix / "www/luci-static/resources/view/wificalling-location-gateway/wloc-health.js").read_text(encoding="utf-8")
             self.assertIn("update_preflight", health)
             self.assertIn("update_apply", health)
+            self.assertIn("params: [ 'path' ]", health)
+            self.assertIn("call(updatePath.value)", health)
 
     def test_diagnostics_rpc_acl_and_ui_are_present_in_both_package_sources(self):
         for prefix in (
@@ -89,7 +95,12 @@ class V2DiagnosticsContractTests(unittest.TestCase):
             self.assertIn("eventFields", monitor)
 
     def test_support_bundle_shell_and_log_regression_scripts_pass(self):
-        for name in ("test-support-bundle.sh", "test-structured-logs.sh", "test-component-update.sh"):
+        for name in (
+            "test-support-bundle.sh",
+            "test-structured-logs.sh",
+            "test-component-update.sh",
+            "test-existing-ax6s-package.sh",
+        ):
             result = subprocess.run(
                 ["sh", str(self.root / "tests/scripts" / name)],
                 check=False,


### PR DESCRIPTION
Closes #39

## Summary
- add a root-only transactional component updater with package identity, version, architecture, Gateway/WLOC compatibility, source, and low-space validation
- preserve UCI and legacy facade configuration, require a known-good rollback IPK, and restore package/config after install, restart, health, or interruption failure
- expose preflight/apply/status/recover through minimal rpcd ACL and the unified LuCI health page
- ship compatibility metadata and the updater through canonical, standalone AX6S, and release packaging paths
- document update state, resource policy, rollback operation, and TDD evidence

## Verification
- `./scripts/ci/verify.sh` passed
- 80 Python tests passed
- Rust line coverage 80.11% (threshold 80%)
- component update shell contract passed: architecture rejection, authorized/unauthorized downgrade, config preservation, health rollback, interrupted recovery, low-space rejection
- OpenWrt/AX6S/release packaging passed
- no `opkg remove`, `nft`, or stable Gateway UDP 500/4500 manipulation in update path

## Risk and rollback
- Update source is explicitly staged under `/tmp/wloc-update`; no arbitrary URL fetch is exposed.
- The update lock and persistent transaction directory prevent concurrent/incomplete mutation; `rollback_failed` is surfaced when restoration cannot be validated.
- Real AX6S flash-full and hard-power-cut evidence remains the next Issue #40 gate.

Handoff capsule: `.handoffs/issue-39.md`
