### PR TITLE
feat: finalize low-resource gateway gates

### DIFF
--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -4,7 +4,7 @@
 
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test
-- Branch: codex/issue-40-ax6s-resource-gates-codex-v2-lead-20260821112742-7cdc1a0b
+- Branch: codex/issue-40-ax6s-resource-gates-review-codex-v2-lead-20260821114718-3db18a06
 - Final local checkpoint before handoff: pending independent review, CI, and AX6S hardware evidence
 - Credentials included: no
 
@@ -19,11 +19,12 @@ measurement template. Do not claim real-device measurements from the host.
 - Added versioned resource metadata to both canonical OpenWrt package source
   trees: combined release binary, integrated package, persistent state, log,
   cache, profile count, startup, RSS, and CPU ceilings.
-- Added portable `profile-resource.sh` plus Python fallback. Reports contain
-  only bounded status, elapsed time, peak RSS, CPU, and command status fields.
+- Added portable `profile-resource.sh` plus Python and procfs fallbacks. Reports
+  contain only bounded status, elapsed time, peak RSS, CPU, and command status
+  fields.
 - Added `verify-resource-budgets.sh` to reject missing/irregular artifacts,
-  oversized runtime binaries, oversized optional package artifacts, and
-  out-of-budget resource reports.
+  oversized runtime binaries, failed commands, and out-of-budget resource
+  reports; added `verify-package-budget.sh` for each actual IPK/APK output.
 - Installed the budget metadata through the canonical OpenWrt Makefile and
   documented the contract in the OpenWrt package README and development test
   plan.
@@ -33,7 +34,8 @@ measurement template. Do not claim real-device measurements from the host.
 - Added resource checks to the normal repository verification path and changed
   release compilation to build all runtime binaries before the size gate.
 - Added package artifact and resource-report assertions to the regression test;
-  oversized runtime artifacts are rejected.
+  oversized runtime/package artifacts, failed reports, RSS, CPU, and startup
+  reports are rejected.
 
 ## Files changed
 
@@ -44,8 +46,10 @@ measurement template. Do not claim real-device measurements from the host.
 - `scripts/ci/profile-resource.py`
 - `scripts/ci/profile-resource.sh`
 - `scripts/ci/verify-resource-budgets.sh`
+- `scripts/ci/verify-package-budget.sh`
 - `scripts/ci/verify-rust.sh`
 - `scripts/ci/verify.sh`
+- `scripts/openwrt/build-release-packages.sh`
 - `tests/scripts/resource-fixture.sh`
 - `tests/scripts/test-resource-budgets.sh`
 - `DEVELOPMENT_TEST_PLAN.md`
@@ -75,6 +79,13 @@ measurement template. Do not claim real-device measurements from the host.
   gate; product CPU acceptance remains an AX6S hardware measurement.
 - The handoff checker initially rejected the title `TDD and verification`;
   it was renamed to the required `Verification` heading.
+- The first resource design declared an idle RSS hard ceiling without a
+  portable collector; the unimplemented key was removed from the machine
+  contract and idle RSS is now explicitly a redacted AX6S observation.
+- Package size was initially only optional in the generic runtime gate; a
+  dedicated package gate is now invoked for every release IPK/APK.
+- The profiler initially required GNU time or Python 3 on target; a lightweight
+  `/proc` sampler now covers small Linux/OpenWrt images.
 - The local commit hook reports `lefthook` unavailable in PATH; repository
   verification itself passed.
 
@@ -84,7 +95,8 @@ measurement template. Do not claim real-device measurements from the host.
   usage, restart/reload, update/rollback, and low-space behavior must still be
   measured on the actual staging router using the redacted template before
   claiming V2-08 complete or enabling a persistent release rollout.
-- CI enforces deterministic artifact/package/report gates. It intentionally
+- CI enforces deterministic runtime artifact and report gates, while the
+  release builder enforces each real package artifact. It intentionally
   does not pretend to run the full OpenWrt service, TProxy/nftables path, or
   real update transaction on the host.
 - The selected budgets are release defaults for a small gateway and require

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -97,6 +97,9 @@ measurement template. Do not claim real-device measurements from the host.
   and bounds all paths with a timeout.
 - Python fallback initially inherited a shell temporary file before `exec`;
   the temporary file is now created only for GNU time mode.
+- The standalone builder initially exposed the package gate's success text on
+  stdout, breaking callers that consume only the generated IPK path; the gate
+  output is now suppressed at that compatibility boundary.
 - The local commit hook reports `lefthook` unavailable in PATH; repository
   verification itself passed.
 

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -4,7 +4,7 @@
 
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test
-- Branch: codex/issue-40-ax6s-resource-gates-review2-codex-v2-lead-20260821120115-0b0f2a16
+- Branch: codex/issue-40-ax6s-resource-gates-ci-fix-codex-v2-lead-20260821121438-72d38e2f
 - Final local checkpoint before handoff: pending independent review, CI, and AX6S hardware evidence
 - Credentials included: no
 
@@ -100,6 +100,9 @@ measurement template. Do not claim real-device measurements from the host.
 - The standalone builder initially exposed the package gate's success text on
   stdout, breaking callers that consume only the generated IPK path; the gate
   output is now suppressed at that compatibility boundary.
+- The CI runner exposed that the resource fixture could exit before procfs
+  sampling, producing the intentional unmeasured-RSS failure; the fixture now
+  has a one-second deterministic observation window.
 - The local commit hook reports `lefthook` unavailable in PATH; repository
   verification itself passed.
 

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -103,6 +103,10 @@ measurement template. Do not claim real-device measurements from the host.
 - The CI runner exposed that the resource fixture could exit before procfs
   sampling, producing the intentional unmeasured-RSS failure; the fixture now
   has a one-second deterministic observation window.
+- The first CI timeout assertion required the implementation-specific exit
+  code 124, but GNU time/timeout combinations can preserve a different
+  non-zero wrapper code; the regression now requires failed status and any
+  non-zero command status while the report still records the exact code.
 - The local commit hook reports `lefthook` unavailable in PATH; repository
   verification itself passed.
 

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -1,0 +1,101 @@
+# Agent handoff: Issue 40
+
+## Identity and scope
+
+- Source agent ID: codex-v2-lead
+- Capabilities used: openwrt,test
+- Branch: codex/issue-40-ax6s-resource-gates-codex-v2-lead-20260821112742-7cdc1a0b
+- Final local checkpoint before handoff: pending independent review, CI, and AX6S hardware evidence
+- Credentials included: no
+
+## Objective
+
+Define and enforce low-memory/low-storage resource budgets for the unified
+Gateway/WLOC component, with reproducible host-side gates and a redacted AX6S
+measurement template. Do not claim real-device measurements from the host.
+
+## Completed
+
+- Added versioned resource metadata to both canonical OpenWrt package source
+  trees: combined release binary, integrated package, persistent state, log,
+  cache, profile count, startup, RSS, and CPU ceilings.
+- Added portable `profile-resource.sh` plus Python fallback. Reports contain
+  only bounded status, elapsed time, peak RSS, CPU, and command status fields.
+- Added `verify-resource-budgets.sh` to reject missing/irregular artifacts,
+  oversized runtime binaries, oversized optional package artifacts, and
+  out-of-budget resource reports.
+- Installed the budget metadata through the canonical OpenWrt Makefile and
+  documented the contract in the OpenWrt package README and development test
+  plan.
+- Added host-side RED/GREEN TDD evidence and a redacted AX6S evidence template
+  covering disabled/one/multiple/degraded/restart/update/rollback/low-space
+  scenarios, including the existing safety invariants.
+- Added resource checks to the normal repository verification path and changed
+  release compilation to build all runtime binaries before the size gate.
+- Added package artifact and resource-report assertions to the regression test;
+  oversized runtime artifacts are rejected.
+
+## Files changed
+
+- `openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf`
+- `openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/resource-budget.conf`
+- `openwrt/Makefile`
+- `openwrt/README.md`
+- `scripts/ci/profile-resource.py`
+- `scripts/ci/profile-resource.sh`
+- `scripts/ci/verify-resource-budgets.sh`
+- `scripts/ci/verify-rust.sh`
+- `scripts/ci/verify.sh`
+- `tests/scripts/resource-fixture.sh`
+- `tests/scripts/test-resource-budgets.sh`
+- `DEVELOPMENT_TEST_PLAN.md`
+- `docs/testing/V2_RESOURCE_BUDGETS.tdd.md`
+- `docs/testing/AX6S_RESOURCE_EVIDENCE.template.md`
+
+## TDD and verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `sh tests/scripts/test-resource-budgets.sh` before implementation | Passed as RED checkpoint | Commit `5453ec7` exited non-zero because the resource contract/harness was absent |
+| `sh tests/scripts/test-resource-budgets.sh` | Passed | Budget schema, portable profiler, package/report checks, and oversized artifact rejection |
+| `./scripts/ci/verify.sh` | Passed | 80 Python tests, all Rust targets, secret scan, packaging/update tests, resource tests, audit, release build |
+| Rust coverage | Passed | 80.11% line coverage, above the 80% repository gate |
+| Rust audit | Passed | Advisories, bans, licenses, sources all pass; existing duplicate `socket2`/`windows-sys` warnings remain |
+| Release resource gate | Passed | Combined runtime binaries `2,958,912` bytes against `8,388,608` bytes |
+| `git diff --check` | Passed | No whitespace errors |
+| ShellCheck | Pending CI | Not installed in the local environment |
+
+## Known limitations and acceptance gap
+
+- The host cannot provide AX6S hardware evidence. RSS, CPU, startup, flash
+  usage, restart/reload, update/rollback, and low-space behavior must still be
+  measured on the actual staging router using the redacted template before
+  claiming V2-08 complete or enabling a persistent release rollout.
+- CI enforces deterministic artifact/package/report gates. It intentionally
+  does not pretend to run the full OpenWrt service, TProxy/nftables path, or
+  real update transaction on the host.
+- The selected budgets are release defaults for a small gateway and require
+  project-lead acceptance or a recorded exception if AX6S measurements show a
+  different safe ceiling.
+
+## Safety invariants retained
+
+- Fail-open behavior remains the release contract.
+- WLOC interception remains limited to the assigned device, exact approved
+  Apple hosts, and TCP 443.
+- UDP 500/4500 and the stable Gateway nftables table are untouched.
+- Reports and evidence must not contain credentials, CA keys, raw traffic,
+  device identifiers, or precise user location.
+
+## Next executable steps
+
+1. Push the branch and open a review PR for Issue 40 without claiming AX6S
+   hardware acceptance.
+2. Obtain independent review focused on resource-gate bypasses and OpenWrt
+   portability; resolve P1/P2 findings.
+3. Run GitHub CI, including ShellCheck and the pinned OpenWrt cross-build.
+4. On an actual AX6S staging router, fill the redacted evidence template and
+   record before/after install, steady state, reload/crash, rollback, and
+   low-space results. Only then decide whether to merge/close the full Issue.
+5. Carry the accepted budgets into Issue 41's release matrix and migration
+   rehearsal.

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -52,7 +52,7 @@ measurement template. Do not claim real-device measurements from the host.
 - `docs/testing/V2_RESOURCE_BUDGETS.tdd.md`
 - `docs/testing/AX6S_RESOURCE_EVIDENCE.template.md`
 
