### PR TITLE
feat: add Standard and Lite release variants

### DIFF
--- a/.handoffs/issue-66.md
+++ b/.handoffs/issue-66.md
@@ -3,7 +3,7 @@
 ## Identity and scope
 
 - Source agent ID: codex-release
-- Capabilities used: openwrt,test,ci,integration,release
+- Capabilities used: openwrt,test,ci,integration
 - Branch: codex/issue-66-standard-lite-variants-codex-release-20260823041333-31bfd3b9
 - Stable base commit: `81d5f6b`
 - Updated at (UTC): 2026-08-23

--- a/.handoffs/issue-66.md
+++ b/.handoffs/issue-66.md
@@ -1,0 +1,90 @@
+# Agent handoff: Issue 66
+
+## Identity and scope
+
+- Source agent ID: codex-release
+- Capabilities used: openwrt,test,ci,integration,release
+- Branch: codex/issue-66-standard-lite-variants-codex-release-20260823041333-31bfd3b9
+- Stable base commit: `81d5f6b`
+- Updated at (UTC): 2026-08-23
+- Credentials included: no
+
+## Objective
+
+Publish Standard and Lite installation variants of the same integrated 1.2.x
+product for all three existing package targets, while preserving the AX6S
+low-memory/low-storage behavior and both UCI configurations.
+
+## Completed
+
+- Added mutually exclusive Standard and Lite package metadata and six-asset
+  release planning. Standard uses the firmware sing-box; Lite explicitly
+  provides/replaces the sing-box package contract.
+- Added a hash-pinned Lite runtime packager. It keeps a compressed payload on
+  flash and installs a transparent wrapper that prepares one verified copy in
+  tmpfs for WCG and PassWall.
+- Applied `GOMAXPROCS=1`, `GOMEMLIMIT=24MiB`, and `GOGC=75` only to the Lite WCG
+  process; Standard inherits firmware defaults.
+- Expanded the pinned Docker matrix to eight Standard/Lite runtime rows and
+  verified executable ownership as well as install/start/socket/status.
+- Built all six r5 assets, installed the exact corrected AArch64 Lite asset on
+  AX6S, preserved both UCI files, cold-booted, and observed a real iPhone WLOC
+  request being synthesized.
+- Updated English/Chinese README, English/Chinese changelog notes, licensing,
+  checksums, and release evidence.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Packaging TDD | Passed |
+| Six package builds | Passed |
+| Eight-row Docker matrix | All installed, started, socket-ok, status-ok |
+| `./scripts/ci/verify.sh` | Passed; 69 Python tests, all Rust/JS suites, 81.40% line coverage, audits, licenses, secrets and repository gates |
+| AX6S Lite migration | UCI hashes unchanged; overlay ~20.4 MB free |
+| AX6S cold boot | tmpfs runtime hash, WCG/WLOC, nftables and status passed |
+| iPhone WLOC | Assigned device request observed and synthesized |
+
+Exact package hashes and hardware evidence are in
+`docs/testing/V1.2.2_R5_STANDARD_LITE_RELEASE.tdd.md`. The release directory
+also contains the upstream sing-box v1.12.25 source archive and its independent
+source checksum manifest for GPL compliance.
+
+## Failed attempts
+
+- The first dual-package SDK build placed conflicting package definitions in
+  one SDK config and hit a Kconfig dependency cycle. Standard and Lite now use
+  isolated SDK containers.
+- The first AX6S Lite candidate stored the 29.7 MB ELF directly on overlay and
+  left 2.8 MB free. It was rejected, replaced by compressed flash storage plus
+  tmpfs preparation, and never published.
+- Minimal rootfs opkg loses temporary architecture declarations after install;
+  ownership checks now read opkg's persisted file list.
+- OpenWrt 25 cannot fetch packages after its firewall starts under Docker
+  Desktop. APK dependencies are resolved before `init`, then runtime checks run
+  after boot.
+
+## Next executable steps
+
+1. Push the branch and open a stacked PR against Issue #64's stable branch.
+2. Wait for GitHub CI and obtain independent review.
+3. Publish tag `v1.2.2-r5` with six packages, `SHA256SUMS`, Docker report,
+   sing-box v1.12.25 source archive and `SOURCE_SHA256SUMS`.
+4. Re-download every release asset and verify both checksum manifests.
+
+## Capabilities required for the next Agent
+
+- openwrt
+- test
+- ci
+- release
+- security-review
+
+## Security and privacy notes
+
+- No credentials, node secrets, CA private keys, precise locations, or raw
+  device payloads are included.
+- Router evidence records only the existing test IP and public service host;
+  proxy credentials and exact saved UCI contents are excluded.
+- Interception scope, UDP 500/4500 behavior, WCG/WLOC schemas and Beta project
+  separation were not broadened.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.2.2-r5] - 2026-08-23
+
+Same-project Standard/Lite packaging and the AX6S low-memory release profile.
+
+### Added and changed
+
+- Every supported target now has two complete integrated assets. **Standard**
+  uses the firmware/feed `/usr/bin/sing-box`; **Lite** owns a pinned bundled
+  runtime. They share the same WCG/WLOC implementation, LuCI, UCI schema and
+  release line and intentionally conflict at package-manager level.
+- Lite stores sing-box as a gzip payload in persistent storage. A transparent
+  wrapper verifies its SHA-256 and expands one shared executable into tmpfs on
+  first use, so WCG and PassWall can reuse it without a second flash copy.
+- The AX6S Lite WCG process applies the validated `GOMAXPROCS=1`,
+  `GOMEMLIMIT=24MiB`, and `GOGC=75` profile. Standard retains firmware defaults.
+- The release matrix now validates six assets across eight Standard/Lite
+  runtime cases, including native OpenWrt 25 APK dependency resolution and
+  package ownership of the sing-box executable contract.
+
+### Hardware verification
+
+- Removed the old integrated and sing-box packages before installing the exact
+  r5 Lite AArch64 asset on Redmi AX6S. Both UCI files retained identical
+  SHA-256 values across the migration.
+- Cold boot regenerated the verified sing-box 1.12.25 runtime in `/tmp`, left
+  about 20.4 MB free on overlay, started WCG and WLOC, restored the scoped
+  nftables rule for `192.168.31.175`, and kept WLOC health at `intercepting`.
+- A real iPhone request to `gs-loc.apple.com/clls/wloc` was observed after the
+  reboot and its WLOC payload was synthesized successfully.
+
+### 中文说明
+
+- 同一 1.2.x 项目为三个目标各提供 Standard 与 Lite 两种完整安装规格，共六个
+  资产；两者不是产品分支，也不拆分 WCG 与 WLOC。
+- Standard 调用固件/软件源的 sing-box；Lite 自带固定哈希的运行时，并通过透明
+  包装器把压缩文件解压到 `/tmp`。WCG 与 PassWall 共用一份 tmpfs 可执行文件。
+- AX6S Lite 使用 24 MiB WCG 堆上限；真机迁移和冷启动后 overlay 仍余约
+  20.4 MB，两份 UCI 配置哈希不变，WCG/WLOC 与 nftables 正常。
+- 冷启动后已实际捕获 iPhone12 的 WLOC 请求并成功生成定位响应；Standard/Lite
+  的八项 Docker 安装、启动、Socket 与状态矩阵全部通过。
+
 ## [1.2.2-r4] - 2026-08-23
 
 Stable deleted-node fail-closed hotfix and release-baseline isolation.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.2.2--r4-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.2.2-r4)
