### PR TITLE
fix: refresh node metrics after manual nodeTest

### DIFF
--- a/.handoffs/issue-72.md
+++ b/.handoffs/issue-72.md
@@ -1,0 +1,74 @@
+# Agent handoff: Issue 72
+
+## Identity and scope
+
+- Source agent ID: codex-node-status
+- Capabilities used: openwrt,test,ci,integration
+- Branch: codex/issue-72-node-status-manual-refresh
+- Checkpoint parent: `7a8781d`
+- Updated at (UTC): 2026-08-28
+- Credentials included: no
+
+## Objective
+
+Refresh a node row's status, Ping/latency, and quality immediately after a
+manual LuCI `nodeTest` result.
+
+## Completed
+
+- Added regression guards for manual row refresh and polling persistence.
+- Updated standalone and integrated LuCI views to normalize and render manual
+  TCP and WireGuard results in the existing three metric cells.
+- Kept the manual result visible for 60 seconds so an older status export
+  cannot immediately overwrite it.
+- Bumped the package release to `1.3.0-r4` and recorded TDD evidence.
+- Built all supported Standard/Lite assets and installed r4 Lite on AX6S.
+
+## Files changed
+
+- Three LuCI overview sources under `openwrt/`.
+- `tests/js/wg_handshake_reason.test.js` and release tests.
+- Release metadata, README/changelog, and the TDD evidence document.
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `node tests/js/wg_handshake_reason.test.js` | Passed | Manual row refresh and 60-second polling overlay guards |
+| `./scripts/ci/verify.sh` | Passed | 69 Python tests, Rust suites, 81.41% line coverage, audits and repository gates |
+| OpenWrt/iStoreOS matrix | Passed | 8/8 Standard/Lite rows installed, started, socket-ok, status-ok |
+| AX6S r4 Lite installation | Passed | Package version, both services, WLOC socket, and live NodeTest latency verified |
+| `git diff --check` and secret scan | Passed | No whitespace errors or sensitive values in the change |
+
+## Failed attempts
+
+- The first AX6S package build omitted the required binary environment inputs;
+  the build was rerun with the existing verified runtime binaries and passed.
+
+## Unresolved decisions and blockers
+
+- None.
+
+## Next executable steps
+
+1. Push this branch and open a PR closing Issue #72.
+2. Wait for all GitHub repository gates and merge after they pass.
+
+## Capabilities required for the next Agent
+
+- openwrt
+- test
+- ci
+- security-review
+
+## Environment assumptions
+
+- OpenWrt 24.10 uses IPK and OpenWrt 25.12 uses native APK.
+- Existing UCI configuration is preserved during package replacement.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- The manual result is a display overlay only; it does not alter routing or
+  the backend status producer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r4] - 2026-08-28
+
+Hotfix for stale node metrics after a manual node test.
+
+- Refresh the node status, ping/latency, and quality cells immediately from
+  the `node_test` result.
+
 ## [1.3.0-r3] - 2026-08-28
 
 Hotfix for an additional VLESS share-link encoding variant.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r3-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r3)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r4-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r4)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -133,10 +133,10 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r3` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r4` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r3.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r3.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r4.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r4.apk`
 
 Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and keeps only the single-worker/moderate-GC runtime profile without an artificial heap ceiling. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
@@ -167,7 +167,7 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
 ```
 
 Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r5 Lite package replaces the separate sing-box package and owns its transparent wrapper.
@@ -175,14 +175,14 @@ Back up both UCI files first. On storage-constrained AX6S units, stop the servic
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -245,7 +245,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 3 \
+  --release 4 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -258,7 +258,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -432,10 +432,10 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r3` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r4` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r3.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r3.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r4.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r4.apk`
 
 固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`；WCG 仅保留单 worker 和适度 GC 设置，不再人为设置堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