-## TDD and verification
+## Verification
 
 | Command | Result | Evidence |
 |---|---|---|

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -65,6 +65,19 @@ measurement template. Do not claim real-device measurements from the host.
 | `git diff --check` | Passed | No whitespace errors |
 | ShellCheck | Pending CI | Not installed in the local environment |
 
+## Failed attempts
+
+- The first resource regression test printed its success line twice; the
+  duplicate assertion was removed.
+- Running the resource gate against the fixture's measured CPU made the test
+  host's transient 72% CPU sample fail the product budget. The test now keeps
+  profiler format coverage and feeds a controlled compliant report to the
+  gate; product CPU acceptance remains an AX6S hardware measurement.
+- The handoff checker initially rejected the title `TDD and verification`;
+  it was renamed to the required `Verification` heading.
+- The local commit hook reports `lefthook` unavailable in PATH; repository
+  verification itself passed.
+
 ## Known limitations and acceptance gap
 
 - The host cannot provide AX6S hardware evidence. RSS, CPU, startup, flash
@@ -78,6 +91,11 @@ measurement template. Do not claim real-device measurements from the host.
   project-lead acceptance or a recorded exception if AX6S measurements show a
   different safe ceiling.
 
+## Capabilities required for the next Agent
+
+- `openwrt`, `test`, `security`, and access to an AX6S staging router for the
+  final resource and update/rollback evidence.
+
 ## Safety invariants retained
 
 - Fail-open behavior remains the release contract.
@@ -86,6 +104,15 @@ measurement template. Do not claim real-device measurements from the host.
 - UDP 500/4500 and the stable Gateway nftables table are untouched.
 - Reports and evidence must not contain credentials, CA keys, raw traffic,
   device identifiers, or precise user location.
+
+## Security and privacy notes
+
+- Resource reports are allowlisted and mode-restricted; the profiler suppresses
+  command output and rejects symlink report paths.
+- Package and runtime gates inspect regular local files only and do not fetch or
+  upload artifacts.
+- AX6S evidence must be redacted before entering Git or GitHub; no credentials,
+  CA private keys, raw traffic, or device identifiers are included.
 
 ## Next executable steps
 

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -4,7 +4,7 @@
 
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test
-- Branch: codex/issue-40-ax6s-resource-gates-review-codex-v2-lead-20260821114718-3db18a06
+- Branch: codex/issue-40-ax6s-resource-gates-review2-codex-v2-lead-20260821120115-0b0f2a16
 - Final local checkpoint before handoff: pending independent review, CI, and AX6S hardware evidence
 - Credentials included: no
 
@@ -21,7 +21,7 @@ measurement template. Do not claim real-device measurements from the host.
   cache, profile count, startup, RSS, and CPU ceilings.
 - Added portable `profile-resource.sh` plus Python and procfs fallbacks. Reports
   contain only bounded status, elapsed time, peak RSS, CPU, and command status
-  fields.
+  fields; commands have a bounded timeout and an unsampled RSS result fails.
 - Added `verify-resource-budgets.sh` to reject missing/irregular artifacts,
   oversized runtime binaries, failed commands, and out-of-budget resource
   reports; added `verify-package-budget.sh` for each actual IPK/APK output.
@@ -36,6 +36,8 @@ measurement template. Do not claim real-device measurements from the host.
 - Added package artifact and resource-report assertions to the regression test;
   oversized runtime/package artifacts, failed reports, RSS, CPU, and startup
   reports are rejected.
+- Enforced package budgets through both integrated OpenWrt release packaging
+  and the standalone AX6S/LuCI IPK builder, with shell-loop failure propagation.
 
 ## Files changed
 
@@ -47,6 +49,7 @@ measurement template. Do not claim real-device measurements from the host.
 - `scripts/ci/profile-resource.sh`
 - `scripts/ci/verify-resource-budgets.sh`
 - `scripts/ci/verify-package-budget.sh`
+- `scripts/build-luci-ipk.sh`
 - `scripts/ci/verify-rust.sh`
 - `scripts/ci/verify.sh`
 - `scripts/openwrt/build-release-packages.sh`
@@ -86,6 +89,14 @@ measurement template. Do not claim real-device measurements from the host.
   dedicated package gate is now invoked for every release IPK/APK.
 - The profiler initially required GNU time or Python 3 on target; a lightweight
   `/proc` sampler now covers small Linux/OpenWrt images.
+- The first package-builder integration used `find -exec`, which could hide a
+  child failure; it was replaced with an explicit shell loop and the standalone
+  builder now invokes the same gate.
+- The procfs sampler initially polled once per second and could under-sample a
+  short-lived command; it now polls at 100ms, rejects zero RSS as unmeasured,
+  and bounds all paths with a timeout.
+- Python fallback initially inherited a shell temporary file before `exec`;
+  the temporary file is now created only for GNU time mode.
 - The local commit hook reports `lefthook` unavailable in PATH; repository
   verification itself passed.
 

--- a/.handoffs/issue-40.md
+++ b/.handoffs/issue-40.md
@@ -4,7 +4,7 @@
 
 - Source agent ID: codex-v2-lead
 - Capabilities used: openwrt,test
-- Branch: codex/issue-40-ax6s-resource-gates-ci-fix-codex-v2-lead-20260821121438-72d38e2f
+- Branch: codex/issue-40-ax6s-resource-gates-ci-fix2-codex-v2-lead-20260821122614-862fa284
 - Final local checkpoint before handoff: pending independent review, CI, and AX6S hardware evidence
 - Credentials included: no
 

--- a/DEVELOPMENT_TEST_PLAN.md
+++ b/DEVELOPMENT_TEST_PLAN.md
@@ -307,6 +307,14 @@ Gateway 1.7/后续版本只声明可选集成，不把引擎设为强制依赖�
 | 并发测试设备 | 1 |
 | WLOC 拦截域名 | 2 |
 
+V2-08 将上述目标固化为包内的
+`/usr/share/wificalling-location-gateway/resource-budget.conf`：运行时三枚
+二进制合计不超过 8MiB，集成包不超过 20MiB，持久状态不超过 10MiB，日志与
+缓存各自总量不超过 1MiB，最多 8 个设备档案，启动不超过 10 秒，空闲 RSS
+不超过 25MiB、峰值 RSS 不超过 35MiB、探测 CPU 不超过 30%。二进制与可选
+包 artifact 在 CI 中硬拦截；RSS/CPU/启动时间通过统一脚本和 AX6S 脱敏证据
+验收，未取得真机证据前不得宣称硬件通过。
+
 运行时还必须限制：
 
 - 总连接数；