+[![Release](https://img.shields.io/badge/release-v1.2.2--r5-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.2.2-r5)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -113,35 +113,33 @@ More detail: [WLOC Service API](docs/api/WLOC_SERVICE_API.md), [Threat model](do
 
 | Platform | Arch | Package manager | Current evidence | Status |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r4 asset installed on hardware; WCG/sing-box/WLOC/config/socket healthy; deleted-node fail-closed and restoration regression passed. Fresh carrier/iPhone traffic remains client-triggered | **Docker + router runtime passed** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r5 Lite asset installed and cold-booted; 20.4 MB overlay remained free; WCG/WLOC, tmpfs sing-box, nftables and config hashes passed; a real iPhone WLOC request was intercepted and synthesized | **Docker + router + iPhone WLOC passed** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker boot of init/ubus, integrated package install, service start, socket and v1 status checks | **Install matrix passed** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | Same as above | **Install matrix passed** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | Same, using native APK v3, not a renamed IPK | **Install matrix passed** |
 | Other OpenWrt / ImmortalWrt versions or CPUs | — | — | No device/SDK evidence yet | **Not verified** |
 
-The runtime packages contain a Rust ELF and **must match the router CPU architecture**; only the LuCI package is `all`/`noarch`. x86_64 packages are built with a pinned SDK; AX6S uses a separate AArch64 `cortex-a53` cross toolchain. The formal Docker matrix installs all three release assets. Docker verifies install and boot, not nftables, DNS, carrier, or iPhone end-to-end behavior.
+The runtime packages contain architecture-specific ELF files and **must match the router CPU architecture**. x86_64 packages are built with pinned SDKs; AX6S uses a separate AArch64 `cortex-a53` toolchain. The formal Docker matrix installs both runtime variants for all three targets (six assets, eight runtime cases). Docker verifies install and boot; the AX6S row adds real router and iPhone WLOC evidence.
 
 ## Installation
 
 ### Prerequisites
 
-- sing-box, firewall4/nftables, LuCI, and rpcd available.
+- firewall4/nftables, LuCI, and rpcd available. Standard additionally requires a firmware/feed `sing-box`; Lite bundles its own runtime.
 - A fixed DHCP address for the test iPhone and a correct node binding in the Gateway.
 - Router config backed up; WARP, Shadowrocket, or any other VPN on the phone stays off during router WLOC testing.
 - Install this project's CA only on the dedicated test device and verify the certificate fingerprint.
 
 ### 1. Choose the right package
 
-Release `v1.2.2-r4` provides exactly three integrated packages:
+Release `v1.2.2-r5` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Redmi AX6S: `wificalling-location-gateway_1.2.2-r4_aarch64_cortex-a53.ipk`
-- OpenWrt/iStoreOS 24.x x86_64: `wificalling-location-gateway_1.2.2-r4_x86_64.ipk`
-- OpenWrt 25.12 x86_64: `wificalling-location-gateway-1.2.2-r4.apk`
+- Standard: `wificalling-location-gateway_1.2.2-r5_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.2.2-r5_x86_64.ipk`, `wificalling-location-gateway-1.2.2-r5.apk`
+- Lite: `wificalling-location-gateway-lite_1.2.2-r5_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.2.2-r5_x86_64.ipk`, `wificalling-location-gateway-lite-1.2.2-r5.apk`
 
-It bundles the Wi‑Fi Calling Gateway, the WLOC service, control tools, and the unified LuCI; installing `luci-app-wificalling-gateway` or `wloc-service` separately is not required. On reinstall or upgrade, opkg preserves `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
+Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and applies the validated 24 MiB WCG heap profile. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
-Since the formal 1.0 line, every platform gets exactly one complete integrated package named
-`wificalling-location-gateway` — Wi‑Fi Calling Gateway, WLOC service, control tools, and unified LuCI in one; users no longer install component packages separately.
+The variant suffix changes runtime ownership only; it does not create a separate product or restore split component packages.
 
 Two ways to install:
 
@@ -165,24 +163,25 @@ Full instructions for both methods live in the
 [feed repository](https://github.com/smthdagg/wificalling-location-gateway-feed)
 (including the manual `.apk` install commands for OpenWrt 25.x).
 
-### 2. Redmi AX6S (single integrated IPK)
+### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.2.2-r4_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.2.2-r5_aarch64_cortex-a53.ipk
 ```
 
-Back up `/etc/config/wificalling-gateway` and `/etc/config/wloc-service` first. A normal in-place upgrade preserves both files. On storage-constrained AX6S units, remove an older package before installing this file, but do not delete the two saved UCI configurations. After installing, check both services below.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r5 Lite package replaces the separate sing-box package and owns its transparent wrapper.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.2.2-r4_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.2.2-r5_x86_64.ipk
+# Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.2.2-r4.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.2.2-r5.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -324,7 +323,7 @@ If this project helps your OpenWrt / Wi‑Fi Calling experiments, a Star, a repr
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE). Third-party dependencies and external projects remain under their own licenses; the MIT grant does not change the isolation requirements for external AGPL implementation material defined in the [clean-room boundary ADR](docs/adr/0001-license-boundary.md).
+This project's own code is licensed under the [MIT License](LICENSE). Lite release assets also contain sing-box under GPL-3.0-or-later; third-party components retain their own licenses. The MIT grant does not change the isolation requirements for external AGPL implementation material defined in the [clean-room boundary ADR](docs/adr/0001-license-boundary.md).
 
 The Wi‑Fi Calling Gateway component was originally a separate project. This repository integrates it as a single installable package; formal builds accept only published IPKs validated by identity, version, and SHA-256.
 
@@ -404,36 +403,33 @@ flowchart LR
 
 | 平台 | 架构 | 包管理器 | 当前证据 | 状态 |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r4 原包已在真机安装；WCG/sing-box/WLOC、配置与 Socket 健康；已通过“绑定节点缺失时停止并恢复”的真机回归。新的运营商/iPhone 流量仍需手机主动触发 | **Docker + 路由器运行时通过** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r5 Lite 原包已安装并冷启动；overlay 剩余 20.4 MB；WCG/WLOC、tmpfs sing-box、nftables 与配置哈希通过；已实际收到并处理 iPhone WLOC 请求 | **Docker + 路由器 + iPhone WLOC 通过** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker 中启动 init/ubus、安装集成包、启动服务、Socket 与 v1 状态检查 | **安装矩阵通过** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | 同上 | **安装矩阵通过** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | 同上，使用原生 APK v3，非改名 IPK | **安装矩阵通过** |
 | 其他 OpenWrt / ImmortalWrt 版本或 CPU | — | — | 尚无对应设备/SDK证据 | **未验证** |
 
-运行时包包含 Rust ELF，**必须与路由器 CPU 架构一致**；LuCI 包才是 `all`/`noarch`。x86_64 包由固定 SDK 构建，AX6S 使用单独的 AArch64 `cortex-a53` 交叉构建链；正式 Docker 矩阵会安装全部三个发布资产。Docker 验证的是安装与启动，不等同于 nftables、DNS、真实运营商或 iPhone 端到端测试。
+运行时包包含与架构相关的 ELF，**必须与路由器 CPU 架构一致**。x86_64 使用固定 SDK，AX6S 使用 AArch64 `cortex-a53` 工具链。正式矩阵覆盖三类目标的 Standard/Lite 两种规格，共六个资产、八个运行用例；AX6S 另有真机与 iPhone WLOC 证据。
 
 ## 安装
 
 ### 前置条件
 
-- sing-box、firewall4/nftables、LuCI 与 rpcd 可用。
+- firewall4/nftables、LuCI 与 rpcd 可用；Standard 还要求固件/软件源提供 sing-box，Lite 自带运行时。
 - 为测试 iPhone 建立固定 DHCP 地址，并在 Gateway 中绑定正确节点。
 - 已备份路由器配置；手机上的 WARP、Shadowrocket 或其他 VPN 在路由器 WLOC 测试期间保持关闭。
 - 只在专用测试设备上安装本项目 CA，并核对证书指纹。
 
 ### 1. 选择正确的安装包
 
-`v1.2.2-r4` 正式版提供且只提供三个集成安装包：
+`v1.2.2-r5` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Redmi AX6S：`wificalling-location-gateway_1.2.2-r4_aarch64_cortex-a53.ipk`
-- OpenWrt/iStoreOS 24.x x86_64：`wificalling-location-gateway_1.2.2-r4_x86_64.ipk`
-- OpenWrt 25.12 x86_64：`wificalling-location-gateway-1.2.2-r4.apk`
+- Standard：`wificalling-location-gateway_1.2.2-r5_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.2.2-r5_x86_64.ipk`、`wificalling-location-gateway-1.2.2-r5.apk`
+- Lite：`wificalling-location-gateway-lite_1.2.2-r5_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.2.2-r5_x86_64.ipk`、`wificalling-location-gateway-lite-1.2.2-r5.apk`
 
-该包内含 Wi‑Fi Calling Gateway、WLOC 服务、控制工具和统一 LuCI，不依赖另行安装 `luci-app-wificalling-gateway` 或 `wloc-service`。重新安装或升级时，opkg 会保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
+固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`，并为 WCG 应用已验证的 24 MiB 堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
-正式版 1.0 对每个平台只提供一个完整集成包。包名统一为
-`wificalling-location-gateway`，内含 Wi‑Fi Calling Gateway、WLOC
-服务、控制工具和统一 LuCI；不再要求用户分别安装组件包。
+Lite 后缀只表示运行时所有权与内存策略不同，不是新项目，也不会恢复拆分组件安装。
 
 两种安装方式：
 
@@ -457,24 +453,25 @@ opkg update && opkg install wificalling-location-gateway
 [feed 仓库](https://github.com/smthdagg/wificalling-location-gateway-feed)（含
 OpenWrt 25.x 的 `.apk` 手动安装命令）。
 
-### 2. Redmi AX6S（单一集成 IPK）
+### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.2.2-r4_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.2.2-r5_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份 `/etc/config/wificalling-gateway` 和 `/etc/config/wloc-service`。普通升级可直接覆盖并保留两份配置；AX6S 空间不足时，应先卸载旧软件包再安装本文件，但不要删除已保存的两份 UCI 配置。安装后按“验证服务”一节检查两个服务。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r5 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.2.2-r4_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.2.2-r5_x86_64.ipk
+# 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.2.2-r4.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.2.2-r5.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -616,6 +613,6 @@ docs/                        API、安全、部署、测试和双语用户教程
 
 ## 开源许可
 
-本项目采用 [MIT License](LICENSE)。第三方依赖及外部项目仍分别遵循其自身许可证；MIT 授权不改变 [clean-room 边界 ADR](docs/adr/0001-license-boundary.md) 中对外部 AGPL 实现材料的隔离要求。
+本项目自有代码采用 [MIT License](LICENSE)。Lite 发布资产还内含采用 GPL-3.0-or-later 的 sing-box；第三方组件继续遵循各自许可证。MIT 授权不改变 [clean-room 边界 ADR](docs/adr/0001-license-boundary.md) 对外部 AGPL 实现材料的隔离要求。
 
 Wi‑Fi Calling Gateway 组件原为独立项目。本仓库将其整合为单一安装包；正式包构建只接受经过身份、版本和 SHA-256 校验的已发布 IPK。

--- a/docs/testing/V1.2.2_R5_STANDARD_LITE_RELEASE.tdd.md
+++ b/docs/testing/V1.2.2_R5_STANDARD_LITE_RELEASE.tdd.md
@@ -1,0 +1,55 @@
+# v1.2.2-r5 Standard/Lite release evidence
+
+Date: 2026-08-23
+
+## Contract
+
+Standard and Lite are installation variants of the same stable integrated
+1.2.x product. Each contains WCG, WLOC, control tools, LuCI and the same UCI
+schema. Standard consumes the firmware `/usr/bin/sing-box`; Lite provides a
+conflicting bundled runtime and applies the AX6S memory profile.
+
+The release has three package targets and six assets: AArch64 cortex-a53 IPK,
+x86_64 OpenWrt/iStoreOS 24.x IPK, and x86_64 OpenWrt 25.x native APK v3.
+
+## TDD checkpoints
+
+- RED commit `68deac2`: package builders rejected the new variant contract.
+- GREEN commit `e24ebd1`: both builders produced mutually exclusive Standard
+  and Lite assets and the Docker matrix selected all six packages.
+- Hardware finding: the first Lite candidate wrote an uncompressed 29.7 MB
+  binary to overlay and left only 2.8 MB free. It was rejected before release.
+- Corrected GREEN commit `77ce558`: Lite persists a compressed, hash-pinned
+  payload and uses a transparent wrapper to prepare one copy in tmpfs.
+
+## Automated verification
+
+Focused packaging tests passed. The pinned Docker matrix passed eight rows:
+Standard and Lite on AX6S-compatible OpenWrt 24, OpenWrt 24 x86_64, iStoreOS
+24 x86_64 and OpenWrt 25 x86_64. Every row installed, started WLOC, created the
+control socket and returned `wloc.service/v1`. Lite also executed the bundled
+sing-box; Standard was proven not to own that file.
+
+## AX6S hardware evidence
+
+- Firmware: ImmortalWrt 24.10.6, AArch64.
+- Old integrated and sing-box packages were removed before Lite installation;
+  both UCI files were backed up and retained identical SHA-256 values.
+- Cold boot recreated sing-box 1.12.25 in tmpfs with SHA-256
+  `7f98d917eff2a91325635f9ffb02bee39e89368a7f74ebdce0ace96ed2b8dfeb`.
+- Overlay had about 20.4 MB free and tmpfs about 89.6 MB free after boot.
+- WCG ran with `GOMAXPROCS=1`, `GOMEMLIMIT=24MiB`, `GOGC=75`; WLOC was healthy
+  and the scoped nftables client set contained only `192.168.31.175`.
+- A post-boot iPhone request to `gs-loc.apple.com/clls/wloc` was observed and
+  synthesized successfully.
+
+## Release checksums
+
+```text
+e8c95fd69cb4a0d981312621cc7eecef01d0870cddbb812b843e16215c12586f  wificalling-location-gateway-lite_1.2.2-r5_aarch64_cortex-a53.ipk
+b9b7a62dd22d5b6b8a458be4d0de8f8ed9ef06b23b8039faf5682ce446e0f2f9  wificalling-location-gateway-lite_1.2.2-r5_x86_64.ipk
+15ad73f6494cd540e6dace52f933bb41cafae8fcd6771da0a374c4b62f7000fd  wificalling-location-gateway_1.2.2-r5_aarch64_cortex-a53.ipk
+abfce5d0a25846a68eedcf27d0250d0ff1fad1e3a194bac305054bb54a5aea33  wificalling-location-gateway_1.2.2-r5_x86_64.ipk
+60601abf61b29857896986ae3e744214e0d443c9a20c9343bfbda6523ce9f3fb  wificalling-location-gateway-1.2.2-r5.apk
+522c1f82279f3983dbf9fcc8ab966c5ba024a521b1a89dfc7beb86819a4d44a6  wificalling-location-gateway-lite-1.2.2-r5.apk
+```

--- a/findings.md
+++ b/findings.md
@@ -109,3 +109,11 @@
 - 桌面 host 仍无直接 aarch64-musl linker，但已用受控 Linux 容器中的 OpenWrt 官方工具链取得真实 AArch64 构建证据。
 - rustls 0.23.43 默认启用 aws-lc-rs、logging、post-quantum 偏好、std 和 TLS 1.2；资源 Spike 必须关闭 default features 并明确选择 crypto provider，否则体积与交叉构建成本会被默认依赖放大。
 - 已安装固定版本 `cargo-audit 0.22.2` 与 `cargo-deny 0.20.2`，并将漏洞、license、source 与重复依赖检查接入 Rust verifier/CI。
+# 2026-08-23 Issue #66 Standard/Lite release findings
+
+- 用户确认这不是项目分叉，而是同一项目的不同内存版本；Git 分支仅为临时开发/审核机制。
+- 现有“三平台”在发布脚本中实际是三类安装产物：AArch64 cortex-a53 IPK、x86_64 OpenWrt/iStoreOS 24.x IPK、x86_64 OpenWrt 25.x APK。Docker 运行矩阵额外把同一个 x86_64 IPK 分别装入 OpenWrt 与 iStoreOS，因此是 3 个资产目标、4 个运行环境。
+- 当前稳定链是 `origin/main -> Issue #62 -> Issue #64`；Issue #64 分支可从 main 快进，故 Issue #66 已从 main 建立并快进到 `81d5f6b`，没有混入 v2/Beta 代码。
+- 当前 standalone 和 SDK builder 都把 `sing-box` 写为硬依赖，健康脚本和运行脚本还硬编码 `/usr/bin/sing-box`。双变体实现必须先抽象运行时路径，再区分系统运行时与 tiny payload。
+- 不能让 Lite 无条件覆盖固件的 `/usr/bin/sing-box`：这会破坏已有 PassWall/系统包的所有权。Lite 应使用项目私有、架构受检的运行时路径；如需与 PassWall 共享 tiny，必须以显式兼容方案处理，不能偷偷替换系统文件。
+- 版本切换必须用 package conflict/provides/replaces 与 conffiles 共同保证“不可共存但配置不丢失”；安装、升级、降级和回滚都需要离线测试。

--- a/findings.md
+++ b/findings.md
@@ -115,5 +115,7 @@
 - 现有“三平台”在发布脚本中实际是三类安装产物：AArch64 cortex-a53 IPK、x86_64 OpenWrt/iStoreOS 24.x IPK、x86_64 OpenWrt 25.x APK。Docker 运行矩阵额外把同一个 x86_64 IPK 分别装入 OpenWrt 与 iStoreOS，因此是 3 个资产目标、4 个运行环境。
 - 当前稳定链是 `origin/main -> Issue #62 -> Issue #64`；Issue #64 分支可从 main 快进，故 Issue #66 已从 main 建立并快进到 `81d5f6b`，没有混入 v2/Beta 代码。
 - 当前 standalone 和 SDK builder 都把 `sing-box` 写为硬依赖，健康脚本和运行脚本还硬编码 `/usr/bin/sing-box`。双变体实现必须先抽象运行时路径，再区分系统运行时与 tiny payload。
-- 不能让 Lite 无条件覆盖固件的 `/usr/bin/sing-box`：这会破坏已有 PassWall/系统包的所有权。Lite 应使用项目私有、架构受检的运行时路径；如需与 PassWall 共享 tiny，必须以显式兼容方案处理，不能偷偷替换系统文件。
+- Lite 通过包管理器显式 `Provides/Replaces/Conflicts` 接管 sing-box 契约，不能与 Standard 或独立 sing-box 包共存；`/usr/bin/sing-box` 是透明包装器，WCG 与 PassWall 共享经哈希校验的 `/tmp/sing-box-lite`，不是静默覆盖未知系统文件。
+- 首个直接写入 29.7 MB ELF 的 AX6S 候选使 overlay 仅余 2.8 MB，已阻断并废弃。压缩驻留修正版清理旧重复文件后恢复到约 20.4 MB 可用，并通过冷启动。
+- AX6S 冷启动后实际记录到 `192.168.31.175` 请求 `gs-loc.apple.com/clls/wloc`，WLOC 响应已成功生成，状态保持 `intercepting`。
 - 版本切换必须用 package conflict/provides/replaces 与 conffiles 共同保证“不可共存但配置不丢失”；安装、升级、降级和回滚都需要离线测试。

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -97,6 +97,12 @@ start_service() {
 	/usr/bin/sing-box check -c "$RUNDIR/sing-box.json" || { logger -t "$APP" "sing-box rejected generated configuration"; return 1; }
 	/usr/libexec/$APP/firewall.sh start "$RUNDIR/clients" || { logger -t "$APP" "firewall setup failed"; /usr/libexec/$APP/firewall.sh stop "$RUNDIR/clients"; return 1; }
 	procd_open_instance sing-box
+	# The Lite package owns /usr/bin/sing-box and marks the runtime profile.
+	# Standard deliberately inherits the firmware/package defaults so routers
+	# with ample memory are not constrained by AX6S-specific limits.
+	if [ "$(cat /usr/share/wificalling-location-gateway/runtime-variant 2>/dev/null)" = lite ]; then
+		procd_set_param env "GOMAXPROCS=1" "GOMEMLIMIT=24MiB" "GOGC=75"
+	fi
 	procd_set_param command /usr/bin/sing-box run -c "$RUNDIR/sing-box.json"
 	procd_set_param respawn 3600 5 5
 	procd_set_param limits nofile="65535 65535"

--- a/progress.md
+++ b/progress.md
@@ -99,3 +99,10 @@
 - `cargo-audit 0.22.2` 和 `cargo-deny 0.20.2` 已安装并接入 Rust verifier/CI；RustSec 扫描及 advisories/bans/licenses/sources 全部通过。
 - 用户授权建立专门 Rust migration 任务并提交开发；已创建 GitHub Issue #15 和 `cap:rust` 标签。
 - 已切换到 `codex/issue-15-rust-migration`，并以 Agent ID `codex-rust-migration` 取得 240 分钟 CAS 租约。
+# 2026-08-23 Issue #66 Standard/Lite variants
+
+- 用户授权进入实际打包、测试和发布，并确认 Standard/Lite 属于同一项目，不是新的产品分支。
+- 创建 GitHub Issue #66，范围为两种内存变体 × 三类平台，共六个发布产物。
+- Agent `codex-release` 以 `openwrt,test,ci,integration` 能力取得 480 分钟租约并创建独立工作树。
+- 工作分支已从 `origin/main` 快进到 Issue #64 稳定链提交 `81d5f6b`，后续以 1.2.x 为唯一基线。
+- 已采用 planning-with-files、TDD 和 production-audit；下一步先写 packaging RED 测试，不先改构建实现。

--- a/progress.md
+++ b/progress.md
@@ -106,3 +106,7 @@
 - Agent `codex-release` 以 `openwrt,test,ci,integration` 能力取得 480 分钟租约并创建独立工作树。
 - 工作分支已从 `origin/main` 快进到 Issue #64 稳定链提交 `81d5f6b`，后续以 1.2.x 为唯一基线。
 - 已采用 planning-with-files、TDD 和 production-audit；下一步先写 packaging RED 测试，不先改构建实现。
+- packaging RED `68deac2`、双规格 GREEN `e24ebd1` 和 tmpfs 修复 `77ce558` 已提交。
+- 六个 r5 资产已生成，固定摘要 Docker 矩阵的八个 Standard/Lite 用例全部通过。
+- 首个 AX6S Lite 候选因直接落盘导致 overlay 仅余 2.8 MB，被生产审计否决；修正版改为 gzip 驻 flash、透明解压到 `/tmp`。
+- 修正版已在 AX6S 卸载旧整合包与 sing-box 后安装；两份 UCI 哈希保持不变，冷启动后 overlay 约余 20.4 MB，WCG/WLOC/nftables 正常，并捕获和处理了真实 iPhone WLOC 请求。

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -10,10 +10,22 @@ out_dir="$root/dist"
 architecture=all
 output_package=$package
 description='Unified LuCI UI for Wi-Fi Calling and WLOC location controls.'
-if [ "$dependency_mode" = ax6s-standalone ]; then
+license=MIT
+variant=standard
+if [ "$dependency_mode" = ax6s-lite ]; then
+	variant=lite
+	license='MIT, GPL-3.0-or-later'
+	architecture=aarch64_cortex-a53
+	output_package=wificalling-location-gateway-lite
+	description='Complete Wi-Fi Calling Gateway and WLOC service with bundled sing-box Lite.'
+elif [ "$dependency_mode" = ax6s-standard ] || [ "$dependency_mode" = ax6s-standalone ]; then
 	architecture=aarch64_cortex-a53
 	output_package=wificalling-location-gateway
-	description='Complete Wi-Fi Calling Gateway and WLOC service with unified LuCI.'
+	if [ "$dependency_mode" = ax6s-standard ]; then
+		description='Complete Wi-Fi Calling Gateway and WLOC service using the system sing-box.'
+	else
+		description='Complete Wi-Fi Calling Gateway and WLOC service with unified LuCI.'
+	fi
 fi
 out="$out_dir/${output_package}_${version}_${architecture}.ipk"
 stage=$(mktemp -d "${TMPDIR:-/tmp}/wloc-luci-ipk.XXXXXX")
@@ -41,6 +53,7 @@ mkdir -p "$stage/control" "$stage/data" "$out_dir"
 cp -R "$source_dir/." "$stage/data/"
 provides=
 replaces=
+conflicts=
 
 archive_is_safe() {
 	archive=$1
@@ -63,11 +76,11 @@ case "$dependency_mode" in
 	production)
 		depends='wloc-service, luci-app-wificalling-gateway, luci-base, rpcd-mod-rpcsys'
 		;;
-	ax6s-existing|ax6s-full|ax6s-standalone)
+	ax6s-existing|ax6s-full|ax6s-standalone|ax6s-standard|ax6s-lite)
 		# The validated AX6S predates package registration for its already-running
 		# wloc-service. The existing/full variants retain the external Gateway
 		# package dependency; standalone safely merges a pinned Gateway IPK.
