### PR TITLE
release: v1.3.0-r7 node health and three-platform packages

### DIFF
--- a/.handoffs/issue-72.md
+++ b/.handoffs/issue-72.md
@@ -21,8 +21,15 @@ manual LuCI `nodeTest` result.
   TCP and WireGuard results in the existing three metric cells.
 - Kept the manual result visible for 60 seconds so an older status export
   cannot immediately overwrite it.
-- Bumped the package release to `1.3.0-r4` and recorded TDD evidence.
-- Built all supported Standard/Lite assets and installed r4 Lite on AX6S.
+- Reused the single running WIFICalling Gateway sing-box for all node quality
+  probes through dedicated loopback HTTP inbounds; no temporary process or
+  duplicate proxy configuration is created.
+- Published monitor results to `/www/wloc-node-status.json` and added browser
+  cache bypassing so background metrics are visible in LuCI.
+- Bumped the package release to `1.3.0-r7` and updated bilingual README,
+  changelog, packaging metadata, tests, and release documentation.
+- Built all six Standard/Lite assets for the three supported platform targets
+  and installed r7 Lite on AX6S.
 
 ## Files changed
 
@@ -35,9 +42,10 @@ manual LuCI `nodeTest` result.
 | Command | Result | Evidence |
 |---|---|---|
 | `node tests/js/wg_handshake_reason.test.js` | Passed | Manual row refresh and 60-second polling overlay guards |
-| `./scripts/ci/verify.sh` | Passed | 69 Python tests, Rust suites, 81.41% line coverage, audits and repository gates |
+| `./scripts/ci/verify.sh` | Passed | 69 Python tests, Rust suites, 81.35% line coverage, audits and repository gates |
 | OpenWrt/iStoreOS matrix | Passed | 8/8 Standard/Lite rows installed, started, socket-ok, status-ok |
-| AX6S r4 Lite installation | Passed | Package version, both services, WLOC socket, and live NodeTest latency verified |
+| AX6S r7 Lite installation | Passed | Five node metrics, one WIFICalling sing-box process, status polling, and 30-second stability verified |
+| Release assets and checksums | Passed | Six r7 packages built and `SHA256SUMS` verified |
 | `git diff --check` and secret scan | Passed | No whitespace errors or sensitive values in the change |
 
 ## Failed attempts
@@ -51,7 +59,7 @@ manual LuCI `nodeTest` result.
 
 ## Next executable steps
 
-1. Push this branch and open a PR closing Issue #72.
+1. Keep PR #74 linked to this capsule and Issue #72.
 2. Wait for all GitHub repository gates and merge after they pass.
 
 ## Capabilities required for the next Agent

--- a/.handoffs/issue-72.md
+++ b/.handoffs/issue-72.md
@@ -1,0 +1,74 @@
+# Agent handoff: Issue 72
+
+## Identity and scope
+
+- Source agent ID: codex-node-status
+- Capabilities used: openwrt,test,ci,integration
+- Branch: codex/issue-72-node-status-manual-refresh
+- Checkpoint parent: `7a8781d`
+- Updated at (UTC): 2026-08-28
+- Credentials included: no
+
+## Objective
+
+Refresh a node row's status, Ping/latency, and quality immediately after a
+manual LuCI `nodeTest` result.
+
+## Completed
+
+- Added regression guards for manual row refresh and polling persistence.
+- Updated standalone and integrated LuCI views to normalize and render manual
+  TCP and WireGuard results in the existing three metric cells.
+- Kept the manual result visible for 60 seconds so an older status export
+  cannot immediately overwrite it.
+- Bumped the package release to `1.3.0-r4` and recorded TDD evidence.
+- Built all supported Standard/Lite assets and installed r4 Lite on AX6S.
+
+## Files changed
+
+- Three LuCI overview sources under `openwrt/`.
+- `tests/js/wg_handshake_reason.test.js` and release tests.
+- Release metadata, README/changelog, and the TDD evidence document.
+
+## Verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `node tests/js/wg_handshake_reason.test.js` | Passed | Manual row refresh and 60-second polling overlay guards |
+| `./scripts/ci/verify.sh` | Passed | 69 Python tests, Rust suites, 81.41% line coverage, audits and repository gates |
+| OpenWrt/iStoreOS matrix | Passed | 8/8 Standard/Lite rows installed, started, socket-ok, status-ok |
+| AX6S r4 Lite installation | Passed | Package version, both services, WLOC socket, and live NodeTest latency verified |
+| `git diff --check` and secret scan | Passed | No whitespace errors or sensitive values in the change |
+
+## Failed attempts
+
+- The first AX6S package build omitted the required binary environment inputs;
+  the build was rerun with the existing verified runtime binaries and passed.
+
+## Unresolved decisions and blockers
+
+- None.
+
+## Next executable steps
+
+1. Push this branch and open a PR closing Issue #72.
+2. Wait for all GitHub repository gates and merge after they pass.
+
+## Capabilities required for the next Agent
+
+- openwrt
+- test
+- ci
+- security-review
+
+## Environment assumptions
+
+- OpenWrt 24.10 uses IPK and OpenWrt 25.12 uses native APK.
+- Existing UCI configuration is preserved during package replacement.
+
+## Security and privacy notes
+
+- No API keys, tokens, private keys, `.env` values, raw captures, device
+  identifiers, or precise user locations are included.
+- The manual result is a display overlay only; it does not alter routing or
+  the backend status producer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r4] - 2026-08-28
+
+Hotfix for stale node metrics after a manual node test.
+
+- Refresh the node status, ping/latency, and quality cells immediately from
+  the `node_test` result.
+
 ## [1.3.0-r3] - 2026-08-28
 
 Hotfix for an additional VLESS share-link encoding variant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r7] - 2026-08-28
+
+Node health and AX6S stability release. This release consolidates the r5/r6
+test packages and is the current three-platform release.
+
+- Reuse the one already-running WIFICalling Gateway sing-box for every node
+  quality test through dedicated loopback HTTP inbounds; no temporary
+  sing-box process or duplicate proxy configuration is created.
+- Report proxy-path reachability and total request latency for all protocols;
+  background checks run about every 30 seconds with a 60-second per-node
+  result cache, while `nodeTest` bypasses the cache for an immediate test.
+- Publish the monitor result to the LuCI-readable `/www/wloc-node-status.json`
+  file and bypass browser caching so refreshed LuCI pages show new metrics.
+- Keep AX6S Lite single-worker/moderate-GC operation without an artificial
+  heap ceiling; live AX6S verification confirmed five node metrics, one
+  WIFICalling sing-box process, and no new OOM event during the stability run.
+
+### 中文说明
+
+节点健康与 AX6S 稳定性版本。本版本合并 r5/r6 测试包的验证结果，作为当前三平台正式发布版本。
+
+- 所有节点质量测试统一复用正在运行的 WIFICalling Gateway sing-box，
+  通过专用回环 HTTP 入站探测，不再启动临时 sing-box 或重复代理配置。
+- 所有协议统一报告代理链路可达性与完整请求延迟；后台约每 30 秒检查一次，
+  单节点结果缓存 60 秒；`nodeTest` 会绕过缓存并立即测试。
+- 后台结果统一写入 LuCI 可读取的 `/www/wloc-node-status.json`，并绕过浏览器缓存，
+  页面刷新后可以显示最新指标。
+- AX6S Lite 保持单 worker 与适度 GC，不设置人为堆上限；AX6S 真机验证确认 5 个节点均有指标、
+  WIFICalling 只有 1 个 sing-box 进程，稳定性观察期间没有新的 OOM。
+
 ## [1.3.0-r4] - 2026-08-28
 
 Hotfix for stale node metrics after a manual node test.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r4-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r4)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r7-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r7)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -57,11 +57,13 @@ The core boundary of the project is "**independent, precise, and revertible**": 
   tunnels and protocol stacks stay off, so memory scales with the nodes
   actually in use rather than the total configured (measured on AX6S:
   sing-box RSS ~19-23 MB → ~15 MB).