--- a/docs/testing/AX6S_RESOURCE_EVIDENCE.template.md
+++ b/docs/testing/AX6S_RESOURCE_EVIDENCE.template.md
@@ -1,0 +1,52 @@
+# AX6S V2-08 resource evidence (redacted template)
+
+Copy this template for a staging run. Do not enter serial numbers, MAC/IP
+addresses, node names, credentials, precise locations, raw traffic, or CA
+material. Use broad firmware and memory/storage values where possible.
+
+## Run metadata
+
+- Date/time (coarse):
+- Firmware family/version:
+- Kernel family/version:
+- Package version/architecture:
+- Operator:
+- Evidence bundle contains secrets: `no`
+
+## Budget inputs
+
+- Total memory / available memory bucket before install:
+- Persistent free-space bucket before install:
+- `/tmp` free-space bucket before install:
+- Existing Gateway 1.7 configuration backed up: `yes/no`
+
+## Measurements
+
+| Scenario | Startup ms | Idle RSS KiB | Peak RSS KiB | CPU % | Persistent bytes | Log/cache bytes | Result |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Disabled service | | | | | | | |
+| One enabled profile | | | | | | | |
+| Multiple enabled profiles | | | | | | | |
+| Degraded/failed probe | | | | | | | |
+| Restart/reload recovery | | | | | | | |
+| Update success | | | | | | | |
+| Health-failure rollback | | | | | | | |
+| Interrupted-update recovery | | | | | | | |
+| Low-space preflight | | | | | | | |
+
+## Functional checks
+
+- Gateway Wi-Fi Calling registration/traffic unaffected: `pass/fail`
+- UDP 500/4500 untouched: `pass/fail`
+- Only assigned device and exact Apple WLOC hosts were intercepted: `pass/fail`
+- Ordinary HTTPS remained outside the WLOC data plane: `pass/fail`
+- Stop/restart restored passthrough: `pass/fail`
+- Configuration preserved across update/rollback: `pass/fail`
+- No secrets or device identifiers in logs/support bundle: `pass/fail`
+
+## Acceptance
+
+- All ceilings in `resource-budget.conf` met: `yes/no`
+- Budget exception approved by project lead: `yes/no/not applicable`
+- AX6S result: `pass/fail/pending`
+- Follow-up Issue:

--- a/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
+++ b/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
@@ -1,0 +1,60 @@
+# V2-08 Resource budgets and AX6S evidence
+
+## Scope
+
+This contract covers small-memory/small-storage OpenWrt gateways. It separates
+offline CI gates from measurements that require an actual AX6S staging device.
+No real device identifier, address, credential, raw traffic, or precise
+location belongs in the evidence.
+
+## User journeys
+
+- As a gateway maintainer, I want binary and package size regressions rejected
+  in CI, so a low-storage device is not silently overfilled.
+- As an operator, I want a bounded resource report for startup, RSS, CPU,
+  logs, caches, profiles, restart, and rollback, so I can tell whether the
+  service is safe to keep enabled.
+- As a release owner, I want a repeatable AX6S checklist, so real-device
+  acceptance does not depend on undocumented observations.
+
+## Machine-readable contract
+
+The installed contract is
+`/usr/share/wificalling-location-gateway/resource-budget.conf`.
+
+| Budget | Ceiling | Enforced by |
+|---|---:|---|
+| Runtime binaries combined | 8 MiB | `verify-resource-budgets.sh` |
+| Integrated package | 20 MiB | `verify-resource-budgets.sh` when artifact is supplied |
+| Persistent update/config state | 10 MiB | package contract and device checklist |
+| Logs combined | 1 MiB | package contract; individual WLOC log is 64 KiB |
+| Caches combined | 1 MiB | package contract and device checklist |
+| Profiles | 8 | existing profile model and package contract |
+| Startup | 10 s | resource report gate when supplied |
+| Idle RSS | 25 MiB | resource report gate when supplied |
+| Peak RSS | 35 MiB | resource report gate when supplied |
+| Probe CPU | 30% | resource report gate when supplied |
+
+The existing 64 KiB WLOC event log, bounded response/cache sizes, 8-profile
+model, and bounded restart policy remain stricter component-level limits.
+
+## TDD evidence
+
+| Stage | Command | Result |
+|---|---|---|
+| RED | `sh tests/scripts/test-resource-budgets.sh` before the contract/harness existed | PASSING RED condition: missing budget/harness caused exit 1 |
+| GREEN | `sh tests/scripts/test-resource-budgets.sh` | PASS; report schema and oversized-binary rejection exercised |
+| GREEN | `cargo build --locked --release --bins && ./scripts/ci/verify-resource-budgets.sh` | PASS; combined runtime binaries: 2,892,256 bytes |
+| Syntax | `sh -n scripts/ci/*.sh tests/scripts/test-resource-budgets.sh` | PASS |
+
+The total runtime size is a local measurement of the current release build,
+not AX6S RSS evidence. The complete repository gate runs this contract after
+building all release binaries.
+
+## AX6S acceptance gap
+
+Hardware acceptance is intentionally not claimed in this change until an
+actual staging AX6S is available. Fill
+`docs/testing/AX6S_RESOURCE_EVIDENCE.template.md` using the target-side
+`scripts/ci/profile-resource.sh` or an equivalent BusyBox-compatible capture,
+then attach only redacted aggregate values to the Issue/PR.

--- a/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
+++ b/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
@@ -31,7 +31,6 @@ The installed contract is
 | Caches combined | 1 MiB | package contract and device checklist |
 | Profiles | 8 | existing profile model and package contract |
 | Startup | 10 s | resource report gate when supplied |
-| Idle RSS | 25 MiB | resource report gate when supplied |
 | Peak RSS | 35 MiB | resource report gate when supplied |
 | Probe CPU | 30% | resource report gate when supplied |
 
@@ -43,18 +42,24 @@ model, and bounded restart policy remain stricter component-level limits.
 | Stage | Command | Result |
 |---|---|---|
 | RED | `sh tests/scripts/test-resource-budgets.sh` before the contract/harness existed | PASSING RED condition: missing budget/harness caused exit 1 |
-| GREEN | `sh tests/scripts/test-resource-budgets.sh` | PASS; report schema and oversized-binary rejection exercised |
+| GREEN | `sh tests/scripts/test-resource-budgets.sh` | PASS; report/package schema, procfs path where available, and oversized binary/package/resource rejection exercised |
 | GREEN | `cargo build --locked --release --bins && ./scripts/ci/verify-resource-budgets.sh` | PASS; combined runtime binaries: 2,892,256 bytes |
 | Syntax | `sh -n scripts/ci/*.sh tests/scripts/test-resource-budgets.sh` | PASS |
 
 The total runtime size is a local measurement of the current release build,
-not AX6S RSS evidence. The complete repository gate runs this contract after
-building all release binaries.
+not AX6S RSS evidence. Idle RSS remains an AX6S observation recorded in the
+evidence template; the portable gate enforces peak RSS because it is the
+portable upper-bound signal available across host and target profilers. The
+complete repository gate runs this contract after building all release
+binaries. The release package builder invokes `verify-package-budget.sh` for
+each generated IPK/APK, so package size is checked against the same installed
+contract when a real package exists.
 
 ## AX6S acceptance gap
 
 Hardware acceptance is intentionally not claimed in this change until an
 actual staging AX6S is available. Fill
 `docs/testing/AX6S_RESOURCE_EVIDENCE.template.md` using the target-side
-`scripts/ci/profile-resource.sh` or an equivalent BusyBox-compatible capture,
+`scripts/ci/profile-resource.sh` (which has a `/proc` fallback and does not
+require GNU time or Python 3) or an equivalent BusyBox-compatible capture,
 then attach only redacted aggregate values to the Issue/PR.

--- a/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
+++ b/docs/testing/V2_RESOURCE_BUDGETS.tdd.md
@@ -25,7 +25,7 @@ The installed contract is
 | Budget | Ceiling | Enforced by |
 |---|---:|---|
 | Runtime binaries combined | 8 MiB | `verify-resource-budgets.sh` |
-| Integrated package | 20 MiB | `verify-resource-budgets.sh` when artifact is supplied |
+| Integrated package | 20 MiB | `verify-package-budget.sh` in every release package builder |
 | Persistent update/config state | 10 MiB | package contract and device checklist |
 | Logs combined | 1 MiB | package contract; individual WLOC log is 64 KiB |
 | Caches combined | 1 MiB | package contract and device checklist |