-		if [ "$dependency_mode" = ax6s-standalone ]; then
+		if [ "$dependency_mode" = ax6s-standalone ] || [ "$dependency_mode" = ax6s-standard ] || [ "$dependency_mode" = ax6s-lite ]; then
 			gateway_ipk=${GATEWAY_IPK:-}
 			gateway_sha=${GATEWAY_IPK_SHA256:-}
 			[ -f "$gateway_ipk" ] || { echo "missing Gateway IPK: $gateway_ipk" >&2; exit 2; }
@@ -102,9 +115,17 @@ case "$dependency_mode" in
 			# Gateway views after the verified Gateway payload is merged.
 			cp -R "$source_dir/." "$stage/data/"
 			rm -f "$stage/data/usr/share/luci/menu.d/luci-app-wificalling-gateway.json"
-			depends='luci-base, rpcd-mod-rpcsys, sing-box, nftables, firewall4, kmod-nft-tproxy, kmod-nft-socket, ip-full'
-			provides='luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
-			replaces='luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
+			if [ "$variant" = lite ]; then
+				depends='luci-base, rpcd-mod-rpcsys, ca-bundle, kmod-inet-diag, kmod-netlink-diag, kmod-tun, nftables, firewall4, kmod-nft-tproxy, kmod-nft-socket, ip-full'
+				provides='wificalling-location-gateway, sing-box, luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
+				replaces='wificalling-location-gateway, sing-box, luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
+				conflicts='wificalling-location-gateway, sing-box'
+			else
+				depends='luci-base, rpcd-mod-rpcsys, sing-box, nftables, firewall4, kmod-nft-tproxy, kmod-nft-socket, ip-full'
+				provides='luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
+				replaces='luci-app-wificalling-location-gateway, luci-app-wificalling-gateway, wloc-service'
+				conflicts='wificalling-location-gateway-lite'
+			fi
 		else
 			depends='luci-app-wificalling-gateway, luci-base, rpcd-mod-rpcsys'
 			rm -f "$stage/data/www/luci-static/resources/view/wificalling-gateway/overview.js"