@@ -466,7 +466,7 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
 ```
 
 安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r5 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
@@ -474,14 +474,14 @@ opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -544,7 +544,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 3 \
+  --release 4 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -557,7 +557,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/docs/testing/V1.3.0_R4_NODE_METRICS.tdd.md
+++ b/docs/testing/V1.3.0_R4_NODE_METRICS.tdd.md
@@ -1,0 +1,31 @@
+# v1.3.0-r4 node metrics refresh TDD evidence
+
+## User journey
+
+As a LuCI user, I want a manual `nodeTest` result to update the node row's
+state, Ping/latency, and quality immediately, so that the displayed result
+matches the test notification.
+
+## Evidence
+
+| Stage | Command | Result |
+|---|---|---|
+| RED | `node tests/js/wg_handshake_reason.test.js` | Failed before implementation: missing manual row-update helper |
+| GREEN | `node tests/js/wg_handshake_reason.test.js` | Passed; all three LuCI node views are covered |
+| Regression | `./scripts/ci/verify.sh` | Passed; 69 Python tests, Rust suites, 81.41% line coverage, audits and repository gates |
+| Package matrix | `./scripts/openwrt/verify-docker-matrix.sh` | Passed; 8/8 Standard/Lite rows installed, started, socket-ok, status-ok |
+| Hardware | AX6S r4 Lite install and `node-test.sh` | Passed; services/socket healthy and a real TCP test returned latency |
+
+## Guarantee
+
+The manual result is normalized to the same display fields as the periodic
+status export. A fresh manual result stays visible for 60 seconds so the next
+poll cannot overwrite it with an older export; after that, live service status
+resumes automatically.
+
+## Scope and gaps
+
+The change is limited to LuCI row rendering and does not alter protocol
+probes, routing, or the status-file producer. Browser automation is not
+available in the router matrix, so the UI behavior is covered by source-level
+regression guards plus the installed AX6S package and live RPC helper result.

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -106,6 +106,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -114,6 +132,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -119,6 +125,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -501,7 +508,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -106,6 +106,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -114,6 +132,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -119,6 +125,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -501,7 +508,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -122,6 +128,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -504,7 +511,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -109,6 +109,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -117,6 +135,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r3}
+version=${1:-1.3.0-r4}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=3
+release=4
 arch=x86_64
 service_bin=
 ctl_bin=

--- a/tests/js/wg_handshake_reason.test.js
+++ b/tests/js/wg_handshake_reason.test.js
@@ -96,6 +96,13 @@ function main() {
 			`${relative}: the test result banner must be rendered by a helper with an explicit close button`);
 		assert(source.includes("wlocI18n.t('Close')"),
 			`${relative}: the test result banner must have a close button`);
+		// A successful manual test must update the row immediately; the
+		// notification alone is not enough because the status export is polled
+		// independently and may still contain the previous result.
+		assert(source.includes('function updateNodeRow'),
+			`${relative}: manual test results must have a row-update helper`);
+		assert(source.includes('updateNodeRow(id, r);'),
+			`${relative}: manual test results must refresh the node row`);
 	});
 
 	i18nSources.forEach(function(relative) {

--- a/tests/js/wg_handshake_reason.test.js
+++ b/tests/js/wg_handshake_reason.test.js
@@ -103,6 +103,10 @@ function main() {
 			`${relative}: manual test results must have a row-update helper`);
 		assert(source.includes('updateNodeRow(id, r);'),
 			`${relative}: manual test results must refresh the node row`);
+		assert(source.includes('manualNodeResults'),
+			`${relative}: polling must not immediately overwrite a fresh manual result`);
+		assert(source.includes('function nodeForDisplay'),
+			`${relative}: manual results need an expiry before live status resumes`);
 	});
 
 	i18nSources.forEach(function(relative) {

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -80,9 +80,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r3.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r4.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r3.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r3.apk'; do
+	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r4.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r4.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 3'
+grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 4'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 3'
+grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 4'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r3.apk'; do
+	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r4.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r3}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 3'
+grep -F 'version=${1:-1.3.0-r4}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 4'
 
 printf '%s\n' 'release version tests passed'


### PR DESCRIPTION
## Summary
- update node status, Ping/latency, and Quality cells from the manual `nodeTest` RPC result
- keep the fresh result visible for 60 seconds so an older polled export cannot overwrite it
- apply the fix to standalone and integrated LuCI views
- bump the package release to `1.3.0-r4`

Closes #72

## TDD evidence
- RED: `node tests/js/wg_handshake_reason.test.js` failed before the row-update helper existed
- GREEN: the same test passed after implementation
- Checkpoint commits preserve both RED and GREEN stages

## Verification
- `./scripts/ci/verify.sh` — passed; Rust coverage 81.41%
- OpenWrt/iStoreOS matrix — 8/8 Standard/Lite combinations passed
- AX6S — r4 Lite installed; gateway/WLOC running; control socket and live NodeTest latency passed
- `git diff --check`, handoff validation, and secret scan — passed
- Handoff capsule: `.handoffs/issue-72.md`

## Rollback
Reinstall the previous `1.3.0-r3` package if rollback is required. UCI configuration is preserved.