@@ -61,5 +61,6 @@ Hardware acceptance is intentionally not claimed in this change until an
 actual staging AX6S is available. Fill
 `docs/testing/AX6S_RESOURCE_EVIDENCE.template.md` using the target-side
 `scripts/ci/profile-resource.sh` (which has a `/proc` fallback and does not
-require GNU time or Python 3) or an equivalent BusyBox-compatible capture,
-then attach only redacted aggregate values to the Issue/PR.
+require GNU time or Python 3), with a bounded timeout and explicit failure when
+RSS cannot be sampled, or an equivalent BusyBox-compatible capture; then attach
+only redacted aggregate values to the Issue/PR.

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -53,6 +53,9 @@ define Package/wloc-service/install
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-health.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-support-bundle.sh $(1)/usr/sbin/
 	$(INSTALL_BIN) ./files/usr/sbin/wloc-component-update.sh $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/usr/share/wificalling-location-gateway
+	$(INSTALL_DATA) ./files/usr/share/wificalling-location-gateway/resource-budget.conf \
+		$(1)/usr/share/wificalling-location-gateway/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/wloc-service $(1)/etc/init.d/
 	$(INSTALL_BIN) ./files/etc/init.d/wificalling-location-gateway $(1)/etc/init.d/

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -33,3 +33,12 @@ the source repository remains isolated and does not vendor the Gateway source.
   Apple hosts, and TCP 443. UDP 500/4500 and the Gateway nftables table are
   outside the WLOC data plane.
 - The socket is root-only (0600); no TCP management listener exists.
+
+## Small-gateway resource contract
+
+The package installs a machine-readable V2 budget at
+`/usr/share/wificalling-location-gateway/resource-budget.conf`. CI enforces
+the combined release-binary ceiling and can enforce a supplied package or
+runtime report. AX6S RSS/CPU/startup and update/rollback measurements must be
+recorded with the redacted evidence template before persistent deployment is
+accepted.

--- a/openwrt/README.md
+++ b/openwrt/README.md
@@ -38,7 +38,8 @@ the source repository remains isolated and does not vendor the Gateway source.
 
 The package installs a machine-readable V2 budget at
 `/usr/share/wificalling-location-gateway/resource-budget.conf`. CI enforces
-the combined release-binary ceiling and can enforce a supplied package or
-runtime report. AX6S RSS/CPU/startup and update/rollback measurements must be
+the combined release-binary ceiling and supplied package/runtime reports;
+release packaging invokes the package check for each output artifact. AX6S
+idle RSS, peak RSS, CPU/startup, and update/rollback measurements must be
 recorded with the redacted evidence template before persistent deployment is
 accepted.

--- a/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf
+++ b/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf
@@ -1,0 +1,13 @@
+# Machine-readable V2 resource contract for small OpenWrt gateways.
+# Values are hard ceilings unless release evidence records an approved exception.
+format=wfc-resource-budget/v1
+runtime_binary_total_max_bytes=8388608
+integrated_package_max_bytes=20971520
+persistent_state_max_bytes=10485760
+log_total_max_bytes=1048576
+cache_total_max_bytes=1048576
+max_profiles=8
+startup_max_seconds=10
+rss_idle_max_bytes=26214400
+rss_peak_max_bytes=36700160
+cpu_probe_max_percent=30

--- a/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf
+++ b/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf
@@ -8,6 +8,5 @@ log_total_max_bytes=1048576
 cache_total_max_bytes=1048576
 max_profiles=8
 startup_max_seconds=10
-rss_idle_max_bytes=26214400
 rss_peak_max_bytes=36700160
 cpu_probe_max_percent=30

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/resource-budget.conf
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/resource-budget.conf
@@ -7,6 +7,5 @@ log_total_max_bytes=1048576
 cache_total_max_bytes=1048576
 max_profiles=8
 startup_max_seconds=10
-rss_idle_max_bytes=26214400
 rss_peak_max_bytes=36700160
 cpu_probe_max_percent=30

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/resource-budget.conf
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/share/wificalling-location-gateway/resource-budget.conf
@@ -1,0 +1,12 @@
+# Machine-readable V2 resource contract for small OpenWrt gateways.
+format=wfc-resource-budget/v1
+runtime_binary_total_max_bytes=8388608
+integrated_package_max_bytes=20971520
+persistent_state_max_bytes=10485760
+log_total_max_bytes=1048576
+cache_total_max_bytes=1048576
+max_profiles=8
+startup_max_seconds=10
+rss_idle_max_bytes=26214400
+rss_peak_max_bytes=36700160
+cpu_probe_max_percent=30

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -261,7 +261,7 @@ make_archive "$stage/control" "$stage/control.tar.gz" .
 make_archive "$stage/data" "$stage/data.tar.gz" .
 rm -f "$out"
 make_archive "$stage" "$out" debian-binary data.tar.gz control.tar.gz
-"$root/scripts/ci/verify-package-budget.sh" "$out"
+"$root/scripts/ci/verify-package-budget.sh" "$out" >/dev/null
 "$root/scripts/create-update-manifest.sh" "$out" >/dev/null
 
 echo "$out"

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -261,6 +261,7 @@ make_archive "$stage/control" "$stage/control.tar.gz" .
 make_archive "$stage/data" "$stage/data.tar.gz" .
 rm -f "$out"
 make_archive "$stage" "$out" debian-binary data.tar.gz control.tar.gz
+"$root/scripts/ci/verify-package-budget.sh" "$out"
 "$root/scripts/create-update-manifest.sh" "$out" >/dev/null
 
 echo "$out"

--- a/scripts/ci/profile-resource.py
+++ b/scripts/ci/profile-resource.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout-seconds", required=True, type=int)
     parser.add_argument("--report", required=True, type=Path)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args()
@@ -23,9 +24,22 @@ def main() -> int:
         parser.error("command is required")
     if args.report.is_symlink():
         parser.error("report must not be a symlink")
+    if args.timeout_seconds <= 0:
+        parser.error("timeout must be a positive integer")
 
     started = time.monotonic()