-- Per-node **nodeTest** button: run a fresh connection test on demand -
-  a real WireGuard handshake (bypassing the monitor's result cache) or a
-  TCP reachability probe for other protocols - with the verified exit IP
-  or a classified failure reason (missing config / timeout / unreachable)
-  in a banner that stays until closed.
+- Per-node **nodeTest** button: run a fresh proxy-path test on demand through
+  the already-running Gateway sing-box. Every protocol reports reachability
+  and total request latency without creating a second sing-box process; the
+  result banner stays until closed.
+- Background node quality polling runs about every 30 seconds, re-probes each
+  node at most once per 60 seconds, and publishes the result to LuCI with
+  browser-cache bypassing. Manual nodeTest always bypasses this cache.
 - A dedicated **Service Status** page (Services > Service Status) reports
   both services at a glance - daemon processes, config validity, nftables
   rules, build patches, and node health - refreshed every 10 seconds.
@@ -114,7 +116,7 @@ More detail: [WLOC Service API](docs/api/WLOC_SERVICE_API.md), [Threat model](do
 
 | Platform | Arch | Package manager | Current evidence | Status |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r5 Lite asset installed and cold-booted; 20.4 MB overlay remained free; WCG/WLOC, tmpfs sing-box, nftables and config hashes passed; a real iPhone WLOC request was intercepted and synthesized | **Docker + router + iPhone WLOC passed** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r7 Lite asset installed; five node proxy metrics passed, one WIFICalling sing-box remained running, status polling and 30-second stability check passed; prior live iPhone WLOC interception and synthesis also passed | **Docker + router + iPhone WLOC passed** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker boot of init/ubus, integrated package install, service start, socket and v1 status checks | **Install matrix passed** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | Same as above | **Install matrix passed** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | Same, using native APK v3, not a renamed IPK | **Install matrix passed** |
@@ -133,10 +135,10 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r4` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r7` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r4.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r4.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r7_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r7_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r7.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r7.apk`
 
 Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and keeps only the single-worker/moderate-GC runtime profile without an artificial heap ceiling. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
@@ -167,22 +169,22 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk
 ```
 
-Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r5 Lite package replaces the separate sing-box package and owns its transparent wrapper.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r7 Lite package replaces the separate sing-box package and owns its transparent wrapper.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r7_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r7.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -245,7 +247,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 4 \
+  --release 7 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -258,7 +260,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r7"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -362,7 +364,8 @@ Wi‑Fi Calling Location Gateway 将两个原本分离的流程组织在同一�
 - 精确到“指定设备 + 授权主机 + TCP 443”的 DNS/nftables 隔离。
 - root-only Unix Socket 控制 API，以及经 rpcd 授权的 LuCI 管理桥接。
 - Wi‑Fi Calling 隧道状态、WLOC 当前目标与脱敏事件日志。
-- 每个节点提供 **nodeTest** 测试按钮：随时执行一次新的连接测试——WireGuard 节点进行真实握手（绕过监控循环的结果缓存），其他协议执行 TCP 连通性探测；结果显示出口 IP 或分类失败原因（配置缺失 / 超时 / 不可达），横幅带关闭按钮且不会自动消失。
+- 每个节点提供 **nodeTest** 测试按钮：通过正在运行的 Gateway sing-box 立即执行代理链路测试。所有协议统一显示可达性与完整请求延迟，不创建第二个 sing-box 进程；结果横幅带关闭按钮且不会自动消失。
+- 节点网络质量后台约每 30 秒轮询一次，每个节点实际最多每 60 秒重新探测一次；结果写入 LuCI 状态文件并绕过浏览器缓存。手动 nodeTest 始终绕过缓存。
 - 只把设备策略实际引用的代理节点编译进 `sing-box.json` 并加载到内存——未引用的 WireGuard 隧道和协议栈不驻留，内存随实际使用节点数而非配置总数增长（AX6S 实测：sing-box RSS 从约 19-23 MB 降到约 15 MB）。
 - IPK（OpenWrt 24.10 / iStoreOS 24.10）与原生 APK v3（OpenWrt 25.12）打包。
 - 固定 SDK/工具链、离线锁定编译、依赖审计、覆盖率门禁和 Docker 启动验证。
@@ -413,7 +416,7 @@ flowchart TD
 
 | 平台 | 架构 | 包管理器 | 当前证据 | 状态 |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r5 Lite 原包已安装并冷启动；overlay 剩余 20.4 MB；WCG/WLOC、tmpfs sing-box、nftables 与配置哈希通过；已实际收到并处理 iPhone WLOC 请求 | **Docker + 路由器 + iPhone WLOC 通过** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r7 Lite；5 个节点代理指标、单 WIFICalling sing-box、状态轮询和 30 秒稳定性检查通过；此前 iPhone WLOC 拦截与响应生成也已通过 | **Docker + 路由器 + iPhone WLOC 通过** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker 中启动 init/ubus、安装集成包、启动服务、Socket 与 v1 状态检查 | **安装矩阵通过** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | 同上 | **安装矩阵通过** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | 同上，使用原生 APK v3，非改名 IPK | **安装矩阵通过** |
@@ -432,10 +435,10 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r4` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r7` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r4.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r4.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r7_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r7_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r7.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r7.apk`
 
 固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`；WCG 仅保留单 worker 和适度 GC 设置，不再人为设置堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
@@ -466,22 +469,22 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r5 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r7 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r7_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r7.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -544,7 +547,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 4 \
+  --release 7 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -557,7 +560,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r7"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r3-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r3)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r4-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r4)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -133,10 +133,10 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r3` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r4` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r3.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r3.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r4.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r4.apk`
 
 Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and keeps only the single-worker/moderate-GC runtime profile without an artificial heap ceiling. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
@@ -167,7 +167,7 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
 ```
 
 Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r5 Lite package replaces the separate sing-box package and owns its transparent wrapper.
@@ -175,14 +175,14 @@ Back up both UCI files first. On storage-constrained AX6S units, stop the servic
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -245,7 +245,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 3 \
+  --release 4 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -258,7 +258,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -432,10 +432,10 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r3` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r4` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r3.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r3.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r4.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r4.apk`
 
 固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`；WCG 仅保留单 worker 和适度 GC 设置，不再人为设置堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
@@ -466,7 +466,7 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r4_aarch64_cortex-a53.ipk
 ```
 
 安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r5 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
@@ -474,14 +474,14 @@ opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r3_aarch64_cortex-a53.
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r3_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r4_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r3.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r4.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -544,7 +544,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 3 \
+  --release 4 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -557,7 +557,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r3"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r4"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md
+++ b/docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md
@@ -37,8 +37,8 @@ Then build the release packages:
 
 ```sh
 ./scripts/openwrt/build-release-packages.sh \
-  --version 1.2.2 \
-  --release 4 \
+  --version 1.3.0 \
+  --release 7 \
   --arch x86_64 \
   --service-bin /absolute/path/wloc-service \
   --ctl-bin /absolute/path/wloc-ctl \
@@ -69,7 +69,7 @@ Run:
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir /absolute/path/dist/wloc-openwrt-release-r4
+  --dist-dir /absolute/path/dist/wloc-openwrt-release-r7
 ```
 
 For each environment the verifier boots `/sbin/init`, waits for ubus, installs

--- a/docs/testing/V1.3.0_R4_NODE_METRICS.tdd.md
+++ b/docs/testing/V1.3.0_R4_NODE_METRICS.tdd.md
@@ -1,0 +1,31 @@
+# v1.3.0-r4 node metrics refresh TDD evidence
+
+## User journey
+
+As a LuCI user, I want a manual `nodeTest` result to update the node row's
+state, Ping/latency, and quality immediately, so that the displayed result
+matches the test notification.
+
+## Evidence
+
+| Stage | Command | Result |
+|---|---|---|
+| RED | `node tests/js/wg_handshake_reason.test.js` | Failed before implementation: missing manual row-update helper |
+| GREEN | `node tests/js/wg_handshake_reason.test.js` | Passed; all three LuCI node views are covered |
+| Regression | `./scripts/ci/verify.sh` | Passed; 69 Python tests, Rust suites, 81.41% line coverage, audits and repository gates |
+| Package matrix | `./scripts/openwrt/verify-docker-matrix.sh` | Passed; 8/8 Standard/Lite rows installed, started, socket-ok, status-ok |
+| Hardware | AX6S r4 Lite install and `node-test.sh` | Passed; services/socket healthy and a real TCP test returned latency |
+
+## Guarantee
+
+The manual result is normalized to the same display fields as the periodic
+status export. A fresh manual result stays visible for 60 seconds so the next
+poll cannot overwrite it with an older export; after that, live service status
+resumes automatically.
+
+## Scope and gaps
+
+The change is limited to LuCI row rendering and does not alter protocol
+probes, routing, or the status-file producer. Browser automation is not
+available in the router matrix, so the UI behavior is covered by source-level
+regression guards plus the installed AX6S package and live RPC helper result.

--- a/docs/testing/V1.3.0_SINGLE_PROCESS_NODE_PROBE.tdd.md
+++ b/docs/testing/V1.3.0_SINGLE_PROCESS_NODE_PROBE.tdd.md
@@ -1,0 +1,31 @@
+# Single-process node probe TDD evidence
+
+## User journey
+
+As an AX6S user, I want node tests to reuse the running Gateway sing-box, so
+testing a node cannot create a second memory-heavy sing-box process.
+
+## RED
+
+`node --test tests/js/node_probe_single_process.test.js` failed before the
+implementation because the compiler had no loopback probe inbound and the
+health helper still contained `sing-box run`.
+
+## GREEN
+
+The implementation adds one loopback HTTP inbound per active node, routes each
+inbound to that node's existing outbound, and makes both manual and periodic
+tests call the existing process. The temporary WireGuard process and its
+temporary configuration/log files are removed.
+
+Validation passed:
+
+- `node --test tests/js/node_probe_single_process.test.js tests/js/wg_handshake_reason.test.js`
+- `node --test tests/js/*.test.js`
+- `./tests/scripts/test-standalone-ax6s-package.sh`
+- Generated mixed VLESS/WireGuard configuration passed JSON validation and
+  sing-box 1.13 `check` in an Alpine container.
+- `./scripts/ci/verify.sh` passed; Rust coverage was 81.41%.
+
+Known deployment gap: AX6S has not been restarted with this source change in
+this turn. The package must be rebuilt and installed before live verification.

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=7
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -18,8 +18,14 @@ wireguard_style() {
 	if [ "$major" -eq 1 ] && [ "$minor" -lt 11 ]; then printf 'legacy'; else printf 'endpoint'; fi
 }
 
+probe_port() {
+	local id="$1" hash
+	hash=$(printf '%s' "$id" | md5sum | cut -c1-4)
+	printf '%d' "$((20000 + (0x$hash % 10000)))"
+}
+
 append_node() {
-	local s="$1" enabled label protocol server port password sni insecure alpn uuid congestion udp_mode public_key short_id fingerprint security transport path host flow alter_id credential auxiliary pin_sha256 private_key local_address reserved mtu
+	local s="$1" enabled label protocol server port password sni insecure alpn uuid congestion udp_mode public_key short_id fingerprint security transport path host flow alter_id credential auxiliary pin_sha256 private_key local_address reserved mtu pre_shared_key test_port
 	config_get_bool enabled "$s" enabled 1
 	[ "$enabled" -eq 1 ] || return 0
 	config_get label "$s" label "$s"; config_get protocol "$s" protocol
@@ -46,10 +52,12 @@ append_node() {
 		trojan) credential=$password; auxiliary= ;;
 		wireguard) credential=$private_key; auxiliary= ;;
 	esac
+	test_port=$(probe_port "$s")
+	printf 'probe|%s|%s\n' "$s" "$test_port" >> "$RUNDIR/normalized.conf"
 	printf 'node|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' "$s" "$protocol" "$server" "$port" "$credential" "$sni" "$insecure" "$alpn" "$auxiliary" "$congestion" "$udp_mode" "$public_key" "$short_id" "$fingerprint" "$security" "$transport" "$path" "$host" "$pin_sha256" "$private_key" "$local_address" "$reserved" "$mtu" "$pre_shared_key" >> "$RUNDIR/normalized.conf"
 	local safe_label
 	safe_label=$(printf '%s' "$label" | tr '|' ' ')
-	printf '%s|%s|%s|%s|%s\n' "$s" "$safe_label" "$protocol" "$server" "$port" >> "$RUNDIR/nodes"
+	printf '%s|%s|%s|%s|%s|%s\n' "$s" "$safe_label" "$protocol" "$server" "$port" "$test_port" >> "$RUNDIR/nodes"
 }
 
 append_ip() { DEVICE_IPS="${DEVICE_IPS}${DEVICE_IPS:+,}$1"; }

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -117,7 +117,7 @@ start_service() {
 	procd_set_param limits nofile="65535 65535"
 	procd_close_instance
 	procd_open_instance monitor
-	procd_set_param command /usr/libexec/$APP/monitor-loop.sh "$RUNDIR/clients" "$RUNDIR/status.json" "$RUNDIR/nodes" "$RUNDIR/node-status.json" "$RUNDIR/events.log" "$RUNDIR/monitor.state" "$event_interval" "$max_events_per_device" "$log_enabled"
+	procd_set_param command /usr/libexec/$APP/monitor-loop.sh "$RUNDIR/clients" "$RUNDIR/status.json" "$RUNDIR/nodes" "/www/wloc-node-status.json" "$RUNDIR/events.log" "$RUNDIR/monitor.state" "$event_interval" "$max_events_per_device" "$log_enabled"
 	procd_set_param respawn
 	procd_close_instance
 }

--- a/openwrt/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/files/usr/libexec/rpcd/luci.wloc
@@ -235,10 +235,8 @@ call)
 		exit 0
 		;;
 	node_test)
-		# Manual connection test for a single node. WireGuard nodes get a
-		# fresh handshake (bypassing the monitor's result cache); other
-		# protocols get a TCP reachability probe. The helper reuses the
-		# monitor's handshake function where applicable.
+		# Manual connection test for a single node. Every protocol uses the
+		# existing Gateway sing-box loopback probe and bypasses the monitor cache.
 		read -r input
 		json_load "$input"
 		json_get_var id id