@@ -160,7 +181,7 @@ with open(path, "w", encoding="utf-8") as handle:
     json.dump(menu, handle, ensure_ascii=False, indent=2)
     handle.write("\n")
 PY
-		if [ "$dependency_mode" = ax6s-full ] || [ "$dependency_mode" = ax6s-standalone ]; then
+		if [ "$dependency_mode" = ax6s-full ] || [ "$dependency_mode" = ax6s-standalone ] || [ "$dependency_mode" = ax6s-standard ] || [ "$dependency_mode" = ax6s-lite ]; then
 			service_bin=${WLOC_SERVICE_BIN:-$out_dir/wloc-service_aarch64-openwrt-linux-musl}
 			ctl_bin=${WLOC_CTL_BIN:-$out_dir/wloc-ctl_aarch64-openwrt-linux-musl}
 			[ -x "$service_bin" ] || { echo "missing WLOC service binary: $service_bin" >&2; exit 2; }
@@ -174,7 +195,27 @@ PY
 			cp "$service_bin" "$stage/data/usr/sbin/wloc-service"
 			cp "$ctl_bin" "$stage/data/usr/sbin/wloc-ctl"
 			chmod 0755 "$stage/data/etc/init.d/wloc-service" "$stage/data/usr/sbin/"*
-			if [ "$dependency_mode" = ax6s-standalone ]; then
+			mkdir -p "$stage/data/usr/share/wificalling-location-gateway"
+			printf '%s\n' "$variant" > "$stage/data/usr/share/wificalling-location-gateway/runtime-variant"
+			if [ "$variant" = lite ]; then
+				tiny_bin=${SINGBOX_LITE_BIN:-}
+				tiny_sha=${SINGBOX_LITE_SHA256:-}
+				[ -x "$tiny_bin" ] || { echo "missing sing-box Lite binary: $tiny_bin" >&2; exit 2; }
+				[ -n "$tiny_sha" ] || { echo 'SINGBOX_LITE_SHA256 is required' >&2; exit 2; }
+				actual_tiny_sha=$(sha256_file "$tiny_bin")
+				[ "$actual_tiny_sha" = "$tiny_sha" ] || {
+					echo "sing-box Lite SHA-256 mismatch: expected $tiny_sha, got $actual_tiny_sha" >&2
+					exit 2
+				}
+				case "$(file "$tiny_bin" 2>/dev/null)" in
+					*ELF*ARM\ aarch64*) ;;
+					*) echo 'sing-box Lite binary must be an AArch64 ELF' >&2; exit 2 ;;
+				esac
+				mkdir -p "$stage/data/usr/bin"
+				cp "$tiny_bin" "$stage/data/usr/bin/sing-box"
+				chmod 0755 "$stage/data/usr/bin/sing-box"
+			fi
+			if [ "$dependency_mode" = ax6s-standalone ] || [ "$dependency_mode" = ax6s-standard ] || [ "$dependency_mode" = ax6s-lite ]; then
 				printf '%s\n' \
 					'/etc/config/wificalling-gateway' \
 					'/etc/config/wloc-service' > "$stage/control/conffiles"
@@ -213,11 +254,12 @@ printf '%s\n' \
 	"Depends: $depends" \
 	'Section: luci' \
 	'Priority: optional' \
-	'License: MIT' \
+	"License: $license" \
 	"Description: $description" \
 	> "$stage/control/control"
 [ -z "$provides" ] || printf 'Provides: %s\n' "$provides" >> "$stage/control/control"
 [ -z "$replaces" ] || printf 'Replaces: %s\n' "$replaces" >> "$stage/control/control"
+[ -z "$conflicts" ] || printf 'Conflicts: %s\n' "$conflicts" >> "$stage/control/control"
 printf '2.0\n' > "$stage/debian-binary"
 
 make_archive "$stage/control" "$stage/control.tar.gz" .

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -211,9 +211,8 @@ PY
 					*ELF*ARM\ aarch64*) ;;
 					*) echo 'sing-box Lite binary must be an AArch64 ELF' >&2; exit 2 ;;
 				esac
-				mkdir -p "$stage/data/usr/bin"
-				cp "$tiny_bin" "$stage/data/usr/bin/sing-box"
-				chmod 0755 "$stage/data/usr/bin/sing-box"
+				"$root/scripts/openwrt/package-singbox-lite.sh" \
+					"$stage/data" "$tiny_bin" "$tiny_sha"
 			fi
 			if [ "$dependency_mode" = ax6s-standalone ] || [ "$dependency_mode" = ax6s-standard ] || [ "$dependency_mode" = ax6s-lite ]; then
 				printf '%s\n' \

--- a/scripts/ci/verify.sh
+++ b/scripts/ci/verify.sh
@@ -20,6 +20,7 @@ done
 ./tests/scripts/test-agent-handoff-tools.sh
 ./tests/scripts/test-verify-rust-openwrt.sh
 ./tests/scripts/test-openwrt-release-packaging.sh
+./tests/scripts/test-package-variants.sh
 ./tests/scripts/test-standalone-ax6s-package.sh
 ./tests/scripts/test-release-version.sh
 ./tests/scripts/test-monitor-temp-cleanup.sh

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -213,9 +213,8 @@ case ",$variants," in
 		lite_dir="$stage/input/wificalling-location-gateway-lite"
 		cp -R "$package_dir" "$lite_dir"
 		printf '%s\n' lite > "$lite_dir/files/usr/share/wificalling-location-gateway/runtime-variant"
-		mkdir -p "$lite_dir/files/usr/bin"
-		cp "$singbox_lite_bin" "$lite_dir/files/usr/bin/sing-box"
-		chmod 0755 "$lite_dir/files/usr/bin/sing-box"
+		"$repo_root/scripts/openwrt/package-singbox-lite.sh" \
+			"$lite_dir/files" "$singbox_lite_bin" "$singbox_lite_sha256"
 		cat > "$lite_dir/Makefile" <<EOF
 include \$(TOPDIR)/rules.mk
 PKG_NAME:=wificalling-location-gateway-lite

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -14,6 +14,9 @@ gateway_ipk=
 gateway_sha256=
 out_dir="$repo_root/dist/openwrt-release"
 plan_only=0
+variants=standard
+singbox_lite_bin=
+singbox_lite_sha256=
 
 fail() {
 	printf 'build-release-packages: %s\n' "$*" >&2
@@ -33,6 +36,9 @@ Options:
   --gateway-ipk PATH         Pinned stable Gateway/integrated IPK (required to build)
   --gateway-sha256 SHA256    Expected base IPK digest (required to build)
   --out-dir PATH             Output directory
+  --variants LIST            standard, lite, or standard,lite (default: standard)
+  --singbox-lite-bin PATH    Architecture-matched sing-box Lite binary
+  --singbox-lite-sha256 SHA  Expected Lite binary digest
   --plan                     Print the immutable build plan without Docker
 EOF
 }
@@ -47,6 +53,9 @@ while [ "$#" -gt 0 ]; do
 		--gateway-ipk) [ "$#" -ge 2 ] || fail 'missing --gateway-ipk value'; gateway_ipk=$2; shift 2 ;;
 		--gateway-sha256) [ "$#" -ge 2 ] || fail 'missing --gateway-sha256 value'; gateway_sha256=$2; shift 2 ;;
 		--out-dir) [ "$#" -ge 2 ] || fail 'missing --out-dir value'; out_dir=$2; shift 2 ;;
+		--variants) [ "$#" -ge 2 ] || fail 'missing --variants value'; variants=$2; shift 2 ;;
+		--singbox-lite-bin) [ "$#" -ge 2 ] || fail 'missing --singbox-lite-bin value'; singbox_lite_bin=$2; shift 2 ;;
+		--singbox-lite-sha256) [ "$#" -ge 2 ] || fail 'missing --singbox-lite-sha256 value'; singbox_lite_sha256=$2; shift 2 ;;
 		--plan) plan_only=1; shift ;;
 		-h|--help) usage; exit 0 ;;
 		*) fail "unknown argument: $1" ;;
@@ -65,12 +74,40 @@ esac
 [ -x "$service_bin" ] || fail "service binary is not executable: $service_bin"
 [ -x "$ctl_bin" ] || fail "control binary is not executable: $ctl_bin"
 
+case "$variants" in
+	standard|lite|standard,lite) ;;
+	*) fail 'variants must be standard, lite, or standard,lite' ;;
+esac
+case ",$variants," in
+	*,lite,*)
+		[ -n "$singbox_lite_bin" ] || fail '--singbox-lite-bin is required for the Lite variant'
+		[ -x "$singbox_lite_bin" ] || fail "sing-box Lite binary is not executable: $singbox_lite_bin"
+		[ -n "$singbox_lite_sha256" ] || fail '--singbox-lite-sha256 is required for the Lite variant'
+		case "$singbox_lite_sha256" in *[!0-9a-fA-F]*|'') fail 'invalid sing-box Lite SHA-256' ;; esac
+		[ "${#singbox_lite_sha256}" -eq 64 ] || fail 'invalid sing-box Lite SHA-256'
+		actual_lite_sha=$(shasum -a 256 "$singbox_lite_bin" | awk '{print $1}')
+		[ "$actual_lite_sha" = "$singbox_lite_sha256" ] || fail 'sing-box Lite SHA-256 mismatch'
+		;;
+esac
+
 cat <<EOF
 24.10 SDK: $OPENWRT_24_SDK
 25.12 SDK: $OPENWRT_25_SDK
-24.10 integrated: wificalling-location-gateway_${version}-r${release}_${arch}.ipk
-25.12 integrated: wificalling-location-gateway-${version}-r${release}.apk (arch: ${arch})
 EOF
+case ",$variants," in
+	*,standard,*)
+		printf '24.10 standard: wificalling-location-gateway_%s-r%s_%s.ipk\n' "$version" "$release" "$arch"
+		printf '25.12 standard: wificalling-location-gateway-%s-r%s.apk (arch: %s)\n' "$version" "$release" "$arch"
+		printf '%s\n' 'standard runtime: firmware /usr/bin/sing-box'
+		;;
+esac
+case ",$variants," in
+	*,lite,*)
+		printf '24.10 Lite: wificalling-location-gateway-lite_%s-r%s_%s.ipk\n' "$version" "$release" "$arch"
+		printf '25.12 Lite: wificalling-location-gateway-lite-%s-r%s.apk (arch: %s)\n' "$version" "$release" "$arch"
+		printf 'lite runtime: %s\n' "$singbox_lite_sha256"
+		;;
+esac
 
 [ "$plan_only" -eq 0 ] || exit 0
 command -v docker >/dev/null 2>&1 || fail 'docker is required'
@@ -121,6 +158,8 @@ for helper in export-mobileconfig.sh wloc-redirect-sync.sh wloc-refresh-set.sh w
 	cp "$repo_root/openwrt/files/usr/sbin/$helper" "$package_dir/files/usr/sbin/$helper"
 done
 chmod 0755 "$package_dir/files/usr/sbin/"* "$package_dir/files/etc/init.d/"*
