### PR TITLE
fix: accept empty-prefix VLESS authorities

### DIFF
--- a/.handoffs/issue-70.md
+++ b/.handoffs/issue-70.md
@@ -1,0 +1,74 @@
+# Agent handoff: Issue 70
+
+## Identity and scope
+
+- Source agent ID: codex-vless-import
+- Capabilities used: openwrt,test,ci,integration
+- Branch: codex/issue-70-vless-empty-authority-codex
+- Checkpoint parent: `e5e06b8`
+- Updated at (UTC): 2026-08-28
+- Credentials included: no
+
+## Objective
+
+Accept Base64-encoded VLESS authorities using the empty-prefix form
+`:UUID@host:port`, while preserving the existing `auto:UUID@host:port` form.
+
+## Completed
+
+- Added a regression test reproducing the empty-prefix import failure.
+- Updated the shared VLESS parser normalization to accept both known forms.
+- Bumped package metadata and release documentation to `1.3.0-r3`.
+- Built standard and Lite packages for the supported targets.
+- Installed the AArch64 Lite package on the test AX6S and verified both services
+  and the WLOC control socket.
+
+## Files changed
+
+- `openwrt/files/www/luci-static/resources/wificalling-gateway/node-import.js`
+- `tests/js/node_import.test.js`
+- Release metadata, packaging scripts, tests, and README/changelog.
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `node tests/js/node_import.test.js` | Passed | Empty-prefix VLESS regression covered |
+| `./scripts/ci/verify.sh` | Passed | 69 Python tests, Rust suites, 81.35% coverage, audits and repository gates |
+| OpenWrt/iStoreOS matrix | Passed | 8/8 standard and Lite rows installed, started, socket-ok, status-ok |
+| AX6S Lite installation | Passed | `1.3.0-r3`, gateway/WLOC running, control socket present |
+| `git diff --check` and secret scan | Passed | No whitespace errors or sensitive values in the change |
+
+## Failed attempts
+
+- The first PR used a branch without the required Issue prefix and was rejected
+  by the pull-request contract; the branch is now aligned with Issue #70.
+
+## Unresolved decisions and blockers
+
+- None.
+
+## Next executable steps
+
+1. Push this renamed branch and update/open the PR for Issue #70.
+2. Wait for all GitHub repository gates and obtain independent review.
+
+## Capabilities required for the next Agent
+
+- openwrt
+- test
+- ci
+- security-review
+
+## Environment assumptions
+
+- The release package format remains selected by target platform: IPK for
+  OpenWrt 24.10 and APK for OpenWrt 25.12.
+- Existing UCI configuration is preserved during package replacement.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- The parser accepts only the two known encoded authority prefixes and keeps
+  malformed input fail-closed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r3] - 2026-08-28
+
+Hotfix for an additional VLESS share-link encoding variant.
+
+- Accept Base64-encoded VLESS authorities using either `auto:UUID@host:port`
+  or `:UUID@host:port`.
+
 ## [1.3.0-r2] - 2026-08-28
 
 Compatibility and stability release for node import and LuCI error handling.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r2-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r2)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r3-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -133,10 +133,10 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r2` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r3` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r2_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r2_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r2.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r2_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r2_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r2.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r3.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r3.apk`
 
 Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and keeps only the single-worker/moderate-GC runtime profile without an artificial heap ceiling. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
@@ -167,7 +167,7 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r2_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
 ```
 
 Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r5 Lite package replaces the separate sing-box package and owns its transparent wrapper.
@@ -175,14 +175,14 @@ Back up both UCI files first. On storage-constrained AX6S units, stop the servic
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r2_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r2.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -245,7 +245,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 2 \
+  --release 3 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -258,7 +258,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r2"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -432,10 +432,10 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r2` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r3` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r2_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r2_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r2.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r2_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r2_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r2.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r3.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r3.apk`
 
 固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`；WCG 仅保留单 worker 和适度 GC 设置，不再人为设置堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
@@ -466,7 +466,7 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r2_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
 ```
 
 安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r5 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
@@ -474,14 +474,14 @@ opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r2_aarch64_cortex-a53.
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r2_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r2.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -544,7 +544,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 2 \
+  --release 3 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -557,7 +557,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r2"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/files/www/luci-static/resources/wificalling-gateway/node-import.js
+++ b/openwrt/files/www/luci-static/resources/wificalling-gateway/node-import.js
@@ -134,7 +134,7 @@ function parse(uri) {
 		if (authority.indexOf('@') < 0) {
 			try {
 				var decodedAuthority = decodeBase64(authority);
-				var legacyAuthority = decodedAuthority.match(/^auto:([^@]+)@(.+)$/);
+				var legacyAuthority = decodedAuthority.match(/^(?:auto:|:)([^@]+)@(.+)$/);
 				if (legacyAuthority) {
 					value = 'vless://' + encodeURIComponent(legacyAuthority[1]) + '@' + legacyAuthority[2] +
 						(queryStart < 0 ? '' : value.slice(queryStart));

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r2}
+version=${1:-1.3.0-r3}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=2
+release=3
 arch=x86_64
 service_bin=
 ctl_bin=

--- a/tests/js/node_import.test.js
+++ b/tests/js/node_import.test.js
@@ -41,6 +41,14 @@ function main() {
 	assert.strictEqual(encodedAuthorityResult.port, '443');
 	assert.strictEqual(encodedAuthorityResult.security, 'reality');
 
+	const emptyPrefixAuthority = Buffer.from(':uuid@example.test:443').toString('base64').replace(/=+$/, '');
+	const emptyPrefixResult = parser.parse(
+		'vless://' + emptyPrefixAuthority + '?tls=1&peer=example.test&xtls=2&pbk=public-key&sid=shortid'
+	);
+	assert.strictEqual(emptyPrefixResult.uuid, 'uuid');
+	assert.strictEqual(emptyPrefixResult.server, 'example.test');
+	assert.strictEqual(emptyPrefixResult.port, '443');
+
 	const commonCases = [
 		['anytls://user:secret@example.test:443?peer=example.test', { protocol: 'anytls', password: 'secret', sni: 'example.test' }],
 		['hysteria2://user:secret@example.test:443?sni=example.test', { protocol: 'hysteria2', password: 'secret', sni: 'example.test' }],

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -80,9 +80,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r2_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r2.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r3.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r2_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r2_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r2.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r2.apk'; do
+	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r3.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r3.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=2' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 2'
+grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 3'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=2' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 2'
+grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 3'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r2_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r2.apk'; do
+	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r3.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r2}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 2'
+grep -F 'version=${1:-1.3.0-r3}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 3'
 
 printf '%s\n' 'release version tests passed'


### PR DESCRIPTION
## Summary
- accept Base64-encoded VLESS authorities in both `auto:UUID@host:port` and `:UUID@host:port` forms
- bump the integrated package release to `1.3.0-r3`
- add a regression test for the empty-prefix form

Closes #70

## Verification
- `./scripts/ci/verify.sh` — passed; Rust coverage 81.35%
- OpenWrt/iStoreOS matrix — 8/8 standard and Lite combinations passed
- AX6S — `1.3.0-r3` Lite installed; gateway and WLOC running; control socket passed
- reported VLESS link — locally parsed with server, port, UUID, Reality, SNI, flow and fingerprint
- diff secret scan and `git diff --check` — passed
- Handoff capsule: `.handoffs/issue-70.md`

## Rollback
Reinstall the previous `1.3.0-r2` package if rollback is required. UCI configuration is preserved.