-    completed = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    timed_out = False
+    try:
+        completed = subprocess.run(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=args.timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        completed = subprocess.CompletedProcess(command, 124)
     elapsed = time.monotonic() - started
     usage = resource.getrusage(resource.RUSAGE_CHILDREN)
     rss = int(usage.ru_maxrss)
@@ -34,7 +48,7 @@ def main() -> int:
     cpu = round(((usage.ru_utime + usage.ru_stime) / max(elapsed, 0.001)) * 100)
     report = "".join(
         (
-            f"status={'pass' if completed.returncode == 0 else 'fail'}\n",
+            f"status={'pass' if completed.returncode == 0 and not timed_out else 'fail'}\n",
             f"elapsed_ms={round(elapsed * 1000)}\n",
             f"peak_rss_kib={rss}\n",
             f"cpu_percent={cpu}\n",

--- a/scripts/ci/profile-resource.py
+++ b/scripts/ci/profile-resource.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Portable resource measurement fallback for macOS and minimal CI hosts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import resource
+import subprocess
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", required=True, type=Path)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if not args.command or args.command[0] != "--":
+        parser.error("command must follow --")
+    command = args.command[1:]
+    if not command:
+        parser.error("command is required")
+    if args.report.is_symlink():
+        parser.error("report must not be a symlink")
+
+    started = time.monotonic()
+    completed = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    elapsed = time.monotonic() - started
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    rss = int(usage.ru_maxrss)
+    if os.uname().sysname == "Darwin":
+        rss //= 1024
+    cpu = round(((usage.ru_utime + usage.ru_stime) / max(elapsed, 0.001)) * 100)
+    report = "".join(
+        (
+            f"status={'pass' if completed.returncode == 0 else 'fail'}\n",
+            f"elapsed_ms={round(elapsed * 1000)}\n",
+            f"peak_rss_kib={rss}\n",
+            f"cpu_percent={cpu}\n",
+            f"command_status={completed.returncode}\n",
+        )
+    )
+    args.report.write_text(report, encoding="ascii")
+    args.report.chmod(0o600)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/profile-resource.sh
+++ b/scripts/ci/profile-resource.sh
@@ -24,17 +24,72 @@ parent=${report%/*}
 tmp=$(mktemp "${TMPDIR:-/tmp}/wloc-resource-time.XXXXXX")
 trap 'rm -f "$tmp"' EXIT HUP INT TERM
 time_bin=
-for candidate in /usr/bin/time "$(command -v gtime 2>/dev/null || true)"; do
-	if [ -x "$candidate" ] && "$candidate" -f '%e' true >/dev/null 2>/dev/null; then
-		time_bin=$candidate
-		break
-	fi
-done
+if [ "${WLOC_RESOURCE_FORCE_PROCFS:-0}" != 1 ]; then
+	for candidate in /usr/bin/time "$(command -v gtime 2>/dev/null || true)"; do
+		if [ -x "$candidate" ] && "$candidate" -f '%e' true >/dev/null 2>/dev/null; then
+			time_bin=$candidate
+			break
+		fi
+	done
+fi
 if [ -z "$time_bin" ]; then
-	python3=$(command -v python3 || true)
-	[ -n "$python3" ] || { echo 'profile-resource: GNU time or Python 3 is required' >&2; exit 127; }
-	exec "$python3" "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/profile-resource.py" \
-		--report "$report" -- "$@"
+	python3=
+	if [ "${WLOC_RESOURCE_FORCE_PROCFS:-0}" != 1 ]; then
+		python3=$(command -v python3 || true)
+	fi
+	if [ -n "$python3" ]; then
+		exec "$python3" "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/profile-resource.py" \
+			--report "$report" -- "$@"
+	fi
+	[ -r /proc/self/status ] && [ -r /proc/self/stat ] || {
+		echo 'profile-resource: GNU time, Python 3, or procfs is required' >&2
+		exit 127
+	}
+
+	proc_ticks() {
+		awk '{ print $14 + $15 }' "/proc/$1/stat" 2>/dev/null || printf '0\n'
+	}
+	proc_rss_kib() {
+		awk '/^VmRSS:/ { print $2; exit }' "/proc/$1/status" 2>/dev/null || printf '0\n'
+	}
+
+	set +e
+	"$@" >/dev/null 2>&1 &
+	pid=$!
+	started=$(date +%s)
+	start_ticks=$(proc_ticks "$pid")
+	last_ticks=$start_ticks
+	peak_rss_kib=$(proc_rss_kib "$pid")
+	case "$peak_rss_kib" in ''|*[!0-9]*) peak_rss_kib=0 ;; esac
+	while kill -0 "$pid" 2>/dev/null; do
+		rss=$(proc_rss_kib "$pid")
+		case "$rss" in ''|*[!0-9]*) rss=0 ;; esac
+		[ "$rss" -gt "$peak_rss_kib" ] && peak_rss_kib=$rss
+		last_ticks=$(proc_ticks "$pid")
+		sleep 1
+	done
+	wait "$pid"
+	command_status=$?
+	ended=$(date +%s)
+	set -e
+
+	elapsed_seconds=$((ended - started))
+	[ "$elapsed_seconds" -gt 0 ] || elapsed_seconds=1
+	hz=$(getconf CLK_TCK 2>/dev/null || printf '100\n')
+	case "$hz" in ''|*[!0-9]*) hz=100 ;; esac
+	delta_ticks=$((last_ticks - start_ticks))
+	[ "$delta_ticks" -gt 0 ] || delta_ticks=0
+	cpu_percent=$((delta_ticks * 100 / (elapsed_seconds * hz)))
+	if [ "$command_status" -eq 0 ]; then status=pass; else status=fail; fi
+	umask 077
+	{
+		printf 'status=%s\n' "$status"
+		printf 'elapsed_ms=%s\n' "$((elapsed_seconds * 1000))"
+		printf 'peak_rss_kib=%s\n' "$peak_rss_kib"
+		printf 'cpu_percent=%s\n' "$cpu_percent"
+		printf 'command_status=%s\n' "$command_status"
+	} > "$report"
+	exit "$command_status"
 fi
 set +e
 "$time_bin" -f 'elapsed_seconds=%e\npeak_rss_kib=%M\ncpu_percent_raw=%P\n' \

--- a/scripts/ci/profile-resource.sh
+++ b/scripts/ci/profile-resource.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Measure one bounded command without recording its stdout/stderr.
+set -eu
+
+report=${WLOC_RESOURCE_REPORT:-}
+if [ "$#" -gt 0 ] && [ "$1" = --report ]; then
+	[ "$#" -ge 2 ] || { echo 'profile-resource: --report needs a path' >&2; exit 2; }
+	report=$2
+	shift 2
+fi
+[ -n "$report" ] || { echo 'profile-resource: WLOC_RESOURCE_REPORT is required' >&2; exit 2; }
+if [ "$#" -lt 2 ] || [ "$1" != -- ]; then
+	echo 'usage: profile-resource.sh [--report PATH] -- COMMAND [ARGS...]' >&2
+	exit 2
+fi
+shift
+[ "$#" -gt 0 ] || { echo 'profile-resource: command is required' >&2; exit 2; }
+
+parent=${report%/*}
+[ "$parent" = "$report" ] && parent=.
+[ -d "$parent" ] || { echo 'profile-resource: report parent is missing' >&2; exit 2; }
+[ ! -L "$report" ] || { echo 'profile-resource: report must not be a symlink' >&2; exit 2; }
+
+tmp=$(mktemp "${TMPDIR:-/tmp}/wloc-resource-time.XXXXXX")
+trap 'rm -f "$tmp"' EXIT HUP INT TERM
+time_bin=
+for candidate in /usr/bin/time "$(command -v gtime 2>/dev/null || true)"; do
+	if [ -x "$candidate" ] && "$candidate" -f '%e' true >/dev/null 2>/dev/null; then
+		time_bin=$candidate
+		break
+	fi
+done
+if [ -z "$time_bin" ]; then
+	python3=$(command -v python3 || true)
+	[ -n "$python3" ] || { echo 'profile-resource: GNU time or Python 3 is required' >&2; exit 127; }
+	exec "$python3" "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/profile-resource.py" \
+		--report "$report" -- "$@"
+fi
+set +e
+"$time_bin" -f 'elapsed_seconds=%e\npeak_rss_kib=%M\ncpu_percent_raw=%P\n' \
+	"$@" >/dev/null 2>"$tmp"
+command_status=$?
+set -e
+
+elapsed_seconds=$(sed -n 's/^elapsed_seconds=//p' "$tmp")
+peak_rss_kib=$(sed -n 's/^peak_rss_kib=//p' "$tmp")
+cpu_percent_raw=$(sed -n 's/^cpu_percent_raw=//p' "$tmp" | tr -d '%')
+case "$elapsed_seconds:$peak_rss_kib:$cpu_percent_raw" in
+	''|*[!0-9.:%-]*) echo 'profile-resource: malformed time output' >&2; exit 1 ;;
+esac
+elapsed_ms=$(awk -v value="$elapsed_seconds" 'BEGIN { printf "%d", (value * 1000) + 0.5 }')
+cpu_percent=$(awk -v value="$cpu_percent_raw" 'BEGIN { printf "%d", value + 0.5 }')
+
+if [ "$command_status" -eq 0 ]; then status=pass; else status=fail; fi
+umask 077
+{
+	printf 'status=%s\n' "$status"
+	printf 'elapsed_ms=%s\n' "$elapsed_ms"
+	printf 'peak_rss_kib=%s\n' "$peak_rss_kib"
+	printf 'cpu_percent=%s\n' "$cpu_percent"
+	printf 'command_status=%s\n' "$command_status"
+} > "$report"
+[ "$command_status" -eq 0 ] || exit "$command_status"

--- a/scripts/ci/profile-resource.sh
+++ b/scripts/ci/profile-resource.sh
@@ -21,8 +21,9 @@ parent=${report%/*}
 [ -d "$parent" ] || { echo 'profile-resource: report parent is missing' >&2; exit 2; }
 [ ! -L "$report" ] || { echo 'profile-resource: report must not be a symlink' >&2; exit 2; }
 
-tmp=$(mktemp "${TMPDIR:-/tmp}/wloc-resource-time.XXXXXX")
-trap 'rm -f "$tmp"' EXIT HUP INT TERM
+timeout_seconds=${WLOC_RESOURCE_TIMEOUT_SECONDS:-30}
+case "$timeout_seconds" in ''|*[!0-9]*) echo 'profile-resource: timeout must be a positive integer' >&2; exit 2 ;; esac
+[ "$timeout_seconds" -gt 0 ] || { echo 'profile-resource: timeout must be a positive integer' >&2; exit 2; }
 time_bin=
 if [ "${WLOC_RESOURCE_FORCE_PROCFS:-0}" != 1 ]; then
 	for candidate in /usr/bin/time "$(command -v gtime 2>/dev/null || true)"; do
@@ -32,6 +33,11 @@ if [ "${WLOC_RESOURCE_FORCE_PROCFS:-0}" != 1 ]; then
 		fi
 	done
 fi
+timeout_bin=$(command -v timeout || true)
+if [ -n "$time_bin" ] && [ -z "$timeout_bin" ] \
+	&& [ -r /proc/self/status ] && [ -r /proc/self/stat ]; then
+	time_bin=
+fi
 if [ -z "$time_bin" ]; then
 	python3=
 	if [ "${WLOC_RESOURCE_FORCE_PROCFS:-0}" != 1 ]; then
@@ -39,7 +45,7 @@ if [ -z "$time_bin" ]; then
 	fi
 	if [ -n "$python3" ]; then
 		exec "$python3" "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/profile-resource.py" \
-			--report "$report" -- "$@"
+			--timeout-seconds "$timeout_seconds" --report "$report" -- "$@"
 	fi
 	[ -r /proc/self/status ] && [ -r /proc/self/stat ] || {
 		echo 'profile-resource: GNU time, Python 3, or procfs is required' >&2
@@ -61,12 +67,20 @@ if [ -z "$time_bin" ]; then
 	last_ticks=$start_ticks
 	peak_rss_kib=$(proc_rss_kib "$pid")
 	case "$peak_rss_kib" in ''|*[!0-9]*) peak_rss_kib=0 ;; esac
+	timed_out=0
 	while kill -0 "$pid" 2>/dev/null; do
+		now=$(date +%s)
+		if [ $((now - started)) -ge "$timeout_seconds" ]; then
+			kill "$pid" 2>/dev/null || true
+			sleep 1
+			kill -9 "$pid" 2>/dev/null || true
+			timed_out=1
+		fi
 		rss=$(proc_rss_kib "$pid")
 		case "$rss" in ''|*[!0-9]*) rss=0 ;; esac
 		[ "$rss" -gt "$peak_rss_kib" ] && peak_rss_kib=$rss
 		last_ticks=$(proc_ticks "$pid")
-		sleep 1
+		sleep 0.1
 	done
 	wait "$pid"
 	command_status=$?
@@ -80,6 +94,8 @@ if [ -z "$time_bin" ]; then
 	delta_ticks=$((last_ticks - start_ticks))
 	[ "$delta_ticks" -gt 0 ] || delta_ticks=0
 	cpu_percent=$((delta_ticks * 100 / (elapsed_seconds * hz)))
+	[ "$peak_rss_kib" -gt 0 ] || command_status=125
+	[ "$timed_out" -eq 0 ] || command_status=124
 	if [ "$command_status" -eq 0 ]; then status=pass; else status=fail; fi
 	umask 077
 	{
@@ -91,9 +107,16 @@ if [ -z "$time_bin" ]; then
 	} > "$report"
 	exit "$command_status"
 fi
+
+[ -n "$timeout_bin" ] || {
+	echo 'profile-resource: timeout utility or procfs is required for GNU time mode' >&2
+	exit 127
+}
+tmp=$(mktemp "${TMPDIR:-/tmp}/wloc-resource-time.XXXXXX")
+trap 'rm -f "$tmp"' EXIT HUP INT TERM
 set +e
 "$time_bin" -f 'elapsed_seconds=%e\npeak_rss_kib=%M\ncpu_percent_raw=%P\n' \
-	"$@" >/dev/null 2>"$tmp"
+	"$timeout_bin" "$timeout_seconds" "$@" >/dev/null 2>"$tmp"
 command_status=$?
 set -e
 

--- a/scripts/ci/verify-package-budget.sh
+++ b/scripts/ci/verify-package-budget.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+budget=${WLOC_RESOURCE_BUDGET:-$repo_root/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf}
+package=${1:-}
+
+fail() { echo "verify-package-budget: $*" >&2; exit 1; }
+value() { sed -n "s/^$1=\([0-9][0-9]*\)$/\1/p" "$budget" | head -n 1; }
+
+[ -n "$package" ] || fail 'usage: verify-package-budget.sh PACKAGE'
+[ -f "$budget" ] && [ ! -L "$budget" ] || fail 'budget file must be a regular file'
+[ "$(sed -n 's/^format=//p' "$budget")" = wfc-resource-budget/v1 ] || fail 'unsupported budget format'
+[ -f "$package" ] && [ ! -L "$package" ] || fail 'package artifact must be a regular file'
+
+size=$(wc -c < "$package" | tr -d ' ')
+case "$size" in ''|*[!0-9]*) fail 'package size is not numeric' ;; esac
+limit=$(value integrated_package_max_bytes)
+[ -n "$limit" ] || fail 'integrated package limit is required'
+[ "$size" -le "$limit" ] || fail "integrated package exceeds ${limit} bytes: $size"
+printf 'package budget passed: bytes=%s\n' "$size"

--- a/scripts/ci/verify-resource-budgets.sh
+++ b/scripts/ci/verify-resource-budgets.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+budget=${WLOC_RESOURCE_BUDGET:-$repo_root/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf}
+artifact_dir=${WLOC_RESOURCE_ARTIFACT_DIR:-$repo_root/target/release}
+package=${WLOC_PACKAGE_ARTIFACT:-}
+
+fail() { echo "verify-resource-budgets: $*" >&2; exit 1; }
+value() { sed -n "s/^$1=\([0-9][0-9]*\)$/\1/p" "$budget" | head -n 1; }
+
+if [ ! -f "$budget" ] || [ -L "$budget" ]; then
+	fail 'budget file must be a regular file'
+fi
+[ "$(sed -n 's/^format=//p' "$budget")" = wfc-resource-budget/v1 ] || fail 'unsupported budget format'
+binary_limit=$(value runtime_binary_total_max_bytes)
+package_limit=$(value integrated_package_max_bytes)
+if [ -z "$binary_limit" ] || [ -z "$package_limit" ]; then
+	fail 'binary/package limits are required'
+fi
+
+total=0
+for binary in wloc-gateway-spike wloc-service wloc-ctl; do
+	path="$artifact_dir/$binary"
+	if [ ! -f "$path" ] || [ -L "$path" ]; then
+		fail "missing regular runtime binary: $path"
+	fi
+	size=$(wc -c < "$path" | tr -d ' ')
+	case "$size" in ''|*[!0-9]*) fail "invalid size for $binary" ;; esac
+	total=$((total + size))
+done
+[ "$total" -le "$binary_limit" ] || fail "runtime binaries exceed ${binary_limit} bytes: $total"
+
+if [ -n "$package" ]; then
+	if [ ! -f "$package" ] || [ -L "$package" ]; then
+		fail 'package artifact must be a regular file'
+	fi
+	package_size=$(wc -c < "$package" | tr -d ' ')
+	[ "$package_size" -le "$package_limit" ] || fail "integrated package exceeds ${package_limit} bytes: $package_size"
+fi
+
+report=${WLOC_RESOURCE_REPORT:-}
+if [ -n "$report" ]; then
+	[ -f "$report" ] || fail "resource report is missing: $report"
+	peak=$(sed -n 's/^peak_rss_kib=\([0-9][0-9]*\)$/\1/p' "$report")
+	cpu=$(sed -n 's/^cpu_percent=\([0-9][0-9]*\)$/\1/p' "$report")
+	startup=$(sed -n 's/^elapsed_ms=\([0-9][0-9]*\)$/\1/p' "$report")
+	if [ -z "$peak" ] || [ -z "$cpu" ] || [ -z "$startup" ]; then
+		fail 'resource report is incomplete'
+	fi
+	max_peak_kib=$(( $(value rss_peak_max_bytes) / 1024 ))
+	[ "$peak" -le "$max_peak_kib" ] || fail "peak RSS exceeds budget: ${peak}KiB"
+	[ "$cpu" -le "$(value cpu_probe_max_percent)" ] || fail "CPU exceeds budget: ${cpu}%"
+	[ "$startup" -le $(( $(value startup_max_seconds) * 1000 )) ] || fail "startup exceeds budget: ${startup}ms"
+fi
+
+if [ -n "$package" ]; then package_checked=yes; else package_checked=no; fi
+printf 'resource budgets passed: runtime_bytes=%s package_checked=%s\n' "$total" "$package_checked"

--- a/scripts/ci/verify-resource-budgets.sh
+++ b/scripts/ci/verify-resource-budgets.sh
@@ -13,6 +13,18 @@ if [ ! -f "$budget" ] || [ -L "$budget" ]; then
 	fail 'budget file must be a regular file'
 fi
 [ "$(sed -n 's/^format=//p' "$budget")" = wfc-resource-budget/v1 ] || fail 'unsupported budget format'
+for key in \
+	runtime_binary_total_max_bytes \
+	integrated_package_max_bytes \
+	persistent_state_max_bytes \
+	log_total_max_bytes \
+	cache_total_max_bytes \
+	max_profiles \
+	startup_max_seconds \
+	rss_peak_max_bytes \
+	cpu_probe_max_percent; do
+	value "$key" | grep -Eq '^[0-9]+$' || fail "invalid or missing budget: $key"
+done
 binary_limit=$(value runtime_binary_total_max_bytes)
 package_limit=$(value integrated_package_max_bytes)
 if [ -z "$binary_limit" ] || [ -z "$package_limit" ]; then
@@ -42,6 +54,8 @@ fi
 report=${WLOC_RESOURCE_REPORT:-}
 if [ -n "$report" ]; then
 	[ -f "$report" ] || fail "resource report is missing: $report"
+	grep -Fx 'status=pass' "$report" >/dev/null || fail 'resource report records a failed command'
+	grep -Fx 'command_status=0' "$report" >/dev/null || fail 'resource command did not exit successfully'
 	peak=$(sed -n 's/^peak_rss_kib=\([0-9][0-9]*\)$/\1/p' "$report")
 	cpu=$(sed -n 's/^cpu_percent=\([0-9][0-9]*\)$/\1/p' "$report")
 	startup=$(sed -n 's/^elapsed_ms=\([0-9][0-9]*\)$/\1/p' "$report")

--- a/scripts/ci/verify-rust.sh
+++ b/scripts/ci/verify-rust.sh
@@ -33,7 +33,7 @@ done
 cargo fmt --all -- --check
 cargo clippy --locked --all-targets -- -D warnings
 cargo llvm-cov --workspace --all-targets --locked --fail-under-lines 80
-cargo build --locked --release --bin wloc-gateway-spike
+cargo build --locked --release --bins
 cargo audit --file Cargo.lock
 cargo deny check
 
@@ -51,6 +51,7 @@ if [ "$size_bytes" -gt "$limit_bytes" ]; then
 fi
 
 "$binary" >/dev/null
+./scripts/ci/verify-resource-budgets.sh
 
 if grep -R "unsafe[[:space:]]*{" src >/dev/null 2>&1; then
   echo "unsafe marker found in Rust spike scope" >&2

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -29,6 +29,7 @@ done
 ./tests/scripts/test-support-bundle.sh
 ./tests/scripts/test-component-update.sh
 ./tests/scripts/test-existing-ax6s-package.sh
+./tests/scripts/test-resource-budgets.sh
 python3 -m unittest discover -s tests -p 'test_*.py'
 python3 ./scripts/scan_secrets.py
 

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -225,6 +225,8 @@ find "$stage/output" -type f \( -name '*.ipk' -o -name '*.apk' \) -exec cp {} "$
 count=$(find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
 	-o -name 'wificalling-location-gateway*.apk' \) | wc -l | tr -d ' ')
 [ "$count" -eq 2 ] || fail "expected two integrated packages, found $count"
+find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
+	-o -name 'wificalling-location-gateway*.apk' \) -exec "$repo_root/scripts/ci/verify-package-budget.sh" {} \;
 (cd "$out_dir" && shasum -a 256 wificalling-location-gateway*.ipk \
 	wificalling-location-gateway*.apk > SHA256SUMS)
 printf 'release packages: %s\n' "$out_dir"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -225,8 +225,11 @@ find "$stage/output" -type f \( -name '*.ipk' -o -name '*.apk' \) -exec cp {} "$
 count=$(find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
 	-o -name 'wificalling-location-gateway*.apk' \) | wc -l | tr -d ' ')
 [ "$count" -eq 2 ] || fail "expected two integrated packages, found $count"
-find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
-	-o -name 'wificalling-location-gateway*.apk' \) -exec "$repo_root/scripts/ci/verify-package-budget.sh" {} \;
+for package in "$out_dir"/wificalling-location-gateway*.ipk \
+	"$out_dir"/wificalling-location-gateway*.apk; do
+	[ -f "$package" ] || continue
+	"$repo_root/scripts/ci/verify-package-budget.sh" "$package"
+done
 (cd "$out_dir" && shasum -a 256 wificalling-location-gateway*.ipk \
 	wificalling-location-gateway*.apk > SHA256SUMS)
 printf 'release packages: %s\n' "$out_dir"

--- a/tests/scripts/resource-fixture.sh
+++ b/tests/scripts/resource-fixture.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+dd if=/dev/zero of="${TMPDIR:-/tmp}/wloc-resource-fixture.$$" bs=1024 count=64 >/dev/null 2>&1
+rm -f "${TMPDIR:-/tmp}/wloc-resource-fixture.$$"

--- a/tests/scripts/resource-fixture.sh
+++ b/tests/scripts/resource-fixture.sh
@@ -2,3 +2,6 @@
 set -eu
 dd if=/dev/zero of="${TMPDIR:-/tmp}/wloc-resource-fixture.$$" bs=1024 count=64 >/dev/null 2>&1
 rm -f "${TMPDIR:-/tmp}/wloc-resource-fixture.$$"
+# Keep the deterministic fixture alive long enough for procfs fallback
+# samplers to observe a non-zero RSS value on a busy CI host.
+sleep 1

--- a/tests/scripts/test-existing-ax6s-package.sh
+++ b/tests/scripts/test-existing-ax6s-package.sh
@@ -9,6 +9,7 @@ trap 'rm -f "$out" "$out.manifest" "$out.sig" "$data"' EXIT HUP INT TERM
 
 "$repo_root/scripts/build-luci-ipk.sh" "$version" ax6s-existing >/dev/null
 [ -s "$out.manifest" ]
+grep -F 'verify-package-budget.sh' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null
 grep -E '^Package-SHA256: [0-9a-f]{64}$' "$out.manifest" >/dev/null
 tar -xOf "$out" data.tar.gz > "$data" 2>/dev/null \
 	|| tar -xOf "$out" ./data.tar.gz > "$data"

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -47,6 +47,11 @@ if grep -F 'shasum -a 256 ./wificalling-location-gateway' "$builder" >/dev/null;
 fi
 grep -F 'luci-app-wificalling-gateway.json' "$builder" >/dev/null ||
 	fail 'integrated release builder must remove the standalone Gateway LuCI menu'
+grep -F 'verify-package-budget.sh' "$builder" >/dev/null ||
+	fail 'integrated release builder must enforce the package budget'
+if grep -F 'find "$out_dir" -maxdepth 1 -type f' "$builder" | grep -F 'verify-package-budget.sh' >/dev/null; then
+	fail 'package budget failure must propagate without find -exec'
+fi
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -5,10 +5,12 @@ repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 budget="$repo_root/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf"
 profile="$repo_root/scripts/ci/profile-resource.sh"
 gate="$repo_root/scripts/ci/verify-resource-budgets.sh"
+package_gate="$repo_root/scripts/ci/verify-package-budget.sh"
 
 [ -s "$budget" ]
 [ -x "$profile" ]
 [ -x "$gate" ]
+[ -x "$package_gate" ]
 
 for key in \
 	format \
@@ -19,7 +21,6 @@ for key in \
 	cache_total_max_bytes \
 	max_profiles \
 	startup_max_seconds \
-	rss_idle_max_bytes \
 	rss_peak_max_bytes \
 	cpu_probe_max_percent; do
 	grep -E "^${key}=" "$budget" >/dev/null || {
@@ -39,12 +40,21 @@ grep -E '^elapsed_ms=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^peak_rss_kib=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^cpu_percent=[0-9]+$' "$tmp/report.env" >/dev/null
 
+if [ -r /proc/self/status ] && [ -r /proc/self/stat ]; then
+	WLOC_RESOURCE_FORCE_PROCFS=1 \
+		WLOC_RESOURCE_REPORT="$tmp/procfs-report.env" \
+		"$profile" -- "$repo_root/tests/scripts/resource-fixture.sh"
+	grep -Fx 'status=pass' "$tmp/procfs-report.env" >/dev/null
+	grep -E '^peak_rss_kib=[0-9]+$' "$tmp/procfs-report.env" >/dev/null
+fi
+
 mkdir -p "$tmp/bins"
 for binary in wloc-gateway-spike wloc-service wloc-ctl; do
 	cp "$repo_root/tests/scripts/resource-fixture.sh" "$tmp/bins/$binary"
 done
 package="$tmp/package.ipk"
 cp "$repo_root/tests/scripts/resource-fixture.sh" "$package"
+"$package_gate" "$package" >/dev/null
 gate_report="$tmp/gate-report.env"
 sed 's/^cpu_percent=.*/cpu_percent=1/' "$tmp/report.env" > "$gate_report"
 WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" \
@@ -57,6 +67,43 @@ limit=$(sed -n 's/^runtime_binary_total_max_bytes=//p' "$budget")
 dd if=/dev/zero of="$oversized" bs=1 count=$((limit + 1)) >/dev/null 2>&1
 if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" "$gate" >/dev/null 2>&1; then
 	echo 'resource gate accepted oversized runtime binaries' >&2
+	exit 1
+fi
+
+package_limit=$(sed -n 's/^integrated_package_max_bytes=//p' "$budget")
+oversized_package="$tmp/oversized.ipk"
+dd if=/dev/zero of="$oversized_package" bs=1m \
+	count=$((package_limit / 1048576 + 1)) >/dev/null 2>&1
+if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" WLOC_PACKAGE_ARTIFACT="$oversized_package" "$gate" >/dev/null 2>&1; then
+	echo 'resource gate accepted oversized package' >&2
+	exit 1
+fi
+if "$package_gate" "$oversized_package" >/dev/null 2>&1; then
+	echo 'package gate accepted oversized package' >&2
+	exit 1
+fi
+
+peak_limit=$(( $(sed -n 's/^rss_peak_max_bytes=//p' "$budget") / 1024 + 1 ))
+cpu_limit=$(( $(sed -n 's/^cpu_probe_max_percent=//p' "$budget") + 1 ))
+startup_limit=$(( $(sed -n 's/^startup_max_seconds=//p' "$budget") * 1000 + 1 ))
+for field in peak_rss_kib cpu_percent elapsed_ms; do
+	case "$field" in
+		peak_rss_kib) value=$peak_limit ;;
+		cpu_percent) value=$cpu_limit ;;
+		elapsed_ms) value=$startup_limit ;;
+	esac
+	bad_report="$tmp/bad-$field.env"
+	sed "s/^$field=.*/$field=$value/" "$gate_report" > "$bad_report"
+	if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" WLOC_RESOURCE_REPORT="$bad_report" "$gate" >/dev/null 2>&1; then
+		echo "resource gate accepted over-budget $field" >&2
+		exit 1
+	fi
+done
+
+failed_report="$tmp/failed-report.env"
+sed -e 's/^status=.*/status=fail/' -e 's/^command_status=.*/command_status=1/' "$gate_report" > "$failed_report"
+if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" WLOC_RESOURCE_REPORT="$failed_report" "$gate" >/dev/null 2>&1; then
+	echo 'resource gate accepted a failed resource command' >&2
 	exit 1
 fi
 

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -40,6 +40,15 @@ grep -E '^elapsed_ms=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^peak_rss_kib=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^cpu_percent=[0-9]+$' "$tmp/report.env" >/dev/null
 
+timeout_report="$tmp/timeout-report.env"
+if WLOC_RESOURCE_TIMEOUT_SECONDS=1 WLOC_RESOURCE_REPORT="$timeout_report" \
+	"$profile" -- sleep 2 >/dev/null 2>&1; then
+	echo 'resource profiler accepted a timed-out command' >&2
+	exit 1
+fi
+grep -Fx 'status=fail' "$timeout_report" >/dev/null
+grep -Fx 'command_status=124' "$timeout_report" >/dev/null
+
 if [ -r /proc/self/status ] && [ -r /proc/self/stat ]; then
 	WLOC_RESOURCE_FORCE_PROCFS=1 \
 		WLOC_RESOURCE_REPORT="$tmp/procfs-report.env" \

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+budget="$repo_root/openwrt/files/usr/share/wificalling-location-gateway/resource-budget.conf"
+profile="$repo_root/scripts/ci/profile-resource.sh"
+gate="$repo_root/scripts/ci/verify-resource-budgets.sh"
+
+[ -s "$budget" ]
+[ -x "$profile" ]
+[ -x "$gate" ]
+
+for key in \
+	format \
+	runtime_binary_total_max_bytes \
+	integrated_package_max_bytes \
+	persistent_state_max_bytes \
+	log_total_max_bytes \
+	cache_total_max_bytes \
+	max_profiles \
+	startup_max_seconds \
+	rss_idle_max_bytes \
+	rss_peak_max_bytes \
+	cpu_probe_max_percent; do
+	grep -E "^${key}=" "$budget" >/dev/null || {
+		echo "resource budget is missing $key" >&2
+		exit 1
+	}
+done
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-resource-budget.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+WLOC_RESOURCE_REPORT="$tmp/report.env" \
+	"$profile" -- "$repo_root/tests/scripts/resource-fixture.sh"
+
+grep -Fx 'status=pass' "$tmp/report.env" >/dev/null
+grep -E '^elapsed_ms=[0-9]+$' "$tmp/report.env" >/dev/null
+grep -E '^peak_rss_kib=[0-9]+$' "$tmp/report.env" >/dev/null
+grep -E '^cpu_percent=[0-9]+$' "$tmp/report.env" >/dev/null
+
+printf 'resource budget tests passed\n'

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -39,4 +39,20 @@ grep -E '^elapsed_ms=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^peak_rss_kib=[0-9]+$' "$tmp/report.env" >/dev/null
 grep -E '^cpu_percent=[0-9]+$' "$tmp/report.env" >/dev/null
 
+mkdir -p "$tmp/bins"
+for binary in wloc-gateway-spike wloc-service wloc-ctl; do
+	cp "$repo_root/tests/scripts/resource-fixture.sh" "$tmp/bins/$binary"
+done
+WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" "$gate"
+
+oversized="$tmp/bins/wloc-service"
+limit=$(sed -n 's/^runtime_binary_total_max_bytes=//p' "$budget")
+dd if=/dev/zero of="$oversized" bs=1 count=$((limit + 1)) >/dev/null 2>&1
+if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" "$gate" >/dev/null 2>&1; then
+	echo 'resource gate accepted oversized runtime binaries' >&2
+	exit 1
+fi
+
+printf 'resource budget tests passed\n'
+
 printf 'resource budget tests passed\n'

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -47,7 +47,7 @@ if WLOC_RESOURCE_TIMEOUT_SECONDS=1 WLOC_RESOURCE_REPORT="$timeout_report" \
 	exit 1
 fi
 grep -Fx 'status=fail' "$timeout_report" >/dev/null
-grep -Fx 'command_status=124' "$timeout_report" >/dev/null
+grep -E '^command_status=[1-9][0-9]*$' "$timeout_report" >/dev/null
 
 if [ -r /proc/self/status ] && [ -r /proc/self/stat ]; then
 	WLOC_RESOURCE_FORCE_PROCFS=1 \

--- a/tests/scripts/test-resource-budgets.sh
+++ b/tests/scripts/test-resource-budgets.sh
@@ -43,7 +43,14 @@ mkdir -p "$tmp/bins"
 for binary in wloc-gateway-spike wloc-service wloc-ctl; do
 	cp "$repo_root/tests/scripts/resource-fixture.sh" "$tmp/bins/$binary"
 done
-WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" "$gate"
+package="$tmp/package.ipk"
+cp "$repo_root/tests/scripts/resource-fixture.sh" "$package"
+gate_report="$tmp/gate-report.env"
+sed 's/^cpu_percent=.*/cpu_percent=1/' "$tmp/report.env" > "$gate_report"
+WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" \
+	WLOC_PACKAGE_ARTIFACT="$package" \
+	WLOC_RESOURCE_REPORT="$gate_report" \
+	"$gate"
 
 oversized="$tmp/bins/wloc-service"
 limit=$(sed -n 's/^runtime_binary_total_max_bytes=//p' "$budget")
@@ -52,7 +59,5 @@ if WLOC_RESOURCE_ARTIFACT_DIR="$tmp/bins" "$gate" >/dev/null 2>&1; then
 	echo 'resource gate accepted oversized runtime binaries' >&2
 	exit 1
 fi
-
-printf 'resource budget tests passed\n'
 
 printf 'resource budget tests passed\n'


### PR DESCRIPTION
Closes #40

## Summary
- define versioned small-gateway budgets for runtime binaries, integrated packages, persistent state, logs, caches, profiles, startup, peak RSS, and CPU;
- add portable profiling with GNU time, Python, and lightweight `/proc` fallbacks, bounded timeouts, and explicit failure when sampling is invalid;
- enforce runtime/report gates in CI and package-size gates in both integrated OpenWrt release packaging and standalone AX6S/LuCI packaging;
- add negative regression coverage for oversized binaries/packages, failed reports, RSS, CPU, startup, profiler timeout, and a deterministic procfs sampling window;
- document the contract, TDD evidence, and redacted AX6S measurement procedure.

## Verification
- `./scripts/ci/verify.sh` passed through the final handoff gate after CI fixture and timeout-wrapper stabilization;
- standalone AX6S package, integrated release packaging, resource package, timeout, and procfs fixture tests passed;
- 80 Python tests passed;
- Rust line coverage 80.11% passed;
- cargo audit passed (existing duplicate socket2/windows-sys warnings remain);
- release runtime binaries: 2,958,912 bytes <= 8,388,608-byte budget.

## Acceptance and release hold
The host-side gates are complete, but this PR deliberately does not claim real AX6S hardware acceptance. Before merging/closing Issue #40 or publishing a persistent V2 release, run the redacted `docs/testing/AX6S_RESOURCE_EVIDENCE.template.md` on the actual staging router, including install, steady state, restart/reload, crash/recovery, update/rollback, and low-space cases. Idle RSS is an evidence observation; peak RSS is the portable hard gate. Adjust budgets only with a recorded project-lead decision.

## Safety / rollback
- fail-open behavior and exact assigned-device/approved-host/TCP 443 scope remain unchanged;
- UDP 500/4500 and the stable Gateway nftables table are untouched;
- rollback is to keep the PR unmerged until the AX6S evidence gate passes; no device state is changed by this PR.

Handoff capsule: `.handoffs/issue-40.md`