+mkdir -p "$package_dir/files/usr/share/wificalling-location-gateway"
+printf '%s\n' standard > "$package_dir/files/usr/share/wificalling-location-gateway/runtime-variant"
 
 cat > "$package_dir/Makefile" <<EOF
 include \$(TOPDIR)/rules.mk
@@ -134,7 +173,9 @@ define Package/wificalling-location-gateway
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Integrated Wi-Fi Calling and WLOC Location Gateway
+  EXTRA_DEPENDS:=luci-base (>=0), rpcd-mod-rpcsys (>=0), sing-box (>=0), nftables (>=0), firewall4 (>=0), kmod-nft-tproxy (>=0), kmod-nft-socket (>=0), ip-full (>=0)
   PROVIDES:=wloc-service luci-app-wificalling-location-gateway luci-app-wificalling-gateway
+  CONFLICTS:=wificalling-location-gateway-lite
 endef
 define Package/wificalling-location-gateway/description
   Complete Wi-Fi Calling Gateway, WLOC service, control client, and unified LuCI UI.
@@ -167,30 +208,103 @@ endef
 \$(eval \$(call BuildPackage,wificalling-location-gateway))
 EOF
 
+case ",$variants," in
+	*,lite,*)
+		lite_dir="$stage/input/wificalling-location-gateway-lite"
+		cp -R "$package_dir" "$lite_dir"
+		printf '%s\n' lite > "$lite_dir/files/usr/share/wificalling-location-gateway/runtime-variant"
+		mkdir -p "$lite_dir/files/usr/bin"
+		cp "$singbox_lite_bin" "$lite_dir/files/usr/bin/sing-box"
+		chmod 0755 "$lite_dir/files/usr/bin/sing-box"
+		cat > "$lite_dir/Makefile" <<EOF
+include \$(TOPDIR)/rules.mk
+PKG_NAME:=wificalling-location-gateway-lite
+PKG_VERSION:=$version
+PKG_RELEASE:=$release
+PKG_MAINTAINER:=wificalling-location-gateway maintainers
+PKG_LICENSE:=MIT GPL-3.0-or-later
+include \$(INCLUDE_DIR)/package.mk
+define Package/wificalling-location-gateway-lite
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=Integrated Wi-Fi Calling and WLOC Location Gateway Lite
+  EXTRA_DEPENDS:=luci-base (>=0), rpcd-mod-rpcsys (>=0), ca-bundle (>=0), kmod-inet-diag (>=0), kmod-netlink-diag (>=0), kmod-tun (>=0), nftables (>=0), firewall4 (>=0), kmod-nft-tproxy (>=0), kmod-nft-socket (>=0), ip-full (>=0)
+  PROVIDES:=wificalling-location-gateway sing-box wloc-service luci-app-wificalling-location-gateway luci-app-wificalling-gateway
+  CONFLICTS:=wificalling-location-gateway sing-box
+endef
+define Package/wificalling-location-gateway-lite/description
+  Complete Wi-Fi Calling Gateway and WLOC with the bundled low-memory sing-box runtime.
+endef
+define Build/Compile
+endef
+define Package/wificalling-location-gateway-lite/conffiles
+/etc/config/wificalling-gateway
+/etc/config/wloc-service
+endef
+define Package/wificalling-location-gateway-lite/install
+	\$(CP) ./files/. \$(1)/
+endef
+define Package/wificalling-location-gateway-lite/postinst
+#!/bin/sh
+[ -n "\$\${IPKG_INSTROOT:-}" ] && exit 0
+for required in /usr/bin/sing-box /usr/sbin/nft /usr/sbin/ip /usr/libexec/rpcd; do
+  [ -e "\$\$required" ] || echo "wificalling-location-gateway-lite: prerequisite missing: \$\$required" >&2
+done
+/etc/init.d/wificalling-gateway enable >/dev/null 2>&1 || true
+/etc/init.d/wloc-service enable >/dev/null 2>&1 || true
+mkdir -p /var/run/wificalling-gateway
+chmod 0700 /var/run/wificalling-gateway
+/etc/init.d/wificalling-gateway restart >/dev/null 2>&1 || true
+/etc/init.d/wloc-service restart >/dev/null 2>&1 || true
+rm -f /tmp/luci-indexcache.*
+/etc/init.d/rpcd reload >/dev/null 2>&1 || true
+exit 0
+endef
+\$(eval \$(call BuildPackage,wificalling-location-gateway-lite))
+EOF
+		;;
+esac
+
 build_with_sdk() {
 	label=$1
 	image=$2
-	out="$stage/output/$label"
+	variant=$3
+	case "$variant" in
+		standard) package=wificalling-location-gateway ;;
+		lite) package=wificalling-location-gateway-lite ;;
+		*) fail "unsupported build variant: $variant" ;;
+	esac
+	out="$stage/output/$label-$variant"
 	mkdir -p "$out"
 	chmod 0777 "$out"
 	docker image inspect "$image" >/dev/null 2>&1 ||
 		fail "pinned SDK image missing; pull explicitly: docker pull --platform linux/amd64 $image"
 	docker run --rm --pull never --platform linux/amd64 --network none \
 		-v "$stage/input:/input:ro" -v "$out:/output" \
-		--entrypoint /bin/bash "$image" -ec '
-			rm -rf /builder/package/wificalling-location-gateway
-			cp -a /input/wificalling-location-gateway /builder/package/
-			printf "%s\n" "CONFIG_PACKAGE_wificalling-location-gateway=m" >> /builder/.config
+		-e WLG_PACKAGE="$package" --entrypoint /bin/bash "$image" -ec '
+			rm -rf "/builder/package/$WLG_PACKAGE"
+			cp -a "/input/$WLG_PACKAGE" /builder/package/
 			cd /builder
+			printf "%s\n" "CONFIG_PACKAGE_$WLG_PACKAGE=m" >> .config
 			make defconfig >/dev/null
-			make package/wificalling-location-gateway/compile V=s
-			find bin/packages -type f \( -name "wificalling-location-gateway*.ipk" \
-				-o -name "wificalling-location-gateway*.apk" \) -exec cp {} /output/ \;
+			make "package/$WLG_PACKAGE/compile" V=s
+			find bin/packages -type f \( -name "$WLG_PACKAGE*.ipk" \
+				-o -name "$WLG_PACKAGE*.apk" \) -exec cp {} /output/ \;
 		'
 }
 
-build_with_sdk openwrt-24.10 "$OPENWRT_24_SDK"
-build_with_sdk openwrt-25.12 "$OPENWRT_25_SDK"
+case ",$variants," in
+	*,standard,*)
+		build_with_sdk openwrt-24.10 "$OPENWRT_24_SDK" standard
+		build_with_sdk openwrt-25.12 "$OPENWRT_25_SDK" standard
+		;;
+esac
+case ",$variants," in
+	*,lite,*)
+		build_with_sdk openwrt-24.10 "$OPENWRT_24_SDK" lite
+		build_with_sdk openwrt-25.12 "$OPENWRT_25_SDK" lite
+		;;
+esac
 
 mkdir -p "$out_dir"
 find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
@@ -199,7 +313,9 @@ find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk'
 find "$stage/output" -type f \( -name '*.ipk' -o -name '*.apk' \) -exec cp {} "$out_dir/" \;
 count=$(find "$out_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' \
 	-o -name 'wificalling-location-gateway*.apk' \) | wc -l | tr -d ' ')
-[ "$count" -eq 2 ] || fail "expected two integrated packages, found $count"
+expected_count=2
+[ "$variants" = standard,lite ] && expected_count=4
+[ "$count" -eq "$expected_count" ] || fail "expected $expected_count integrated packages, found $count"
 (cd "$out_dir" && shasum -a 256 wificalling-location-gateway*.ipk \
 	wificalling-location-gateway*.apk > SHA256SUMS)
 printf 'release packages: %s\n' "$out_dir"

--- a/scripts/openwrt/package-singbox-lite.sh
+++ b/scripts/openwrt/package-singbox-lite.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+set -eu
+
+data_root=${1:-}
+runtime_bin=${2:-}
+expected_sha=${3:-}
+
+fail() {
+	printf 'package-singbox-lite: %s\n' "$*" >&2
+	exit 2
+}
+
+[ -d "$data_root" ] || fail 'package data root must exist'
+[ -x "$runtime_bin" ] || fail 'runtime binary must be executable'
+case "$expected_sha" in *[!0-9a-fA-F]*|'') fail 'invalid runtime SHA-256' ;; esac
+[ "${#expected_sha}" -eq 64 ] || fail 'invalid runtime SHA-256'
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual_sha=$(sha256sum "$runtime_bin" | awk '{print $1}')
+else
+	actual_sha=$(shasum -a 256 "$runtime_bin" | awk '{print $1}')
+fi
+[ "$actual_sha" = "$expected_sha" ] || fail 'runtime SHA-256 mismatch'
+
+share_dir="$data_root/usr/share/wificalling-location-gateway"
+mkdir -p "$data_root/usr/bin" "$share_dir"
+gzip -9 -n -c "$runtime_bin" > "$share_dir/sing-box-lite.gz"
+printf '%s\n' "$expected_sha" > "$share_dir/sing-box-lite.sha256"
+chmod 0644 "$share_dir/sing-box-lite.gz" "$share_dir/sing-box-lite.sha256"
+
+cat > "$data_root/usr/bin/sing-box" <<EOF
+#!/bin/sh
+set -eu
+
+archive=/usr/share/wificalling-location-gateway/sing-box-lite.gz
+expected_sha='$expected_sha'
+target=/tmp/sing-box-lite
+stamp=/tmp/sing-box-lite.sha256
+lock_dir=/tmp/.sing-box-lite.lock
+
+runtime_ready() {
+	[ -x "\$target" ] && [ "\$(cat "\$stamp" 2>/dev/null || true)" = "\$expected_sha" ]
+}
+
+if ! runtime_ready; then
+	if mkdir "\$lock_dir" 2>/dev/null; then
+		candidate="\$target.new.\$\$"
+		cleanup() {
+			rm -f "\$candidate"
+			rmdir "\$lock_dir" 2>/dev/null || true
+		}
+		trap cleanup EXIT HUP INT TERM
+		gzip -dc "\$archive" > "\$candidate"
+		if command -v sha256sum >/dev/null 2>&1; then
+			actual_sha=\$(sha256sum "\$candidate" | awk '{print \$1}')
+		else
+			actual_sha=\$(shasum -a 256 "\$candidate" | awk '{print \$1}')
+		fi
+		[ "\$actual_sha" = "\$expected_sha" ] || {
+			echo 'sing-box Lite runtime checksum mismatch' >&2
+			exit 126
+		}
+		chmod 0755 "\$candidate"
+		mv "\$candidate" "\$target"
+		printf '%s\n' "\$expected_sha" > "\$stamp"
+		rmdir "\$lock_dir"
+		trap - EXIT HUP INT TERM
+	else
+		attempt=0
+		while ! runtime_ready && [ "\$attempt" -lt 15 ]; do
+			attempt=\$((attempt + 1))
+			sleep 1
+		done
+		runtime_ready || {
+			echo 'sing-box Lite runtime preparation timed out' >&2
+			exit 126
+		}
+	fi
+fi
+
+exec "\$target" "\$@"
+EOF
+chmod 0755 "$data_root/usr/bin/sing-box"