--- a/openwrt/files/usr/libexec/wificalling-gateway/compiler.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/compiler.sh
@@ -24,6 +24,11 @@ function tls(sni, insecure, alpn, pin, extra) {
   return "{" extra "}"
 }
 $1=="global" { if ($2=="log_level") level=$3; if ($2=="wireguard_style") wg_style=$3; next }
+$1=="probe" {
+  if ($2=="" || $3 !~ /^[0-9]+$/ || $3<1024 || $3>65535) fail("invalid probe port for node: " $2)
+  if (probe_owner[$3] && probe_owner[$3]!=$2) fail("duplicate probe port: " $3)
+  probe_port_by_id[$2]=$3; probe_owner[$3]=$2; next
+}
 $1=="node" {
   id=$2; proto=$3
   if (id=="" || seen_node[id]++) fail("duplicate or empty node id: " id)
@@ -37,6 +42,7 @@ $1=="node" {
     if ($23!="" && $23 !~ /^[0-9]+(,[0-9]+)*$/) fail("wireguard node " id " reserved must be comma-separated numbers: " $23)
     if ($24!="" && $24 !~ /^[0-9]+$/) fail("wireguard node " id " mtu must be a number: " $24)
   }
+  if (!probe_port_by_id[id]) fail("node " id " is missing a probe port")
   node[++nn]=$0; node_id[nn]=id; node_proto[id]=proto
   if (proto=="wireguard") wg_nodes[++nw]=nn
   next
@@ -86,7 +92,13 @@ END {
     print "  ],"
   }
   print "  \"log\":{\"level\":" q(level) ",\"timestamp\":true},"
-  print "  \"inbounds\":[{\"type\":\"tproxy\",\"tag\":\"wfc-tcp\",\"listen\":\"0.0.0.0\",\"listen_port\":11441,\"network\":\"tcp\"},{\"type\":\"tproxy\",\"tag\":\"wfc-udp\",\"listen\":\"0.0.0.0\",\"listen_port\":11442,\"network\":\"udp\"}],"
+  inbounds="  \"inbounds\":[{\"type\":\"tproxy\",\"tag\":\"wfc-tcp\",\"listen\":\"0.0.0.0\",\"listen_port\":11441,\"network\":\"tcp\"},{\"type\":\"tproxy\",\"tag\":\"wfc-udp\",\"listen\":\"0.0.0.0\",\"listen_port\":11442,\"network\":\"udp\"}"
+  for(k=1;k<=nn;k++) {
+    split(node[k],f,"|"); id=f[2]
+    if (!used[id]) continue
+    inbounds=inbounds ",{\"type\":\"http\",\"tag\":" q("probe-" id) ",\"listen\":\"127.0.0.1\",\"listen_port\":" probe_port_by_id[id] "}"
+  }
+  print inbounds "],"
   print "  \"outbounds\":["
   for(k=1;k<=nn;k++) {
     split(node[k],f,"|"); id=f[2]; p=f[3]
@@ -136,6 +148,12 @@ END {
   print "    {\"type\":\"direct\",\"tag\":\"direct\"}"
   print "  ],"
   print "  \"route\":{\"auto_detect_interface\":true,\"final\":\"direct\",\"rules\":["
+  for(k=1;k<=nn;k++) {
+    split(node[k],f,"|"); id=f[2]
+    if (!used[id]) continue
+    out=(node_proto[id]=="wireguard" && wg_style=="endpoint") ? "wg-" id : "node-" id
+    print "    {\"inbound\":[" q("probe-" id) "],\"action\":\"route\",\"outbound\":" q(out) "},"
+  }
   print "    {\"ip_is_private\":true,\"action\":\"route\",\"outbound\":\"direct\"}" (nd?",":"")
   for(k=1;k<=nd;k++) {
     n=split(devips[k],ips,","); list=""

--- a/openwrt/files/usr/libexec/wificalling-gateway/node-health.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/node-health.sh
@@ -12,34 +12,32 @@ json_escape() {
 	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
-# Real WireGuard handshake validation: run a temporary sing-box
-# endpoint for the node and ask an echo service through it. The
-# result is cached for 60s (the monitor loop runs every 5s and a
-# handshake test takes seconds). Prints the exit IP on success.
-# The reserved field is forwarded too: WARP-style endpoints need it
-# and would otherwise fail every handshake. Cache line 3 carries the
-# failure reason (config_missing / timeout / unreachable) so the
-# status export can tell a bad node apart from a dead server.
-# A mkdir lock serializes the actual tests: the monitor loop can
-# tick a fresh instance before this one finished (a handshake takes
-# up to ~8s, the loop ticks every 5s), and two instances racing on
-# the same probe port would hand each other the wrong exit IP.
-wg_handshake_test() {
-	id=$1; server=$2; port=$3
-	cache="/tmp/wg-health-$id"
-	lock=/tmp/wg-health.lock
+probe_port_for() {
+	local id hash
+	hash=$(printf '%s' "$1" | md5sum | cut -c1-4)
+	printf '%d' "$((20000 + (0x$hash % 10000)))"
+}
+
+# Probe through the loopback inbound compiled into the already-running
+# Gateway sing-box. Each node's inbound is routed to that node's outbound,
+# which validates the complete proxy path without creating another process.
+# Cache entries last 60s; the cache is only a status optimization and never
+# starts or owns a network process.
+node_proxy_test() {
+	id=$1; probe_port=$2
+	cache="/tmp/node-health-$id"
+	lock="/tmp/node-health.lock"
 	if [ -f "$cache" ]; then
 		cache_ts=$(sed -n '1p' "$cache" 2>/dev/null || echo 0)
-		age=$(($(date +%s) - ${cache_ts:-0}))
-		if [ "$age" -lt 60 ] 2>/dev/null; then
+		case "$cache_ts" in *[!0-9]*|'') cache_ts=0;; esac
+		age=$(($(date +%s) - cache_ts))
+		if [ "$age" -ge 0 ] && [ "$age" -lt 60 ]; then
 			[ "$(sed -n '2p' "$cache")" = ok ] || return 1
-			sed -n '3p' "$cache"
+			printf '%s|%s' "$(sed -n '3p' "$cache")" "$(sed -n '4p' "$cache")"
 			return 0
 		fi
 	fi
 	if ! mkdir "$lock" 2>/dev/null; then
-		# A tick killed mid-test (SIGHUP/reboot) can leave the lock
-		# behind; its holder PID is gone, so take it over.
 		lock_pid=$(cat "$lock/pid" 2>/dev/null || echo 0)
 		if ! kill -0 "$lock_pid" 2>/dev/null; then
 			rm -f "$lock/pid"; rmdir "$lock" 2>/dev/null || true
@@ -47,98 +45,41 @@ wg_handshake_test() {
 		fi
 	fi
 	if ! [ -d "$lock" ]; then
-		# Another monitor tick is testing right now; use the cache
-		# as-is (even stale) instead of racing on the probe port.
-		if [ -f "$cache" ] && [ "$(sed -n '2p' "$cache")" = ok ]; then
-			sed -n '3p' "$cache"
-			return 0
-		fi
 		return 1
 	fi
 	echo $$ > "$lock/pid"
-	priv=$(uci -q get "wificalling-gateway.$id.private_key") || true
-	pub=$(uci -q get "wificalling-gateway.$id.public_key") || true
-	local_addr=$(uci -q get "wificalling-gateway.$id.local_address") || true
-	if [ -z "$priv" ] || [ -z "$pub" ] || [ -z "$local_addr" ]; then
-		printf '%s\nfailed\nconfig_missing\n' "$(date +%s)" > "$cache"
+	result=$(curl -sS --max-time 8 -x "http://127.0.0.1:$probe_port" \
+		-w '\n%{time_total}' 'http://ip-api.com/json?fields=query' 2>/dev/null || true)
+	seconds=$(printf '%s\n' "$result" | tail -n 1)
+	ping_ms=$(printf '%s\n' "$seconds" | awk '/^[0-9]+(\.[0-9]+)?$/ { printf "%.2f", $1 * 1000 }')
+	body=$(printf '%s\n' "$result" | sed '$d')
+	exit_ip=$(printf '%s\n' "$body" | sed -n 's/.*"query":"\([0-9.]*\)".*/\1/p')
+	if [ -n "$ping_ms" ]; then
+		printf '%s\nok\n%s\n%s\n' "$(date +%s)" "$ping_ms" "$exit_ip" > "$cache"
 		rm -f "$lock/pid"; rmdir "$lock" 2>/dev/null || true
-		return 1
-	fi
-	psk=$(uci -q get "wificalling-gateway.$id.pre_shared_key") || true
-	mtu=$(uci -q get "wificalling-gateway.$id.mtu") || true
-	reserved=$(uci -q get "wificalling-gateway.$id.reserved") || true
-	lport=$((19000 + (0x$(printf '%s' "$id" | md5sum | cut -c1-4) % 1000))) 2>/dev/null || lport=19099
-	cfg="/tmp/wg-health-$id.json"
-	{
-		printf '{"log":{"level":"debug"},"inbounds":[{"type":"http","tag":"probe","listen":"127.0.0.1","listen_port":%s}],' "$lport"
-		printf '"endpoints":[{"type":"wireguard","tag":"wg","address":[%s],"private_key":%s,"peers":[{"address":%s,"port":%s,"public_key":%s,"allowed_ips":["0.0.0.0/0"]' \
-			"\"$local_addr\"" "\"$priv\"" "\"$server\"" "$port" "\"$pub\""
-		[ -n "$psk" ] && printf ',"pre_shared_key":"%s"' "$psk"
-		[ -n "$reserved" ] && printf ',"reserved":[%s]' "$(printf '%s' "$reserved" | tr -d ' ')"
-		printf '}],"mtu":%s}],"outbounds":[{"type":"direct","tag":"direct"}],"route":{"final":"wg"}}' "${mtu:-1420}"
-	} > "$cfg"
-	/usr/bin/sing-box run -c "$cfg" > /tmp/wg-health-$id.log 2>&1 &
-	pid=$!
-	sleep 2
-	ip=$(curl -s --max-time 6 -x "http://127.0.0.1:$lport" 'http://ip-api.com/json?fields=query' 2>/dev/null | sed -n 's/.*"query":"\([0-9.]*\)".*/\1/p' || true)
-	kill "$pid" 2>/dev/null || true
-	wait "$pid" 2>/dev/null || true
-	if [ -n "$ip" ]; then
-		rm -f "$cfg" /tmp/wg-health-$id.log
-		printf '%s\nok\n%s\n' "$(date +%s)" "$ip" > "$cache"
-		rm -f "$lock/pid"; rmdir "$lock" 2>/dev/null || true
-		printf '%s' "$ip"
+		printf '%s|%s' "$ping_ms" "$exit_ip"
 		return 0
 	fi
-	if grep -q 'handshake did not complete' /tmp/wg-health-$id.log 2>/dev/null; then
-		reason=timeout
-	else
-		reason=unreachable
-	fi
-	rm -f "$cfg" /tmp/wg-health-$id.log
-	printf '%s\nfailed\n%s\n' "$(date +%s)" "$reason" > "$cache"
 	rm -f "$lock/pid"; rmdir "$lock" 2>/dev/null || true
+	printf '%s\nfailed\nproxy_failed\n' "$(date +%s)" > "$cache"
 	return 1
 }
 
 {
 	printf '{"generated_at":%s,"nodes":[' "$(date +%s)"
 	first=1
-	while IFS='|' read -r id label protocol server port; do
+	while IFS='|' read -r id label protocol server port probe_port; do
 		[ -n "$id" ] || continue
-		ping_output=$(ping -c 1 -W 1 "$server" 2>/dev/null || true)
-		latency=$(printf '%s\n' "$ping_output" | sed -n 's/.*time[=<]\{0,1\}\([0-9][0-9.]*\)[[:space:]]*ms.*/\1/p' | head -n 1)
-		state=no_icmp_reply; ping_json=null; measurement=icmp
-		if [ -n "$latency" ]; then
-			state=reachable; ping_json=$latency
-		else
-			case "$protocol" in
-				anytls|vless|vmess|trojan)
-					if command -v tcping >/dev/null 2>&1; then
-						measurement=tcp
-						tcp_output=$(tcping -c 1 -t 1 -p "$port" "$server" 2>/dev/null || true)
-						latency=$(printf '%s\n' "$tcp_output" | sed -n 's/.*time=\([0-9][0-9.]*\)[[:space:]]*ms.*/\1/p' | head -n 1)
-						if [ -n "$latency" ]; then state=tcp_reachable; ping_json=$latency; else state=unreachable; fi
-					fi
-					;;
-			esac
-		fi
-		# WireGuard nodes are validated by a real handshake, not ICMP.
-		if [ "$protocol" = wireguard ]; then
-			measurement=wg_handshake
-			if exit_ip=$(wg_handshake_test "$id" "$server" "$port"); then
-				state=handshake_ok; ping_json="\"$exit_ip\""; reason_json=null
-			else
-				state=handshake_failed; ping_json=null
-				reason_json="\"$(sed -n '3p' "/tmp/wg-health-$id" 2>/dev/null || echo unreachable)\""
-			fi
-		else
-			reason_json=null
+		[ -n "$probe_port" ] || probe_port=$(probe_port_for "$id")
+		state=proxy_failed; measurement=proxy; ping_json=null; reason_json='"proxy_failed"'
+		if result=$(node_proxy_test "$id" "$probe_port"); then
+			ping_ms=${result%%|*}
+			state=proxy_reachable; ping_json=$ping_ms; reason_json=null
 		fi
 		[ "$first" -eq 1 ] || printf ','
 		first=0
-printf '{"id":"%s","state":"%s","measurement":"%s","ping_ms":%s,"reason":%s}' \
-			"$(json_escape "$id")" "$state" "$measurement" "$ping_json" "${reason_json:-null}"
+		printf '{"id":"%s","state":"%s","measurement":"%s","ping_ms":%s,"reason":%s}' \
+			"$(json_escape "$id")" "$state" "$measurement" "$ping_json" "$reason_json"
 	done < "$nodes"
 	printf ']}\n'
 } > "$tmp"

--- a/openwrt/files/usr/libexec/wificalling-gateway/node-test.sh
+++ b/openwrt/files/usr/libexec/wificalling-gateway/node-test.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 # node-test.sh — manual connection test for one proxy node.
 #
-# WireGuard nodes run the same handshake probe the monitor loop uses (the
-# function is extracted from the patched node-health.sh, so there is
-# exactly one implementation), bypassing the 60s result cache so the user
-# gets a fresh answer on demand. Every other protocol gets a TCP
-# reachability probe of the node's server:port (tcping when installed,
-# busybox nc otherwise). Prints one JSON object; always exits 0 so rpcd
-# forwards the reply untouched.
+# Every protocol is tested through the loopback HTTP inbound of the already
+# running Gateway sing-box. The inbound is compiled with a fixed route to
+# this node's existing outbound, so no second sing-box process is needed.
+# Prints one JSON object; always exits 0 so rpcd forwards the reply untouched.
 
 set -eu
 
@@ -20,62 +17,15 @@ if [ -z "$server" ] || [ -z "$port" ]; then
 	exit 0
 fi
 
-proto=$(uci -q get "wificalling-gateway.$id.protocol") || true
-if [ "$proto" = wireguard ]; then
-	health=/usr/libexec/wificalling-gateway/node-health.sh
-	[ -f "$health" ] || {
-		printf '{"state":"failed","reason":"no_health_script"}\n'
-		exit 0
-	}
-
-	# Extract the handshake function from the patched monitor script so
-	# the manual test and the monitor loop share one implementation.
-	func=$(mktemp /tmp/wg-test-func.XXXXXX)
-	trap 'rm -f "$func"' EXIT HUP INT TERM
-	awk '/^wg_handshake_test\(\)/,/^}/' "$health" > "$func"
-	. "$func"
-
-	# The monitor loop may be mid-test right now; wait for its lock so
-	# this run is authoritative (a handshake takes up to ~8s, give it 20s).
-	n=0
-	while [ -d /tmp/wg-health.lock ]; do
-		n=$((n + 1))
-		[ "$n" -ge 40 ] && {
-			printf '{"state":"failed","reason":"busy"}\n'
-			exit 0
-		}
-		sleep 1
-	done
-
-	# Bypass the 60s cache: the cached result is exactly what the user
-	# is asking to re-check.
-	rm -f "/tmp/wg-health-$id"
-
-	if exit_ip=$(wg_handshake_test "$id" "$server" "$port"); then
-		printf '{"state":"handshake_ok","exit_ip":"%s"}\n' "$exit_ip"
-	else
-		reason=$(sed -n '3p' "/tmp/wg-health-$id" 2>/dev/null || echo unreachable)
-		printf '{"state":"handshake_failed","reason":"%s"}\n' "$reason"
-	fi
+test_port=$(printf '%s' "$id" | md5sum | cut -c1-4)
+test_port=$((20000 + (0x$test_port % 10000)))
+result=$(curl -sS --max-time 8 -x "http://127.0.0.1:$test_port" \
+	-w '\n%{time_total}' 'http://ip-api.com/json?fields=query' 2>/dev/null || true)
+seconds=$(printf '%s\n' "$result" | tail -n 1)
+ms=$(printf '%s\n' "$seconds" | awk '/^[0-9]+(\.[0-9]+)?$/ { printf "%.2f", $1 * 1000 }')
+[ -n "$ms" ] || {
+	printf '{"state":"unreachable","reason":"proxy_failed"}\n'
 	exit 0
-fi
-
-# Non-WireGuard protocols: TCP reachability of the node server.
-if command -v tcping >/dev/null 2>&1; then
-	ms=$(tcping -c 1 -t 2 -p "$port" "$server" 2>/dev/null |
-		sed -n 's/.*time=\([0-9][0-9.]*\)[[:space:]]*ms.*/\1/p' | head -n 1)
-	if [ -n "$ms" ]; then
-		printf '{"state":"tcp_reachable","ping_ms":"%s"}\n' "$ms"
-	else
-		printf '{"state":"unreachable","reason":"tcp_failed"}\n'
-	fi
-elif command -v nc >/dev/null 2>&1; then
-	if nc -w 3 "$server" "$port" >/dev/null 2>&1; then
-		printf '{"state":"tcp_reachable","ping_ms":null}\n'
-	else
-		printf '{"state":"unreachable","reason":"tcp_failed"}\n'
-	fi
-else
-	printf '{"state":"failed","reason":"no_tcp_probe"}\n'
-fi
+}
+printf '{"state":"proxy_reachable","measurement":"proxy","ping_ms":"%s"}\n' "$ms"
 exit 0

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -68,7 +68,7 @@ return view.extend({
 				var reason = wgFailReason(n.reason);
 				return wlocI18n.t('Handshake failed') + (reason ? ' (' + reason + ')' : '');
 			}
-			if (n.state === 'reachable' || n.state === 'tcp_reachable') return wlocI18n.t('Alive');
+			if (n.state === 'reachable' || n.state === 'tcp_reachable' || n.state === 'proxy_reachable') return wlocI18n.t('Alive');
 			if (n.state === 'unreachable') return wlocI18n.t('Offline');
 			return wlocI18n.t('Unknown');
 		}
@@ -146,7 +146,7 @@ return view.extend({
 				else if (r && r.state === 'handshake_failed') {
 					testNotify(wlocI18n.t('Handshake failed') + ' (' + wgFailReason(r.reason) + ')', 'error', wgFailDetail(r.reason));
 				}
-				else if (r && r.state === 'tcp_reachable') {
+				else if (r && (r.state === 'tcp_reachable' || r.state === 'proxy_reachable')) {
 					testNotify(wlocI18n.t('Alive') + (r.ping_ms ? ' — ' + r.ping_ms + ' ms' : ''), 'info');
 				}
 				else if (r && r.state === 'unreachable') {

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -86,10 +86,9 @@ return view.extend({
 			if (reason === 'unreachable') return wlocI18n.t('Server unreachable');
 			return '';
 		}
-		// Manual connection test: asks the router to run a fresh check
-		// right now - a WireGuard handshake (bypassing the monitor's
-		// result cache) or a TCP reachability probe for other protocols -
-		// and reports the exit IP or the failure reason.
+		// Manual connection test: asks the router to run a fresh proxy-path
+		// check through the existing Gateway sing-box, bypassing the monitor's
+		// result cache, and reports latency or the failure reason.
 		// The result banner carries an explicit close button (the stock
 		// LuCI notification's dismiss control is easy to miss under some
 		// themes) and never auto-dismisses.

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -106,6 +106,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -114,6 +132,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -119,6 +125,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -501,7 +508,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -23,7 +23,7 @@ return view.extend({
 		// read with a plain GET: the /ubus JSON-RPC channel truncates
 		// larger replies on some firmwares, leaving the status blank.
 		return Promise.all([
-			L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}'),
+			L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}'),
 			uci.load('wificalling-gateway'),
 			L.resolveDefault(fs.read('/tmp/dhcp.leases'), ''),
 			uci.load('dhcp'),
@@ -505,7 +505,7 @@ return view.extend({
 				};
 
 		poll.add(function() {
-			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
+			return L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
 					var displayNode = nodeForDisplay(n);

--- a/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/faq.js
+++ b/openwrt/files/www/luci-static/resources/view/wificalling-location-gateway/faq.js
@@ -50,7 +50,7 @@ var CONTENT = {
 			'WLOC 使用日志最多显示最近 20 条，可一键清空；日志仅记录替换元数据，不记录原始 WLOC 响应内容。',
 			'配置（开关、模式、手动坐标、预设）保存在 /etc/config/wloc-service，重启后仍然生效。',
 			'「服务状态」页（服务 → 服务状态）集中显示 wloc-service 与 Wi-Fi 通话网关的进程、配置、规则、补丁与节点健康，每 10 秒自动刷新；异常项以红点标出。',
-			'每个代理节点行的「nodeTest」按钮可随时执行一次新的连接测试：WireGuard 节点进行真实握手并显示出口 IP，其他协议执行 TCP 连通性探测；若握手失败，状态列会显示简短原因（超时 / 不可达 / 配置缺失），鼠标悬停可查看完整解释。'
+			'每个代理节点行的「nodeTest」按钮会通过正在运行的 Gateway sing-box 立即执行一次新的代理链路测试；所有协议均显示可达性与请求延迟，不会创建第二个进程。'
 		]
 	},
 	en: {
@@ -92,7 +92,7 @@ var CONTENT = {
 			'The WLOC usage log keeps the newest 20 entries and can be cleared with one click; it only records replacement metadata, never raw WLOC responses.',
 			'Settings (switch, mode, manual coordinates, presets) are stored in /etc/config/wloc-service and survive reboots.',
 			'"Service Status" (Services > Service Status) shows both services in one place: daemon processes, config validity, nftables rules, build patches and node health, refreshed every 10 seconds; anything unhealthy is marked with a red dot.',
-			'The "nodeTest" button on every proxy node row runs a fresh connection test on demand: WireGuard nodes perform a real handshake and show the verified exit IP, other protocols get a TCP reachability probe; when a handshake fails, the status cell shows a short reason (Timeout / Unreachable / Missing config) and hovering reveals the full explanation.'
+			'The "nodeTest" button on every proxy node row runs a fresh proxy-path test through the existing Gateway sing-box; every protocol reports reachability and request latency without creating a second process.'
 		]
 	}
 };

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=4
+PKG_RELEASE:=7
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/rpcd/luci.wloc
@@ -253,10 +253,8 @@ call)
 		exit 0
 		;;
 	node_test)
-		# Manual connection test for a single node. WireGuard nodes get a
-		# fresh handshake (bypassing the monitor's result cache); other
-		# protocols get a TCP reachability probe. The helper reuses the
-		# monitor's handshake function where applicable.
+		# Manual connection test for a single node. Every protocol uses the
+		# existing Gateway sing-box loopback probe and bypasses the monitor cache.
 		read -r input
 		json_load "$input"
 		json_get_var id id

--- a/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/wificalling-gateway/node-test.sh
+++ b/openwrt/luci-app-wificalling-location-gateway/files/usr/libexec/wificalling-gateway/node-test.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 # node-test.sh — manual connection test for one proxy node.
 #
-# WireGuard nodes run the same handshake probe the monitor loop uses (the
-# function is extracted from the patched node-health.sh, so there is
-# exactly one implementation), bypassing the 60s result cache so the user
-# gets a fresh answer on demand. Every other protocol gets a TCP
-# reachability probe of the node's server:port (tcping when installed,
-# busybox nc otherwise). Prints one JSON object; always exits 0 so rpcd
-# forwards the reply untouched.
+# Every protocol is tested through the loopback HTTP inbound of the already
+# running Gateway sing-box. The inbound is compiled with a fixed route to
+# this node's existing outbound, so no second sing-box process is needed.
+# Prints one JSON object; always exits 0 so rpcd forwards the reply untouched.
 
 set -eu
 
@@ -20,62 +17,15 @@ if [ -z "$server" ] || [ -z "$port" ]; then
 	exit 0
 fi
 
-proto=$(uci -q get "wificalling-gateway.$id.protocol") || true
-if [ "$proto" = wireguard ]; then
-	health=/usr/libexec/wificalling-gateway/node-health.sh
-	[ -f "$health" ] || {
-		printf '{"state":"failed","reason":"no_health_script"}\n'
-		exit 0
-	}
-
-	# Extract the handshake function from the patched monitor script so
-	# the manual test and the monitor loop share one implementation.
-	func=$(mktemp /tmp/wg-test-func.XXXXXX)
-	trap 'rm -f "$func"' EXIT HUP INT TERM
-	awk '/^wg_handshake_test\(\)/,/^}/' "$health" > "$func"
-	. "$func"
-
-	# The monitor loop may be mid-test right now; wait for its lock so
-	# this run is authoritative (a handshake takes up to ~8s, give it 20s).
-	n=0
-	while [ -d /tmp/wg-health.lock ]; do
-		n=$((n + 1))
-		[ "$n" -ge 40 ] && {
-			printf '{"state":"failed","reason":"busy"}\n'
-			exit 0
-		}
-		sleep 1
-	done
-
-	# Bypass the 60s cache: the cached result is exactly what the user
-	# is asking to re-check.
-	rm -f "/tmp/wg-health-$id"
-
-	if exit_ip=$(wg_handshake_test "$id" "$server" "$port"); then
-		printf '{"state":"handshake_ok","exit_ip":"%s"}\n' "$exit_ip"
-	else
-		reason=$(sed -n '3p' "/tmp/wg-health-$id" 2>/dev/null || echo unreachable)
-		printf '{"state":"handshake_failed","reason":"%s"}\n' "$reason"
-	fi
+test_port=$(printf '%s' "$id" | md5sum | cut -c1-4)
+test_port=$((20000 + (0x$test_port % 10000)))
+result=$(curl -sS --max-time 8 -x "http://127.0.0.1:$test_port" \
+	-w '\n%{time_total}' 'http://ip-api.com/json?fields=query' 2>/dev/null || true)
+seconds=$(printf '%s\n' "$result" | tail -n 1)
+ms=$(printf '%s\n' "$seconds" | awk '/^[0-9]+(\.[0-9]+)?$/ { printf "%.2f", $1 * 1000 }')
+[ -n "$ms" ] || {
+	printf '{"state":"unreachable","reason":"proxy_failed"}\n'
 	exit 0
-fi
-
-# Non-WireGuard protocols: TCP reachability of the node server.
-if command -v tcping >/dev/null 2>&1; then
-	ms=$(tcping -c 1 -t 2 -p "$port" "$server" 2>/dev/null |
-		sed -n 's/.*time=\([0-9][0-9.]*\)[[:space:]]*ms.*/\1/p' | head -n 1)
-	if [ -n "$ms" ]; then
-		printf '{"state":"tcp_reachable","ping_ms":"%s"}\n' "$ms"
-	else
-		printf '{"state":"unreachable","reason":"tcp_failed"}\n'
-	fi
-elif command -v nc >/dev/null 2>&1; then
-	if nc -w 3 "$server" "$port" >/dev/null 2>&1; then
-		printf '{"state":"tcp_reachable","ping_ms":null}\n'
-	else
-		printf '{"state":"unreachable","reason":"tcp_failed"}\n'
-	fi
-else
-	printf '{"state":"failed","reason":"no_tcp_probe"}\n'
-fi
+}
+printf '{"state":"proxy_reachable","measurement":"proxy","ping_ms":"%s"}\n' "$ms"
 exit 0

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -68,7 +68,7 @@ return view.extend({
 				var reason = wgFailReason(n.reason);
 				return wlocI18n.t('Handshake failed') + (reason ? ' (' + reason + ')' : '');
 			}
-			if (n.state === 'reachable' || n.state === 'tcp_reachable') return wlocI18n.t('Alive');
+			if (n.state === 'reachable' || n.state === 'tcp_reachable' || n.state === 'proxy_reachable') return wlocI18n.t('Alive');
 			if (n.state === 'unreachable') return wlocI18n.t('Offline');
 			return wlocI18n.t('Unknown');
 		}
@@ -146,7 +146,7 @@ return view.extend({
 				else if (r && r.state === 'handshake_failed') {
 					testNotify(wlocI18n.t('Handshake failed') + ' (' + wgFailReason(r.reason) + ')', 'error', wgFailDetail(r.reason));
 				}
-				else if (r && r.state === 'tcp_reachable') {
+				else if (r && (r.state === 'tcp_reachable' || r.state === 'proxy_reachable')) {
 					testNotify(wlocI18n.t('Alive') + (r.ping_ms ? ' — ' + r.ping_ms + ' ms' : ''), 'info');
 				}
 				else if (r && r.state === 'unreachable') {

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -86,10 +86,9 @@ return view.extend({
 			if (reason === 'unreachable') return wlocI18n.t('Server unreachable');
 			return '';
 		}
-		// Manual connection test: asks the router to run a fresh check
-		// right now - a WireGuard handshake (bypassing the monitor's
-		// result cache) or a TCP reachability probe for other protocols -
-		// and reports the exit IP or the failure reason.
+		// Manual connection test: asks the router to run a fresh proxy-path
+		// check through the existing Gateway sing-box, bypassing the monitor's
+		// result cache, and reports latency or the failure reason.
 		// The result banner carries an explicit close button (the stock
 		// LuCI notification's dismiss control is easy to miss under some
 		// themes) and never auto-dismisses.

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -106,6 +106,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -114,6 +132,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -119,6 +125,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -501,7 +508,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-gateway/overview.js
@@ -23,7 +23,7 @@ return view.extend({
 		// read with a plain GET: the /ubus JSON-RPC channel truncates
 		// larger replies on some firmwares, leaving the status blank.
 		return Promise.all([
-			L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}'),
+			L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}'),
 			uci.load('wificalling-gateway'),
 			L.resolveDefault(fs.read('/tmp/dhcp.leases'), ''),
 			uci.load('dhcp'),
@@ -505,7 +505,7 @@ return view.extend({
 				};
 
 		poll.add(function() {
-			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
+			return L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
 					var displayNode = nodeForDisplay(n);

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/faq.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/faq.js
@@ -50,7 +50,7 @@ var CONTENT = {
 			'WLOC 使用日志最多显示最近 20 条，可一键清空；日志仅记录替换元数据，不记录原始 WLOC 响应内容。',
 			'配置（开关、模式、手动坐标、预设）保存在 /etc/config/wloc-service，重启后仍然生效。',
 			'「服务状态」页（服务 → 服务状态）集中显示 wloc-service 与 Wi-Fi 通话网关的进程、配置、规则、补丁与节点健康，每 10 秒自动刷新；异常项以红点标出。',
-			'每个代理节点行的「nodeTest」按钮可随时执行一次新的连接测试：WireGuard 节点进行真实握手并显示出口 IP，其他协议执行 TCP 连通性探测；若握手失败，状态列会显示简短原因（超时 / 不可达 / 配置缺失），鼠标悬停可查看完整解释。'
+			'每个代理节点行的「nodeTest」按钮会通过正在运行的 Gateway sing-box 立即执行一次新的代理链路测试；所有协议均显示可达性与请求延迟，不会创建第二个进程。'
 		]
 	},
 	en: {
@@ -92,7 +92,7 @@ var CONTENT = {
 			'The WLOC usage log keeps the newest 20 entries and can be cleared with one click; it only records replacement metadata, never raw WLOC responses.',
 			'Settings (switch, mode, manual coordinates, presets) are stored in /etc/config/wloc-service and survive reboots.',
 			'"Service Status" (Services > Service Status) shows both services in one place: daemon processes, config validity, nftables rules, build patches and node health, refreshed every 10 seconds; anything unhealthy is marked with a red dot.',
-			'The "nodeTest" button on every proxy node row runs a fresh connection test on demand: WireGuard nodes perform a real handshake and show the verified exit IP, other protocols get a TCP reachability probe; when a handshake fails, the status cell shows a short reason (Timeout / Unreachable / Missing config) and hovering reveals the full explanation.'
+			'The "nodeTest" button on every proxy node row runs a fresh proxy-path test through the existing Gateway sing-box; every protocol reports reachability and request latency without creating a second process.'
 		]
 	}
 };

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -68,7 +68,7 @@ return view.extend({
 				var reason = wgFailReason(n.reason);
 				return wlocI18n.t('Handshake failed') + (reason ? ' (' + reason + ')' : '');
 			}
-			if (n.state === 'reachable' || n.state === 'tcp_reachable') return wlocI18n.t('Alive');
+			if (n.state === 'reachable' || n.state === 'tcp_reachable' || n.state === 'proxy_reachable') return wlocI18n.t('Alive');
 			if (n.state === 'unreachable') return wlocI18n.t('Offline');
 			return wlocI18n.t('Unknown');
 		}
@@ -149,7 +149,7 @@ return view.extend({
 				else if (r && r.state === 'handshake_failed') {
 					testNotify(wlocI18n.t('Handshake failed') + ' (' + wgFailReason(r.reason) + ')', 'error', wgFailDetail(r.reason));
 				}
-				else if (r && r.state === 'tcp_reachable') {
+				else if (r && (r.state === 'tcp_reachable' || r.state === 'proxy_reachable')) {
 					testNotify(wlocI18n.t('Alive') + (r.ping_ms ? ' — ' + r.ping_ms + ' ms' : ''), 'info');
 				}
 				else if (r && r.state === 'unreachable') {

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -34,9 +34,15 @@ return view.extend({
 		wlocI18n.localizeTabs();
 		var nodeParsed;
 		try { nodeParsed = JSON.parse(data[0]); } catch (e) { nodeParsed = { nodes: [] }; }
+		var manualNodeResults = {};
+		function nodeForDisplay(n) {
+			if (!n) return null;
+			var manual = manualNodeResults[n.id];
+			return manual && Date.now() - manual.testedAt < 60000 ? manual.node : n;
+		}
 		function nodeById(id, source) {
 			var nodes = (source || nodeParsed).nodes || [];
-			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodes[i];
+			for (var i = 0; i < nodes.length; i++) if (nodes[i].id === id) return nodeForDisplay(nodes[i]);
 			return null;
 		}
 		function quality(n) {
@@ -122,6 +128,7 @@ return view.extend({
 				n.measurement = 'wg_handshake';
 				n.ping_ms = r.exit_ip;
 			}
+			manualNodeResults[id] = { node: n, testedAt: Date.now() };
 			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
 				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
 				if (el) dom.content(el, v[1]);
@@ -504,7 +511,8 @@ return view.extend({
 			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
-					[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+					var displayNode = nodeForDisplay(n);
+					[['state', nodeState(displayNode)], ['ping', latency(displayNode)], ['quality', quality(displayNode)]].forEach(function(v) {
 						var el = document.getElementById('wfc-node-' + v[0] + '-' + n.id); if (el) dom.content(el, v[1]);
 					});
 				});

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -109,6 +109,24 @@ return view.extend({
 			mc.insertBefore(msg, mc.firstElementChild);
 			return msg;
 		}
+		function updateNodeRow(id, r) {
+			if (!r || !r.state) return;
+			var n = {
+				state: r.state,
+				reason: r.reason,
+				measurement: r.measurement,
+				ping_ms: r.ping_ms
+			};
+			if (n.state === 'tcp_reachable') n.measurement = 'tcp';
+			if (n.state === 'handshake_ok') {
+				n.measurement = 'wg_handshake';
+				n.ping_ms = r.exit_ip;
+			}
+			[['state', nodeState(n)], ['ping', latency(n)], ['quality', quality(n)]].forEach(function(v) {
+				var el = document.getElementById('wfc-node-' + v[0] + '-' + id);
+				if (el) dom.content(el, v[1]);
+			});
+		}
 		function runNodeTest(id, btn) {
 			if (btn.disabled) return;
 			btn.disabled = true;
@@ -117,6 +135,7 @@ return view.extend({
 			nodeTestRpc(id).then(function(r) {
 				btn.disabled = false;
 				btn.textContent = original;
+				updateNodeRow(id, r);
 				if (r && r.state === 'handshake_ok') {
 					testNotify(wlocI18n.t('Handshake OK') + ' — ' + r.exit_ip, 'info');
 				}

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -86,10 +86,9 @@ return view.extend({
 			if (reason === 'unreachable') return wlocI18n.t('Server unreachable');
 			return '';
 		}
-		// Manual connection test: asks the router to run a fresh check
-		// right now - a WireGuard handshake (bypassing the monitor's
-		// result cache) or a TCP reachability probe for other protocols -
-		// and reports the exit IP or the failure reason.
+		// Manual connection test: asks the router to run a fresh proxy-path
+		// check through the existing Gateway sing-box, bypassing the monitor's
+		// result cache, and reports latency or the failure reason.
 		// The result banner carries an explicit close button (the stock
 		// LuCI notification's dismiss control is easy to miss under some
 		// themes) and never auto-dismisses.

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/overview.js
@@ -23,7 +23,7 @@ return view.extend({
 		// read with a plain GET: the /ubus JSON-RPC channel truncates
 		// larger replies on some firmwares, leaving the status blank.
 		return Promise.all([
-			L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}'),
+			L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}'),
 			uci.load('wificalling-gateway'),
 			L.resolveDefault(fs.read('/tmp/dhcp.leases'), ''),
 			uci.load('dhcp'),
@@ -508,7 +508,7 @@ return view.extend({
 				};
 
 		poll.add(function() {
-			return L.resolveDefault(fetch('/wloc-node-status.json').then(function(r) { return r.text(); }), '{}').then(function(raw) {
+			return L.resolveDefault(fetch('/wloc-node-status.json?t=' + Date.now(), { cache: 'no-store' }).then(function(r) { return r.text(); }), '{}').then(function(raw) {
 				var current; try { current = JSON.parse(raw); } catch (e) { current = { nodes: [] }; }
 				(current.nodes || []).forEach(function(n) {
 					var displayNode = nodeForDisplay(n);

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r4}
+version=${1:-1.3.0-r7}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r3}
+version=${1:-1.3.0-r4}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=3
+release=4
 arch=x86_64
 service_bin=
 ctl_bin=

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=4
+release=7
 arch=x86_64
 service_bin=
 ctl_bin=

--- a/scripts/openwrt/patch-wireguard-health.sh
+++ b/scripts/openwrt/patch-wireguard-health.sh
@@ -1,162 +1,32 @@
 #!/bin/sh
-# Patch the Gateway node-health.sh so WireGuard nodes are validated by a
-# real handshake instead of ICMP ping alone.
+# Synchronize the node-probe files into a merged Gateway payload.
 #
-# The stock checker only ICMP-pings the server (with a TCP fallback that
-# does not cover wireguard), so an imported wireguard node can show
-# "reachable" while its handshake never completes (missing/mismatched
-# preshared key, wrong endpoint, ...). This patch adds a handshake test
-# that brings up a temporary sing-box wireguard endpoint, asks an echo
-# service through it, and reports handshake_ok/handshake_failed with the
-# exit IP. Results are cached for 60s because the monitor loop runs every
-# 5s and a handshake test takes seconds.
-#
-# Fail-closed: any missing target string aborts the build. Idempotent.
+# Node tests must use the one Gateway sing-box instance. The maintained
+# compiler adds loopback probe inbounds and the health/manual helpers call
+# those inbounds; copying the complete set keeps an older merged payload from
+# mixing incompatible compiler and probe formats.
 
 set -eu
 
 payload=${1:?payload directory required}
-health="$payload/usr/libexec/wificalling-gateway/node-health.sh"
+repo_root=$(CDPATH='' cd -- "$(dirname "$0")/../.." && pwd)
 
-[ -f "$health" ] || { echo "patch-wireguard-health: missing $health" >&2; exit 2; }
+for relative in \
+	etc/init.d/wificalling-gateway \
+	usr/libexec/wificalling-gateway/compiler.sh \
+	usr/libexec/wificalling-gateway/node-health.sh \
+	usr/libexec/wificalling-gateway/node-test.sh; do
+	src="$repo_root/openwrt/files/$relative"
+	dst="$payload/$relative"
+	[ -f "$src" ] || { echo "patch-wireguard-health: missing source $src" >&2; exit 2; }
+	[ -f "$dst" ] || { echo "patch-wireguard-health: missing payload $dst" >&2; exit 2; }
+	mkdir -p "$(dirname "$dst")"
+	cp "$src" "$dst"
+done
 
-python3 - "$health" <<'PY'
-import sys
-
-health = sys.argv[1]
-
-with open(health, encoding='utf-8') as handle:
-    text = handle.read()
-
-if 'wg_handshake_test' in text:
-    print('patch-wireguard-health: already patched', file=sys.stderr)
-    raise SystemExit(0)
-
-edits = [
-    # 1. handshake test function after json_escape
-    (
-        "json_escape() {\n\tprintf '%s' \"$1\" | sed 's/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g'\n}\n",
-        "json_escape() {\n\tprintf '%s' \"$1\" | sed 's/\\\\/\\\\\\\\/g; s/\"/\\\\\"/g'\n}\n\n"
-        "# Real WireGuard handshake validation: run a temporary sing-box\n"
-        "# endpoint for the node and ask an echo service through it. The\n"
-        "# result is cached for 60s (the monitor loop runs every 5s and a\n"
-        "# handshake test takes seconds). Prints the exit IP on success.\n"
-        "# The reserved field is forwarded too: WARP-style endpoints need it\n"
-        "# and would otherwise fail every handshake. Cache line 3 carries the\n"
-        "# failure reason (config_missing / timeout / unreachable) so the\n"
-        "# status export can tell a bad node apart from a dead server.\n"
-        "# A mkdir lock serializes the actual tests: the monitor loop can\n"
-        "# tick a fresh instance before this one finished (a handshake takes\n"
-        "# up to ~8s, the loop ticks every 5s), and two instances racing on\n"
-        "# the same probe port would hand each other the wrong exit IP.\n"
-        "wg_handshake_test() {\n"
-        "\tid=$1; server=$2; port=$3\n"
-        "\tcache=\"/tmp/wg-health-$id\"\n"
-        "\tlock=/tmp/wg-health.lock\n"
-        "\tif [ -f \"$cache\" ]; then\n"
-        "\t\tcache_ts=$(sed -n '1p' \"$cache\" 2>/dev/null || echo 0)\n"
-        "\t\tage=$(($(date +%s) - ${cache_ts:-0}))\n"
-        "\t\tif [ \"$age\" -lt 60 ] 2>/dev/null; then\n"
-        "\t\t\t[ \"$(sed -n '2p' \"$cache\")\" = ok ] || return 1\n"
-        "\t\t\tsed -n '3p' \"$cache\"\n"
-        "\t\t\treturn 0\n"
-        "\t\tfi\n"
-        "\tfi\n"
-        "\tif ! mkdir \"$lock\" 2>/dev/null; then\n"
-        "\t\t# A tick killed mid-test (SIGHUP/reboot) can leave the lock\n"
-        "\t\t# behind; its holder PID is gone, so take it over.\n"
-        "\t\tlock_pid=$(cat \"$lock/pid\" 2>/dev/null || echo 0)\n"
-        "\t\tif ! kill -0 \"$lock_pid\" 2>/dev/null; then\n"
-        "\t\t\trm -f \"$lock/pid\"; rmdir \"$lock\" 2>/dev/null || true\n"
-        "\t\t\tmkdir \"$lock\" 2>/dev/null || true\n"
-        "\t\tfi\n"
-        "\tfi\n"
-        "\tif ! [ -d \"$lock\" ]; then\n"
-        "\t\t# Another monitor tick is testing right now; use the cache\n"
-        "\t\t# as-is (even stale) instead of racing on the probe port.\n"
-        "\t\tif [ -f \"$cache\" ] && [ \"$(sed -n '2p' \"$cache\")\" = ok ]; then\n"
-        "\t\t\tsed -n '3p' \"$cache\"\n"
-        "\t\t\treturn 0\n"
-        "\t\tfi\n"
-        "\t\treturn 1\n"
-        "\tfi\n"
-        "\techo $$ > \"$lock/pid\"\n"
-        "\tpriv=$(uci -q get \"wificalling-gateway.$id.private_key\") || true\n"
-        "\tpub=$(uci -q get \"wificalling-gateway.$id.public_key\") || true\n"
-        "\tlocal_addr=$(uci -q get \"wificalling-gateway.$id.local_address\") || true\n"
-        "\tif [ -z \"$priv\" ] || [ -z \"$pub\" ] || [ -z \"$local_addr\" ]; then\n"
-        "\t\tprintf '%s\\nfailed\\nconfig_missing\\n' \"$(date +%s)\" > \"$cache\"\n"
-        "\t\trm -f \"$lock/pid\"; rmdir \"$lock\" 2>/dev/null || true\n"
-        "\t\treturn 1\n"
-        "\tfi\n"
-        "\tpsk=$(uci -q get \"wificalling-gateway.$id.pre_shared_key\") || true\n"
-        "\tmtu=$(uci -q get \"wificalling-gateway.$id.mtu\") || true\n"
-        "\treserved=$(uci -q get \"wificalling-gateway.$id.reserved\") || true\n"
-        "\tlport=$((19000 + (0x$(printf '%s' \"$id\" | md5sum | cut -c1-4) % 1000))) 2>/dev/null || lport=19099\n"
-        "\tcfg=\"/tmp/wg-health-$id.json\"\n"
-        "\t{\n"
-        "\t\tprintf '{\"log\":{\"level\":\"debug\"},\"inbounds\":[{\"type\":\"http\",\"tag\":\"probe\",\"listen\":\"127.0.0.1\",\"listen_port\":%s}],' \"$lport\"\n"
-        "\t\tprintf '\"endpoints\":[{\"type\":\"wireguard\",\"tag\":\"wg\",\"address\":[%s],\"private_key\":%s,\"peers\":[{\"address\":%s,\"port\":%s,\"public_key\":%s,\"allowed_ips\":[\"0.0.0.0/0\"]' \\\n"
-        "\t\t\t\"\\\"$local_addr\\\"\" \"\\\"$priv\\\"\" \"\\\"$server\\\"\" \"$port\" \"\\\"$pub\\\"\"\n"
-        "\t\t[ -n \"$psk\" ] && printf ',\"pre_shared_key\":\"%s\"' \"$psk\"\n"
-        "\t\t[ -n \"$reserved\" ] && printf ',\"reserved\":[%s]' \"$(printf '%s' \"$reserved\" | tr -d ' ')\"\n"
-        "\t\tprintf '}],\"mtu\":%s}],\"outbounds\":[{\"type\":\"direct\",\"tag\":\"direct\"}],\"route\":{\"final\":\"wg\"}}' \"${mtu:-1420}\"\n"
-        "\t} > \"$cfg\"\n"
-        "\t/usr/bin/sing-box run -c \"$cfg\" > /tmp/wg-health-$id.log 2>&1 &\n"
-        "\tpid=$!\n"
-        "\tsleep 2\n"
-        "\tip=$(curl -s --max-time 6 -x \"http://127.0.0.1:$lport\" 'http://ip-api.com/json?fields=query' 2>/dev/null | sed -n 's/.*\"query\":\"\\([0-9.]*\\)\".*/\\1/p' || true)\n"
-        "\tkill \"$pid\" 2>/dev/null || true\n"
-        "\twait \"$pid\" 2>/dev/null || true\n"
-        "\tif [ -n \"$ip\" ]; then\n"
-        "\t\trm -f \"$cfg\" /tmp/wg-health-$id.log\n"
-        "\t\tprintf '%s\\nok\\n%s\\n' \"$(date +%s)\" \"$ip\" > \"$cache\"\n"
-        "\t\trm -f \"$lock/pid\"; rmdir \"$lock\" 2>/dev/null || true\n"
-        "\t\tprintf '%s' \"$ip\"\n"
-        "\t\treturn 0\n"
-        "\tfi\n"
-        "\tif grep -q 'handshake did not complete' /tmp/wg-health-$id.log 2>/dev/null; then\n"
-        "\t\treason=timeout\n"
-        "\telse\n"
-        "\t\treason=unreachable\n"
-        "\tfi\n"
-        "\trm -f \"$cfg\" /tmp/wg-health-$id.log\n"
-        "\tprintf '%s\\nfailed\\n%s\\n' \"$(date +%s)\" \"$reason\" > \"$cache\"\n"
-        "\trm -f \"$lock/pid\"; rmdir \"$lock\" 2>/dev/null || true\n"
-        "\treturn 1\n"
-        "}\n",
-    ),
-    # 2. wireguard override after the ICMP/TCP branch
-    (
-        "\t\t[ \"$first\" -eq 1 ] || printf ','\n",
-        "\t\t# WireGuard nodes are validated by a real handshake, not ICMP.\n"
-        "\t\tif [ \"$protocol\" = wireguard ]; then\n"
-        "\t\t\tmeasurement=wg_handshake\n"
-        "\t\t\tif exit_ip=$(wg_handshake_test \"$id\" \"$server\" \"$port\"); then\n"
-        "\t\t\t\tstate=handshake_ok; ping_json=$exit_ip; reason_json=null\n"
-        "\t\t\telse\n"
-        "\t\t\t\tstate=handshake_failed; ping_json=null\n"
-        "\t\t\t\treason_json=\"\\\"$(sed -n '3p' \"/tmp/wg-health-$id\" 2>/dev/null || echo unreachable)\\\"\"\n"
-        "\t\t\tfi\n"
-        "\t\telse\n"
-        "\t\t\treason_json=null\n"
-        "\t\tfi\n"
-        "\t\t[ \"$first\" -eq 1 ] || printf ','\n",
-    ),
-]
-
-for old, new in edits:
-    if old not in text:
-        print(
-            f'patch-wireguard-health: target not found; '
-            'gateway version mismatch?',
-            file=sys.stderr,
-        )
-        raise SystemExit(2)
-    text = text.replace(old, new, 1)
-
-with open(health, 'w', encoding='utf-8') as handle:
-    handle.write(text)
-
-print('patch-wireguard-health: applied handshake validation', file=sys.stderr)
-PY
+chmod 0755 \
+	"$payload/etc/init.d/wificalling-gateway" \
+	"$payload/usr/libexec/wificalling-gateway/compiler.sh" \
+	"$payload/usr/libexec/wificalling-gateway/node-health.sh" \
+	"$payload/usr/libexec/wificalling-gateway/node-test.sh"
+printf '%s\n' 'patch-wireguard-health: synchronized single-process node probes' >&2

--- a/tests/js/node_probe_single_process.test.js
+++ b/tests/js/node_probe_single_process.test.js
@@ -24,7 +24,7 @@ const patch = fs.readFileSync(
 test('compiler gives every node a loopback probe routed to its existing outbound', () => {
 	assert.match(compiler, /127\.0\.0\.1/);
 	assert.match(compiler, /probe-/);
-	assert.match(compiler, /\"inbound\"/);
+	assert.match(compiler, /inbound/);
 	assert.match(compiler, /probe_port/);
 });
 

--- a/tests/js/node_probe_single_process.test.js
+++ b/tests/js/node_probe_single_process.test.js
@@ -1,0 +1,38 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.resolve(__dirname, '..', '..');
+const compiler = fs.readFileSync(
+	path.join(root, 'openwrt/files/usr/libexec/wificalling-gateway/compiler.sh'),
+	'utf8'
+);
+const health = fs.readFileSync(
+	path.join(root, 'openwrt/files/usr/libexec/wificalling-gateway/node-health.sh'),
+	'utf8'
+);
+const nodeTest = fs.readFileSync(
+	path.join(root, 'openwrt/files/usr/libexec/wificalling-gateway/node-test.sh'),
+	'utf8'
+);
+const patch = fs.readFileSync(
+	path.join(root, 'scripts/openwrt/patch-wireguard-health.sh'),
+	'utf8'
+);
+
+test('compiler gives every node a loopback probe routed to its existing outbound', () => {
+	assert.match(compiler, /127\.0\.0\.1/);
+	assert.match(compiler, /probe-/);
+	assert.match(compiler, /\"inbound\"/);
+	assert.match(compiler, /probe_port/);
+});
+
+test('node health and manual tests never launch a second sing-box', () => {
+	assert.doesNotMatch(health, /sing-box run/);
+	assert.doesNotMatch(nodeTest, /sing-box run/);
+	assert.match(health, /127\.0\.0\.1/);
+	assert.match(nodeTest, /127\.0\.0\.1/);
+	assert.doesNotMatch(patch, /temporary sing-box/);
+	assert.doesNotMatch(patch, /sing-box run/);
+});

--- a/tests/js/wan_dhcp_fallback.test.js
+++ b/tests/js/wan_dhcp_fallback.test.js
@@ -38,8 +38,10 @@ function main() {
 			`${relative}: lease-bound devices must keep the bind status`);
 		assert(source.includes("return wlocI18n.t('Device offline');"),
 			`${relative}: offline must remain the last-resort state`);
-		assert(source.includes("fetch('/wloc-node-status.json')"),
+		assert(source.includes("fetch('/wloc-node-status.json?t='"),
 			`${relative}: node status must be read via the static docroot export`);
+		assert(source.includes("cache: 'no-store'"),
+			`${relative}: node status polling must bypass browser cache`);
 	});
 
 	wlocSources.forEach(function(relative) {

--- a/tests/js/wg_handshake_reason.test.js
+++ b/tests/js/wg_handshake_reason.test.js
@@ -96,6 +96,13 @@ function main() {
 			`${relative}: the test result banner must be rendered by a helper with an explicit close button`);
 		assert(source.includes("wlocI18n.t('Close')"),
 			`${relative}: the test result banner must have a close button`);
+		// A successful manual test must update the row immediately; the
+		// notification alone is not enough because the status export is polled
+		// independently and may still contain the previous result.
+		assert(source.includes('function updateNodeRow'),
+			`${relative}: manual test results must have a row-update helper`);
+		assert(source.includes('updateNodeRow(id, r);'),
+			`${relative}: manual test results must refresh the node row`);
 	});
 
 	i18nSources.forEach(function(relative) {

--- a/tests/js/wg_handshake_reason.test.js
+++ b/tests/js/wg_handshake_reason.test.js
@@ -1,18 +1,12 @@
 'use strict';
 
-// Regression guards for the WireGuard handshake-failure diagnostics:
+// Regression guards for single-process node probing:
 //
-// 1. node-health.sh must emit a machine-readable reason for failed
-//    handshakes (config_missing / timeout / unreachable) so the status
-//    view can tell a bad node apart from a dead server.
-// 2. The overview view must render that reason next to "Handshake
-//    failed" instead of a bare "Offline".
-// 3. The handshake probe must forward the reserved field (WARP-style
-//    endpoints), derive its probe port with a busybox-safe hash, and
-//    serialize concurrent monitor ticks so two runs cannot race on the
-//    same probe port and hand each other the wrong exit IP.
-// 4. The shared i18n table must carry the reason strings in both
-//    languages.
+// 1. Node health and manual tests must use the loopback inbound of the
+//    existing Gateway sing-box, never launch a temporary process.
+// 2. The compiler must expose a private, per-node test inbound routed to the
+//    corresponding outbound.
+// 3. The existing UI and translations remain present for older cached data.
 
 const assert = require('assert');
 const fs = require('fs');
@@ -30,22 +24,22 @@ function main() {
 		'openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js'
 	];
 
-	// The patch source that generates node-health.sh's handshake test.
+	// The patch source must synchronize the complete single-process probe set.
 	const patch = fs.readFileSync(path.join(root, 'scripts/openwrt/patch-wireguard-health.sh'), 'utf8');
-	assert(patch.includes("reason=config_missing") || patch.includes('config_missing'),
-		'patch-wireguard-health.sh: missing-key handshakes must be classified as config_missing');
-	assert(patch.includes("handshake did not complete"),
-		'patch-wireguard-health.sh: unanswered handshakes must be classified as timeout');
-	assert(patch.includes('reason=unreachable'),
-		'patch-wireguard-health.sh: failed test launches must be classified as unreachable');
-	assert(patch.includes('reserved=$(uci -q get'),
-		'patch-wireguard-health.sh: the probe must forward the reserved field');
-	assert(patch.includes("md5sum | cut -c1-4"),
-		'patch-wireguard-health.sh: the probe port must use a busybox-safe hash (cksum is absent on ImmortalWrt)');
-	assert(patch.includes('wg-health.lock'),
-		'patch-wireguard-health.sh: concurrent monitor ticks must be serialized');
-	assert(patch.includes('kill -0'),
-		'patch-wireguard-health.sh: a lock left by a killed tick must be reclaimed');
+	assert(patch.includes('node-health.sh'),
+		'patch-wireguard-health.sh: the health helper must be synchronized');
+	assert(patch.includes('compiler.sh'),
+		'patch-wireguard-health.sh: the compiler must be synchronized with the helper');
+	assert(!patch.includes('sing-box run'),
+		'patch-wireguard-health.sh: the patch must not start a second sing-box');
+
+	const compiler = fs.readFileSync(path.join(root, 'openwrt/files/usr/libexec/wificalling-gateway/compiler.sh'), 'utf8');
+	assert(compiler.includes('127.0.0.1'),
+		'compiler.sh: probe inbounds must be loopback-only');
+	assert(compiler.includes('inbound'),
+		'compiler.sh: probe routes must select by inbound tag');
+	assert(compiler.includes('probe_port_by_id'),
+		'compiler.sh: probe ports must be tied to node ids');
 
 	// The compact-status patch must carry the reason into the public export.
 	const compact = fs.readFileSync(path.join(root, 'scripts/openwrt/patch-node-status-compact.sh'), 'utf8');

--- a/tests/js/wg_handshake_reason.test.js
+++ b/tests/js/wg_handshake_reason.test.js
@@ -103,6 +103,10 @@ function main() {
 			`${relative}: manual test results must have a row-update helper`);
 		assert(source.includes('updateNodeRow(id, r);'),
 			`${relative}: manual test results must refresh the node row`);
+		assert(source.includes('manualNodeResults'),
+			`${relative}: polling must not immediately overwrite a fresh manual result`);
+		assert(source.includes('function nodeForDisplay'),
+			`${relative}: manual results need an expiry before live status resumes`);
 	});
 
 	i18nSources.forEach(function(relative) {

--- a/tests/scripts/test-gateway-health-report.sh
+++ b/tests/scripts/test-gateway-health-report.sh
@@ -4,6 +4,7 @@ set -eu
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 health="$repo_root/openwrt/files/usr/sbin/wloc-health.sh"
 node_health="$repo_root/openwrt/files/usr/libexec/wificalling-gateway/node-health.sh"
+init="$repo_root/openwrt/files/etc/init.d/wificalling-gateway"
 
 fail() {
 	printf 'FAIL: %s\n' "$1" >&2
@@ -22,5 +23,7 @@ fi
 # Gateway status endpoint can read the same result that the monitor generated.
 grep -F 'output=${2:-/www/wloc-node-status.json}' "$node_health" >/dev/null ||
 	fail 'node-health must honor the output path supplied by monitor-loop'
+grep -F '"$RUNDIR/nodes" "/www/wloc-node-status.json"' "$init" >/dev/null ||
+	fail 'monitor-loop must publish node health to the LuCI-readable status file'
 
 printf 'gateway health report checks passed\n'

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -80,9 +80,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r4.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r7.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -80,9 +80,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r3.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r4.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r4.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r4.apk'; do
+	'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r7.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r7.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r3.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r3.apk'; do
+	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r4.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r4.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 3'
+grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 4'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=3' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 3'
+grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 4'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r3_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r3.apk'; do
+	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r4.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r3}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 3'
+grep -F 'version=${1:-1.3.0-r4}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 4'
 
 printf '%s\n' 'release version tests passed'

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 4'
+grep -Fx 'PKG_RELEASE:=7' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 7'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=4' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 4'
+grep -Fx 'PKG_RELEASE:=7' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 7'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r4_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r4.apk'; do
+	'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r7.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r4}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 4'
+grep -F 'version=${1:-1.3.0-r7}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 7'
 
 printf '%s\n' 'release version tests passed'

--- a/tests/scripts/test-standalone-ax6s-package.sh
+++ b/tests/scripts/test-standalone-ax6s-package.sh
@@ -178,29 +178,24 @@ grep -F 'device_guard_marker' \
 grep -F 'fail("device references unknown node: " $3)' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/compiler.sh" >/dev/null &&
 	fail 'standalone package must not keep the fail-hard unknown-node device path'
-grep -F 'wg_handshake_test' \
+grep -F 'node_proxy_test' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package must patch node-health.sh with the wireguard handshake test'
-[ "$(grep -c 'wg_handshake_test' "$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh")" -ge 2 ] ||
-	fail 'standalone package handshake patch must define and call wg_handshake_test'
-grep -F '[ -n "$reserved" ]' \
+	fail 'standalone package must use the existing Gateway sing-box for node tests'
+if grep -F 'sing-box run' "$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null; then
+	fail 'standalone package node health must not start a temporary sing-box'
+fi
+grep -F '127.0.0.1' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must forward the reserved field'
+	fail 'standalone package node health must use a loopback probe'
 grep -F 'reason_json=' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must report a failure reason'
-grep -F 'config_missing' \
-	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must distinguish missing key material'
+	fail 'standalone package node health must report a failure reason'
 grep -F 'md5sum | cut -c1-4' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must derive the probe port from a busybox-safe hash'
-grep -F 'wg-health.lock' \
-	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must serialize concurrent handshake tests'
-grep -F 'kill -0' \
-	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
-	fail 'standalone package handshake patch must reclaim stale test locks'
+	fail 'standalone package node health must derive a busybox-safe probe port'
+grep -F 'probe_port_by_id' \
+	"$tmp/result/data/usr/libexec/wificalling-gateway/compiler.sh" >/dev/null ||
+	fail 'standalone package compiler must route per-node probe inbounds'
 grep -F 'compact_status_marker' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-health.sh" >/dev/null ||
 	fail 'standalone package must compact the node-status.json output'
@@ -211,9 +206,12 @@ grep -F '"reason":%s' \
 	fail 'standalone package compact output must include the handshake failure reason'
 # The manual per-node connection test helper must ship and be wired into
 # rpcd so the LuCI "Test connection" button can ask for a fresh check.
-grep -F 'wg_handshake_test' \
+grep -F '127.0.0.1' \
 	"$tmp/result/data/usr/libexec/wificalling-gateway/node-test.sh" >/dev/null ||
-	fail 'standalone package must ship the manual node test helper'
+	fail 'standalone package manual node test must use the running Gateway'
+if grep -F 'sing-box run' "$tmp/result/data/usr/libexec/wificalling-gateway/node-test.sh" >/dev/null; then
+	fail 'standalone package manual node test must not start a temporary sing-box'
+fi
 grep -F 'node_test' \
 	"$tmp/result/data/usr/libexec/rpcd/luci.wloc" >/dev/null ||
 	fail 'standalone package rpcd plugin must expose the node_test method'


### PR DESCRIPTION
Closes #72

Handoff capsule: `.handoffs/issue-72.md`

## Summary
- Reuse the single running WIFICalling Gateway sing-box for all node quality probes through loopback HTTP inbounds.
- Publish node status to the LuCI-served file with browser-cache bypass; manual nodeTest bypasses the 60-second cache.
- Update bilingual README and changelog, and bump package/build/test metadata to v1.3.0-r7.
- Build the six release assets for AX6S AArch64, OpenWrt/iStoreOS 24.10 x86_64, and OpenWrt 25.12 x86_64.

## Verification
- `./scripts/ci/verify.sh` — passed; 69 Python tests, Rust tests, 81.35% line coverage, secret scan and cargo-deny gates passed.
- `./scripts/openwrt/verify-docker-matrix.sh --dist-dir dist/wloc-openwrt-release-r7` — passed 8/8 standard/Lite combinations: installed, started, socket-ok, status-ok.
- AX6S live verification — r7 Lite installed; five node metrics, one WIFICalling sing-box process, automatic status polling, and 30-second stability check passed; no new OOM event observed.
- `SHA256SUMS` generated and verified for all six assets.

## Rollback
Install the previously released package for the target package manager after preserving UCI configuration. Standard and Lite remain mutually exclusive.