--- a/scripts/openwrt/verify-docker-matrix.sh
+++ b/scripts/openwrt/verify-docker-matrix.sh
@@ -26,10 +26,12 @@ done
 
 [ -n "$dist_dir" ] || fail '--dist-dir is required'
 
-printf '%s|%s|%s\n' 'Redmi AX6S / OpenWrt 24.10.5' opkg "$AX6S_24_ROOTFS"
-printf '%s|%s|%s\n' 'OpenWrt 24.10.8' opkg "$OPENWRT_24_ROOTFS"
-printf '%s|%s|%s\n' 'OpenWrt 25.12.3' apk "$OPENWRT_25_ROOTFS"
-printf '%s|%s|%s\n' 'iStoreOS 24.10.5' opkg "$ISTOREOS_24_ROOTFS"
+for variant in standard lite; do
+	printf '%s|%s|%s|variant=%s\n' 'Redmi AX6S / OpenWrt 24.10.5' opkg "$AX6S_24_ROOTFS" "$variant"
+	printf '%s|%s|%s|variant=%s\n' 'OpenWrt 24.10.8' opkg "$OPENWRT_24_ROOTFS" "$variant"
+	printf '%s|%s|%s|variant=%s\n' 'OpenWrt 25.12.3' apk "$OPENWRT_25_ROOTFS" "$variant"
+	printf '%s|%s|%s|variant=%s\n' 'iStoreOS 24.10.5' opkg "$ISTOREOS_24_ROOTFS" "$variant"
+done
 [ "$plan_only" -eq 0 ] || exit 0
 
 command -v docker >/dev/null 2>&1 || fail 'docker is required'
@@ -44,8 +46,8 @@ else
 fi
 
 manifest_entries=$(awk 'NF == 2 { print $2 }' "$dist_dir/SHA256SUMS")
-[ "$(printf '%s\n' "$manifest_entries" | sed '/^$/d' | wc -l | tr -d ' ')" -eq 3 ] ||
-	fail 'SHA256SUMS must list exactly the three release packages'
+[ "$(printf '%s\n' "$manifest_entries" | sed '/^$/d' | wc -l | tr -d ' ')" -eq 6 ] ||
+	fail 'SHA256SUMS must list exactly six packages: three targets for each variant'
 case "$manifest_entries" in *'/'*) fail 'SHA256SUMS package names must be basenames' ;; esac
 
 select_manifest_package() {
@@ -57,9 +59,12 @@ select_manifest_package() {
 	printf '%s/%s\n' "$dist_dir" "$selected"
 }
 
-ax6s_package=$(select_manifest_package '^wificalling-location-gateway.*_aarch64_cortex-a53\.ipk$' 'AX6S AArch64 IPK')
-ipk_package=$(select_manifest_package '^wificalling-location-gateway.*_x86_64\.ipk$' 'x86_64 IPK')
-apk_package=$(select_manifest_package '^wificalling-location-gateway.*\.apk$' 'x86_64 APK')
+ax6s_standard_package=$(select_manifest_package '^wificalling-location-gateway_[^/]*_aarch64_cortex-a53\.ipk$' 'Standard AX6S AArch64 IPK')
+ax6s_lite_package=$(select_manifest_package '^wificalling-location-gateway-lite_[^/]*_aarch64_cortex-a53\.ipk$' 'Lite AX6S AArch64 IPK')
+ipk_standard_package=$(select_manifest_package '^wificalling-location-gateway_[^/]*_x86_64\.ipk$' 'Standard x86_64 IPK')
+ipk_lite_package=$(select_manifest_package '^wificalling-location-gateway-lite_[^/]*_x86_64\.ipk$' 'Lite x86_64 IPK')
+apk_standard_package=$(select_manifest_package '^wificalling-location-gateway-[0-9][^/]*\.apk$' 'Standard x86_64 APK')
+apk_lite_package=$(select_manifest_package '^wificalling-location-gateway-lite-[0-9][^/]*\.apk$' 'Lite x86_64 APK')
 
 find "$dist_dir" -maxdepth 1 -type f \( -name 'wificalling-location-gateway*.ipk' -o -name 'wificalling-location-gateway*.apk' \) -print |
 	while IFS= read -r candidate; do
@@ -79,17 +84,34 @@ run_case() {
 	manager=$3
 	image=$4
 	package_path=$5
-	platform=$6
-	package_arch=$7
+	variant=$6
+	platform=$7
+	package_arch=$8
+	case "$variant" in
+		standard) package_name=wificalling-location-gateway ;;
+		lite) package_name=wificalling-location-gateway-lite ;;
+		*) fail "unsupported matrix variant: $variant" ;;
+	esac
 	container="wloc-matrix-${name}-$$"
 	containers="$containers $container"
 	docker image inspect "$image" >/dev/null 2>&1 || fail "missing Docker image: $image"
-	docker run -d --rm --privileged --pull never --platform "$platform" \
-		--name "$container" -v "$dist_dir:/packages:ro" \
-		--entrypoint /sbin/init "$image" >/dev/null
+	if [ "$manager" = apk ]; then
+		# Resolve dependencies before OpenWrt's firewall starts. Once init has
+		# applied its default policy, Docker Desktop's translated egress is no
+		# longer available inside this minimal rootfs.
+		docker run -d --rm --privileged --pull never --platform "$platform" \
+			--name "$container" -v "$dist_dir:/packages:ro" \
+			-e "WLG_PACKAGE_BASENAME=${package_path##*/}" \
+			--entrypoint /bin/sh "$image" -c \
+			'apk add --allow-untrusted "/packages/$WLG_PACKAGE_BASENAME" >/tmp/wlg-apk-install.log && exec /sbin/init' >/dev/null
+	else
+		docker run -d --rm --privileged --pull never --platform "$platform" \
+			--name "$container" -v "$dist_dir:/packages:ro" \
+			--entrypoint /sbin/init "$image" >/dev/null
+	fi
 
 	ready=0
-	for _attempt in 1 2 3 4 5 6 7 8 9 10; do
+	for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45; do
 		if docker exec "$container" /bin/sh -c 'ubus list system >/dev/null 2>&1'; then
 			ready=1
 			break
@@ -103,17 +125,41 @@ run_case() {
 		# architecture stanza. Register the architecture reported by the image;
 		# production firmware already has this in /etc/opkg.conf.
 		docker exec "$container" /bin/sh -c '
-			for package in firewall4 ip-full nftables sing-box luci-base rpcd-mod-rpcsys kmod-nft-tproxy kmod-nft-socket; do
+			for package in ca-bundle firewall4 ip-full nftables luci-base rpcd-mod-rpcsys kmod-inet-diag kmod-netlink-diag kmod-tun kmod-nft-tproxy kmod-nft-socket; do
 				printf "Package: %s\nVersion: 0-docker-smoke\nArchitecture: all\nStatus: install ok installed\n\n" "$package" >> /usr/lib/opkg/status
 				: > "/usr/lib/opkg/info/$package.list"
 			done
 		'
-		docker exec "$container" opkg --add-arch all:1 --add-arch "$package_arch:100" install --force-depends \
+		if [ "$variant" = standard ]; then
+			docker exec "$container" /bin/sh -c '
+				printf "Package: sing-box\nVersion: 0-docker-smoke\nArchitecture: all\nStatus: install ok installed\n\n" >> /usr/lib/opkg/status
+				printf "%s\n" /usr/bin/sing-box > /usr/lib/opkg/info/sing-box.list
+				printf "#!/bin/sh\necho sing-box docker-smoke\n" > /usr/bin/sing-box
+				chmod 0755 /usr/bin/sing-box
+			'
+		fi
+		runtime_arch=$(docker exec "$container" /bin/sh -c '. /etc/openwrt_release; printf "%s" "$DISTRIB_ARCH"')
+		docker exec "$container" opkg --add-arch all:1 --add-arch "$runtime_arch:50" \
+			--add-arch "$package_arch:100" install --force-depends \
 			"/packages/${package_path##*/}" >/dev/null
+	fi
+
+	if [ "$manager" = opkg ]; then
+		# --add-arch applies only to the install invocation in these minimal
+		# rootfs images, so inspect the package manager's persisted file list.
+		owned=$(docker exec "$container" cat "/usr/lib/opkg/info/$package_name.list")
 	else
-		docker exec "$container" apk add --allow-untrusted --no-network \
-			--force-missing-repositories --repositories-file /dev/null \
-			"/packages/${package_path##*/}" >/dev/null
+		owned=$(docker exec "$container" apk info -L "$package_name")
+	fi
+	if [ "$variant" = standard ]; then
+		if printf '%s\n' "$owned" | grep -E '^/?usr/bin/sing-box$' >/dev/null; then
+			fail "$display standard package unexpectedly owns /usr/bin/sing-box"
+		fi
+	else
+		printf '%s\n' "$owned" | grep -E '^/?usr/bin/sing-box$' >/dev/null ||
+			fail "$display Lite package did not install /usr/bin/sing-box"
+		docker exec "$container" /usr/bin/sing-box version >/dev/null ||
+			fail "$display Lite sing-box runtime is not executable"
 	fi
 
 	docker exec "$container" /etc/init.d/wloc-service enable
@@ -131,19 +177,33 @@ run_case() {
 	printf '%s\n' "$status" | grep -F '"api_version"' | grep -F 'wloc.service/v1' >/dev/null ||
 		fail "$display returned an invalid control response"
 	release=$(docker exec "$container" /bin/sh -c '. /etc/openwrt_release; printf "%s %s %s" "$DISTRIB_ID" "$DISTRIB_RELEASE" "$DISTRIB_ARCH"')
-	printf '%s|%s|installed|started|socket-ok|status-ok\n' "$display" "$release" >> "$tmp/report"
+	printf '%s|%s|%s|installed|started|socket-ok|status-ok\n' "$display" "$release" "$variant" >> "$tmp/report"
 	docker rm -f "$container" >/dev/null
 	containers=$(printf '%s' "$containers" | sed "s/ $container//")
 }
 
-run_case ax6s2410 'Redmi AX6S / OpenWrt 24.10.5' opkg "$AX6S_24_ROOTFS" \
-	"$ax6s_package" linux/aarch64_generic aarch64_cortex-a53
-run_case openwrt2410 'OpenWrt 24.10.8' opkg "$OPENWRT_24_ROOTFS" \
-	"$ipk_package" linux/amd64 x86_64
-run_case openwrt2512 'OpenWrt 25.12.3' apk "$OPENWRT_25_ROOTFS" \
-	"$apk_package" linux/amd64 x86_64
-run_case istoreos2410 'iStoreOS 24.10.5' opkg "$ISTOREOS_24_ROOTFS" \
-	"$ipk_package" linux/amd64 x86_64
+for variant in standard lite; do
+	case "$variant" in
+		standard)
+			ax6s_package=$ax6s_standard_package
+			ipk_package=$ipk_standard_package
+			apk_package=$apk_standard_package
+			;;
+		lite)
+			ax6s_package=$ax6s_lite_package
+			ipk_package=$ipk_lite_package
+			apk_package=$apk_lite_package
+			;;
+	esac
+	run_case "ax6s2410-$variant" 'Redmi AX6S / OpenWrt 24.10.5' opkg "$AX6S_24_ROOTFS" \
+		"$ax6s_package" "$variant" linux/aarch64_generic aarch64_cortex-a53
+	run_case "openwrt2410-$variant" 'OpenWrt 24.10.8' opkg "$OPENWRT_24_ROOTFS" \
+		"$ipk_package" "$variant" linux/amd64 x86_64
+	run_case "openwrt2512-$variant" 'OpenWrt 25.12.3' apk "$OPENWRT_25_ROOTFS" \
+		"$apk_package" "$variant" linux/amd64 x86_64
+	run_case "istoreos2410-$variant" 'iStoreOS 24.10.5' opkg "$ISTOREOS_24_ROOTFS" \
+		"$ipk_package" "$variant" linux/amd64 x86_64
+done
 
 cp "$tmp/report" "$report"
 cat "$report"

--- a/task_plan.md
+++ b/task_plan.md
@@ -49,11 +49,11 @@
 | 40. 阶段 3 真实环境测试 | 待开始 | 授权路由器/iPhone、精确域名、定位/WFC/普通网络与恢复证据 |
 | 41. 服务合并与 Gateway 1.7 集成 | 待开始 | 独立安全评审后合并，再以可选包/feature flag 集成 |
 | 42. LuCI UI 开发 | 待开始 | API 冻结后单独 Issue/PR 实现 UI |
-| 43. 1.2.x Standard/Lite 发布契约 | 进行中 | Issue #66；同项目、同配置、两种内存变体、三类平台六个产物 |
-| 44. 双变体 packaging TDD | 待开始 | 先建立命名、依赖、冲突、架构、配置保留和 tiny 校验的 RED 测试 |
-| 45. Standard/Lite 构建实现 | 待开始 | Standard 调用系统 sing-box；Lite 携带架构匹配 tiny 并应用 AX6S 资源限制 |
-| 46. 三平台构建与安装矩阵 | 待开始 | AX6S AArch64 IPK、24.x x86_64 IPK、25.x x86_64 APK，各构建两版 |
-| 47. AX6S 实机与发布验收 | 待开始 | Lite 冷启动/资源/WCG/WLOC/升级保留测试，文档、校验和、回滚和 GitHub Release |
+| 43. 1.2.x Standard/Lite 发布契约 | 完成 | Issue #66；同项目、同配置、两种内存规格、三类平台六个产物 |
+| 44. 双变体 packaging TDD | 完成 | RED/GREEN 覆盖命名、依赖、冲突、架构、配置保留、哈希与 tmpfs 包装器 |
+| 45. Standard/Lite 构建实现 | 完成 | Standard 调用系统 sing-box；Lite 压缩驻留、透明解压并应用 AX6S 资源限制 |
+| 46. 三平台构建与安装矩阵 | 完成 | 六包构建；四环境 × 两规格共八行全部安装、启动、Socket、状态通过 |
+| 47. AX6S 实机与发布验收 | 进行中 | Lite 已迁移、冷启动、容量、WCG/WLOC、真实 iPhone WLOC 通过；待全仓门禁与 GitHub Release |
 
 ## 约束与原则
 

--- a/task_plan.md
+++ b/task_plan.md
@@ -49,6 +49,11 @@
 | 40. 阶段 3 真实环境测试 | 待开始 | 授权路由器/iPhone、精确域名、定位/WFC/普通网络与恢复证据 |
 | 41. 服务合并与 Gateway 1.7 集成 | 待开始 | 独立安全评审后合并，再以可选包/feature flag 集成 |
 | 42. LuCI UI 开发 | 待开始 | API 冻结后单独 Issue/PR 实现 UI |
+| 43. 1.2.x Standard/Lite 发布契约 | 进行中 | Issue #66；同项目、同配置、两种内存变体、三类平台六个产物 |
+| 44. 双变体 packaging TDD | 待开始 | 先建立命名、依赖、冲突、架构、配置保留和 tiny 校验的 RED 测试 |
+| 45. Standard/Lite 构建实现 | 待开始 | Standard 调用系统 sing-box；Lite 携带架构匹配 tiny 并应用 AX6S 资源限制 |
+| 46. 三平台构建与安装矩阵 | 待开始 | AX6S AArch64 IPK、24.x x86_64 IPK、25.x x86_64 APK，各构建两版 |
+| 47. AX6S 实机与发布验收 | 待开始 | Lite 冷启动/资源/WCG/WLOC/升级保留测试，文档、校验和、回滚和 GitHub Release |
 
 ## 约束与原则
 
@@ -58,6 +63,12 @@
 - 安全、隐私、可观测性、回滚和测试必须进入首期设计。
 
 ## 关键决策
+
+- Issue #66 的 Standard/Lite 是同一 1.2.x 产品的安装变体，不是产品分叉；临时 Git 分支只用于审查和集成。
+- 发布面固定为三类产物：AX6S/AArch64 24.x IPK、OpenWrt/iStoreOS 24.x x86_64 IPK、OpenWrt 25.x x86_64 APK；两种变体合计六个产物。
+- Standard 必须使用固件已有的标准 `/usr/bin/sing-box`，不得覆盖或捆绑另一份标准运行时。
+- Lite 必须携带与包架构一致的 sing-box tiny，并复用 AX6S 已验证的低内存限制；两种变体必须互斥且切换时保留 WCG/WLOC UCI 配置。
+- 稳定基线为 Issue #62 + Issue #64 的 1.2.x 发布链；禁止重新引入 1.7 独立项目或 v2/Beta 多设备代码。
 
 - 沿用 1.7.0 DHCP/MAC 自愈和网关数据平面，不重写现有核心。
 - Gateway 1.7 稳定仓库与路由器侧 WLOC 实验项目保持代码、进程、包和许可证隔离。

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -40,6 +40,12 @@ grep -F 'manifest_entries=' "$matrix" >/dev/null ||
 	fail 'Docker verification must select install artifacts from the checksum manifest'
 grep -F 'unexpected release package not listed in SHA256SUMS' "$matrix" >/dev/null ||
 	fail 'Docker verification must reject unlisted matching release packages'
+grep -F "variant=\$6" "$matrix" >/dev/null ||
+	fail 'Docker verification must execute each runtime row for an explicit package variant'
+grep -F 'standard package unexpectedly owns /usr/bin/sing-box' "$matrix" >/dev/null ||
+	fail 'Docker verification must enforce firmware ownership for the Standard runtime'
+grep -F 'Lite package did not install /usr/bin/sing-box' "$matrix" >/dev/null ||
+	fail 'Docker verification must enforce bundled runtime ownership for Lite'
 if grep -F 'shasum -a 256 ./wificalling-location-gateway' "$builder" >/dev/null; then
 	fail 'release builder must write basename-only SHA256SUMS entries'
 fi
@@ -100,6 +106,10 @@ for expected in \
 	'iStoreOS 24.10.5|opkg|wukongdaily/openwrt-istoreos:amd64-latest'; do
 	printf '%s\n' "$matrix_plan" | grep -F "$expected" >/dev/null ||
 		fail "missing Docker matrix row: $expected"
+done
+for variant in standard lite; do
+	printf '%s\n' "$matrix_plan" | grep -F "variant=$variant" >/dev/null ||
+		fail "Docker matrix plan must include the $variant package variant"
 done
 printf '%s\n' "$matrix_plan" | grep -F 'sha256:93f980c266b9b68e3085f3eee7909c04f1dc4061047558e18a9ef12aec43efa9' >/dev/null ||
 	fail 'AX6S-compatible AArch64 rootfs image must be immutable'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+release_builder="$repo_root/scripts/openwrt/build-release-packages.sh"
+ax6s_builder="$repo_root/scripts/build-luci-ipk.sh"
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/wlg-variant-test.XXXXXX")
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+fail() {
+	printf 'FAIL: %s\n' "$*" >&2
+	exit 1
+}
+
+printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
+printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
+printf 'mock x86_64 sing-box tiny\n' > "$tmp/sing-box-x86_64"
+chmod 0755 "$tmp/wloc-service" "$tmp/wloc-ctl" "$tmp/sing-box-x86_64"
+tiny_sha=$(shasum -a 256 "$tmp/sing-box-x86_64" | awk '{print $1}')
+
+plan=$(
+	"$release_builder" --plan \
+		--variants standard,lite \
+		--arch x86_64 \
+		--service-bin "$tmp/wloc-service" \
+		--ctl-bin "$tmp/wloc-ctl" \
+		--singbox-lite-bin "$tmp/sing-box-x86_64" \
+		--singbox-lite-sha256 "$tiny_sha"
+)
+
+for expected in \
+	'wificalling-location-gateway_1.2.0-r1_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.2.0-r1_x86_64.ipk' \
+	'wificalling-location-gateway-1.2.0-r1.apk' \
+	'wificalling-location-gateway-lite-1.2.0-r1.apk'; do
+	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
+		fail "dual-variant plan is missing $expected"
+done
+
+printf '%s\n' "$plan" | grep -F 'standard runtime: firmware /usr/bin/sing-box' >/dev/null ||
+	fail 'standard plan must declare the firmware-owned sing-box runtime'
+printf '%s\n' "$plan" | grep -F "lite runtime: $tiny_sha" >/dev/null ||
+	fail 'lite plan must bind the supplied tiny runtime digest'
+
+if "$release_builder" --plan --variants standard,lite --arch x86_64 \
+	--service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl" \
+	--singbox-lite-bin "$tmp/sing-box-x86_64" \
+	--singbox-lite-sha256 deadbeef >"$tmp/out" 2>"$tmp/err"; then
+	fail 'lite build plan must reject an unpinned tiny runtime'
+fi
+grep -F 'sing-box Lite SHA-256 mismatch' "$tmp/err" >/dev/null ||
+	fail 'tiny digest rejection must be explicit'
+
+if "$release_builder" --plan --variants lite --arch x86_64 \
+	--service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl" \
+	>"$tmp/out" 2>"$tmp/err"; then
+	fail 'lite plan must require a tiny runtime input'
+fi
+grep -F -- '--singbox-lite-bin is required for the Lite variant' "$tmp/err" >/dev/null ||
+	fail 'missing Lite runtime rejection must be explicit'
+
+if "$release_builder" --plan --variants standard,beta --arch x86_64 \
+	--service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl" \
+	>"$tmp/out" 2>"$tmp/err"; then
+	fail 'unknown package variants must be rejected'
+fi
+grep -F 'variants must be standard, lite, or standard,lite' "$tmp/err" >/dev/null ||
+	fail 'variant rejection must list the supported choices'
+
+grep -F 'Conflicts: wificalling-location-gateway-lite' "$ax6s_builder" >/dev/null ||
+	fail 'standard package must conflict with the Lite package'
+grep -F 'Package: wificalling-location-gateway-lite' "$ax6s_builder" >/dev/null ||
+	fail 'AX6S builder must define the Lite package identity'
+grep -F 'Provides: wificalling-location-gateway, sing-box' "$ax6s_builder" >/dev/null ||
+	fail 'Lite must provide the integrated product and sing-box runtime'
+grep -F 'Conflicts: wificalling-location-gateway, sing-box' "$ax6s_builder" >/dev/null ||
+	fail 'Lite must not coexist with the standard product or standard sing-box package'
+grep -F 'GOMEMLIMIT=24MiB' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'Lite runtime profile must retain the AX6S-validated sing-box heap limit'
+grep -F '/usr/bin/sing-box' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'both variants must keep the shared sing-box executable contract'
+
+printf '%s\n' 'Standard/Lite package variant tests passed'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -4,6 +4,7 @@ set -eu
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 release_builder="$repo_root/scripts/openwrt/build-release-packages.sh"
 ax6s_builder="$repo_root/scripts/build-luci-ipk.sh"
+runtime_packager="$repo_root/scripts/openwrt/package-singbox-lite.sh"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wlg-variant-test.XXXXXX")
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
@@ -11,6 +12,8 @@ fail() {
 	printf 'FAIL: %s\n' "$*" >&2
 	exit 1
 }
+
+[ -x "$runtime_packager" ] || fail 'missing sing-box Lite runtime packager'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -79,5 +82,9 @@ grep -F 'GOMEMLIMIT=24MiB' "$repo_root/openwrt/files/etc/init.d/wificalling-gate
 	fail 'Lite runtime profile must retain the AX6S-validated sing-box heap limit'
 grep -F '/usr/bin/sing-box' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
 	fail 'both variants must keep the shared sing-box executable contract'
+grep -F '/usr/share/wificalling-location-gateway/sing-box-lite.gz' "$runtime_packager" >/dev/null ||
+	fail 'Lite must keep the compressed runtime on persistent storage'
+grep -F '/tmp/sing-box-lite' "$runtime_packager" >/dev/null ||
+	fail 'Lite must expand sing-box into tmpfs at runtime'
 
 printf '%s\n' 'Standard/Lite package variant tests passed'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -45,7 +45,7 @@ printf '%s\n' "$plan" | grep -F "lite runtime: $tiny_sha" >/dev/null ||
 if "$release_builder" --plan --variants standard,lite --arch x86_64 \
 	--service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl" \
 	--singbox-lite-bin "$tmp/sing-box-x86_64" \
-	--singbox-lite-sha256 deadbeef >"$tmp/out" 2>"$tmp/err"; then
+	--singbox-lite-sha256 0000000000000000000000000000000000000000000000000000000000000000 >"$tmp/out" 2>"$tmp/err"; then
 	fail 'lite build plan must reject an unpinned tiny runtime'
 fi
 grep -F 'sing-box Lite SHA-256 mismatch' "$tmp/err" >/dev/null ||
@@ -67,13 +67,13 @@ fi
 grep -F 'variants must be standard, lite, or standard,lite' "$tmp/err" >/dev/null ||
 	fail 'variant rejection must list the supported choices'
 
-grep -F 'Conflicts: wificalling-location-gateway-lite' "$ax6s_builder" >/dev/null ||
+grep -F "conflicts='wificalling-location-gateway-lite'" "$ax6s_builder" >/dev/null ||
 	fail 'standard package must conflict with the Lite package'
-grep -F 'Package: wificalling-location-gateway-lite' "$ax6s_builder" >/dev/null ||
+grep -F 'output_package=wificalling-location-gateway-lite' "$ax6s_builder" >/dev/null ||
 	fail 'AX6S builder must define the Lite package identity'
-grep -F 'Provides: wificalling-location-gateway, sing-box' "$ax6s_builder" >/dev/null ||
+grep -F "provides='wificalling-location-gateway, sing-box" "$ax6s_builder" >/dev/null ||
 	fail 'Lite must provide the integrated product and sing-box runtime'
-grep -F 'Conflicts: wificalling-location-gateway, sing-box' "$ax6s_builder" >/dev/null ||
+grep -F "conflicts='wificalling-location-gateway, sing-box'" "$ax6s_builder" >/dev/null ||
 	fail 'Lite must not coexist with the standard product or standard sing-box package'
 grep -F 'GOMEMLIMIT=24MiB' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
 	fail 'Lite runtime profile must retain the AX6S-validated sing-box heap limit'

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -4,10 +4,12 @@ set -eu
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 builder="$repo_root/scripts/build-luci-ipk.sh"
 tmp=$(mktemp -d "${TMPDIR:-/tmp}/wloc-standalone-package-test.XXXXXX")
-built_output=
+built_outputs=
 cleanup() {
 	rm -rf "$tmp"
-	[ -z "$built_output" ] || rm -f "$built_output"
+	for built_output in $built_outputs; do
+		rm -f "$built_output"
+	done
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -77,6 +79,7 @@ output=$(
 	"$builder" "$version" ax6s-standalone
 )
 built_output=$output
+built_outputs="$built_outputs $output"
 [ -f "$output" ] || fail 'standalone builder did not create an IPK'
 
 mkdir -p "$tmp/result"
@@ -195,6 +198,57 @@ grep -F 'node_test' \
 grep -F '"note":"ICMP ping only' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null &&
 	fail 'standalone package compact output must drop the note field'
+
+# The Lite variant owns an architecture-matched sing-box binary, replaces the
+# standard runtime through package metadata, and preserves the same UCI files.
+mkdir -p "$tmp/mock-bin"
+cat > "$tmp/mock-bin/file" <<'FILE'
+#!/bin/sh
+printf '%s: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV)\n' "$1"
+FILE
+chmod 0755 "$tmp/mock-bin/file"
+printf 'mock aarch64 sing-box Lite\n' > "$tmp/sing-box-lite"
+chmod 0755 "$tmp/sing-box-lite"
+tiny_sha=$(shasum -a 256 "$tmp/sing-box-lite" | awk '{print $1}')
+lite_version="0.1.0-4-lite-test"
+lite_output=$(
+	PATH="$tmp/mock-bin:$PATH" \
+	WLOC_SERVICE_BIN="$tmp/wloc-service" \
+	WLOC_CTL_BIN="$tmp/wloc-ctl" \
+	GATEWAY_IPK="$tmp/gateway.ipk" \
+	GATEWAY_IPK_SHA256="$gateway_sha" \
+	SINGBOX_LITE_BIN="$tmp/sing-box-lite" \
+	SINGBOX_LITE_SHA256="$tiny_sha" \
+	"$builder" "$lite_version" ax6s-lite
+)
+built_outputs="$built_outputs $lite_output"
+mkdir -p "$tmp/lite-result/data"
+tar -xf "$lite_output" -C "$tmp/lite-result"
+lite_control=$(tar -xOf "$tmp/lite-result/control.tar.gz" ./control)
+lite_conffiles=$(tar -xOf "$tmp/lite-result/control.tar.gz" ./conffiles)
+tar -xzf "$tmp/lite-result/data.tar.gz" -C "$tmp/lite-result/data"
+
+printf '%s\n' "$lite_control" | grep -Fx 'Package: wificalling-location-gateway-lite' >/dev/null ||
+	fail 'Lite package must have an explicit package identity'
+printf '%s\n' "$lite_control" | grep -F 'Provides: wificalling-location-gateway, sing-box' >/dev/null ||
+	fail 'Lite package must provide the integrated product and sing-box runtime'
+printf '%s\n' "$lite_control" | grep -F 'Conflicts: wificalling-location-gateway, sing-box' >/dev/null ||
+	fail 'Lite package must conflict with the standard product and sing-box package'
+if printf '%s\n' "$lite_control" | grep '^Depends:.*sing-box' >/dev/null; then
+	fail 'Lite package must not depend on the standard sing-box package'
+fi
+printf '%s\n' "$lite_control" | grep -F 'kmod-inet-diag, kmod-netlink-diag, kmod-tun' >/dev/null ||
+	fail 'Lite package must carry the runtime kernel dependencies'
+for conffile in /etc/config/wificalling-gateway /etc/config/wloc-service; do
+	printf '%s\n' "$lite_conffiles" | grep -Fx "$conffile" >/dev/null ||
+		fail "Lite package must preserve $conffile"
+done
+cmp "$tmp/sing-box-lite" "$tmp/lite-result/data/usr/bin/sing-box" >/dev/null ||
+	fail 'Lite package must install the exact hash-pinned sing-box runtime'
+[ "$(cat "$tmp/lite-result/data/usr/share/wificalling-location-gateway/runtime-variant")" = lite ] ||
+	fail 'Lite package must install its runtime marker'
+grep -F 'GOMEMLIMIT=24MiB' "$tmp/lite-result/data/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'Lite package must apply the AX6S-validated sing-box memory profile'
 
 # The retired standalone 1.7 package must never be accepted as a baseline.
 mkdir -p "$tmp/legacy"

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -243,8 +243,12 @@ for conffile in /etc/config/wificalling-gateway /etc/config/wloc-service; do
 	printf '%s\n' "$lite_conffiles" | grep -Fx "$conffile" >/dev/null ||
 		fail "Lite package must preserve $conffile"
 done
-cmp "$tmp/sing-box-lite" "$tmp/lite-result/data/usr/bin/sing-box" >/dev/null ||
-	fail 'Lite package must install the exact hash-pinned sing-box runtime'
+grep -F '/tmp/sing-box-lite' "$tmp/lite-result/data/usr/bin/sing-box" >/dev/null ||
+	fail 'Lite package must install the transparent tmpfs runtime wrapper'
+gzip -dc "$tmp/lite-result/data/usr/share/wificalling-location-gateway/sing-box-lite.gz" \
+	> "$tmp/lite-result/sing-box-lite.unpacked"
+cmp "$tmp/sing-box-lite" "$tmp/lite-result/sing-box-lite.unpacked" >/dev/null ||
+	fail 'Lite package must persist the exact hash-pinned sing-box runtime in compressed form'
 [ "$(cat "$tmp/lite-result/data/usr/share/wificalling-location-gateway/runtime-variant")" = lite ] ||
 	fail 'Lite package must install its runtime marker'
 grep -F 'GOMEMLIMIT=24MiB' "$tmp/lite-result/data/etc/init.d/wificalling-gateway" >/dev/null ||


### PR DESCRIPTION
Closes #66

## Summary
- publish Standard and Lite installation variants of the same integrated stable 1.2.x project
- build six assets across AX6S AArch64 IPK, OpenWrt/iStoreOS 24 x86_64 IPK, and OpenWrt 25 x86_64 APK
- keep Standard on the firmware sing-box; make Lite own a hash-pinned compressed runtime with transparent tmpfs preparation and AX6S memory limits
- preserve both UCI files and document bilingual selection, installation, rollback, licensing, and validation

## Evidence
- `./scripts/ci/verify.sh`: passed (69 Python tests, all Rust/JS suites, 81.40% Rust line coverage, RustSec/license/source/secret/repository gates)
- pinned Docker matrix: 8/8 Standard/Lite rows installed, started, socket-ok, status-ok
- AX6S Lite: exact r5 package installed after removing the old integrated/sing-box packages; UCI SHA-256 values unchanged; cold boot passed; overlay retained about 20.4 MB free
- post-boot iPhone WLOC request from the assigned test device was observed and synthesized
- checksums and TDD evidence: `docs/testing/V1.2.2_R5_STANDARD_LITE_RELEASE.tdd.md`

## Risks
- Standard requires a compatible firmware/feed sing-box and has no physical-router test in this PR; x86 Standard uses the real OpenWrt 25 dependency and all Standard targets pass Docker boot validation
- Lite intentionally conflicts with Standard and a separately installed sing-box package; low-storage routers must remove the old packages before installing Lite
- Lite uses tmpfs for the executable, trading flash capacity for one shared runtime copy in memory; AX6S cold-boot capacity was measured

## Rollback
1. Back up `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
2. Stop WCG/WLOC (and PassWall when it uses the shared runtime).
3. Remove the installed variant.
4. Install the previous r4 integrated package plus the required sing-box package.
5. Confirm both UCI hashes/configurations and restart services.

## Handoff
- Handoff capsule: `.handoffs/issue-66.md`
- Authoritative commit: `853802f6ca085bac389f3cc730fb1a3d11886fd6`
