### PR TITLE
release: v1.3.0-r8 automatic WLOC refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r8] - 2026-08-28
+
+Standardized automatic WLOC location refresh after manual mode changes.
+
+- Switching from manual location back to automatic node-following now always
+  refreshes the exit IP and Geo target, including while the service is disabled.
+- Added regression coverage for the disabled-service transition and aligned the
+  three-platform package release metadata to r8.
+
+### 中文说明
+
+标准化手动定位与自动跟随定位的切换行为。
+
+- 从手动定位切回自动跟随时，无论服务当前是否启用，都会重新刷新出口 IP
+  与 Geo 目标，避免使用空目标或旧定位。
+- 增加 disabled 状态切换回归测试，并将三平台包发布元数据统一为 r8。
+
 ## [1.3.0-r7] - 2026-08-28
 
 Node health and AX6S stability release. This release consolidates the r5/r6

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r7-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r7)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r8-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r8)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -116,7 +116,7 @@ More detail: [WLOC Service API](docs/api/WLOC_SERVICE_API.md), [Threat model](do
 
 | Platform | Arch | Package manager | Current evidence | Status |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r7 Lite asset installed; five node proxy metrics passed, one WIFICalling sing-box remained running, status polling and 30-second stability check passed; prior live iPhone WLOC interception and synthesis also passed | **Docker + router + iPhone WLOC passed** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | Exact r8 Lite asset installed; five node proxy metrics passed, one WIFICalling sing-box remained running, status polling and 30-second stability check passed; prior live iPhone WLOC interception and synthesis also passed | **Docker + router + iPhone WLOC passed** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker boot of init/ubus, integrated package install, service start, socket and v1 status checks | **Install matrix passed** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | Same as above | **Install matrix passed** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | Same, using native APK v3, not a renamed IPK | **Install matrix passed** |
@@ -135,10 +135,10 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r7` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r8` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r7_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r7_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r7.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r7.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r8_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r8_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r8.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r8_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r8_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r8.apk`
 
 Choose **Standard** when the firmware already supplies a suitable `/usr/bin/sing-box`. Choose **Lite** for constrained gateways such as AX6S: it stores a hash-pinned compressed sing-box in flash, transparently expands one shared copy into `/tmp`, and keeps only the single-worker/moderate-GC runtime profile without an artificial heap ceiling. Standard and Lite conflict intentionally and must not be installed together. Both preserve `/etc/config/wificalling-gateway` and `/etc/config/wloc-service`.
 
@@ -169,22 +169,22 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r8_aarch64_cortex-a53.ipk
 ```
 
-Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r7 Lite package replaces the separate sing-box package and owns its transparent wrapper.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r8 Lite package replaces the separate sing-box package and owns its transparent wrapper.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r7_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r8_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r7.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r8.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -247,7 +247,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 7 \
+  --release 8 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -260,7 +260,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r7"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r8"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -416,7 +416,7 @@ flowchart TD
 
 | 平台 | 架构 | 包管理器 | 当前证据 | 状态 |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r7 Lite；5 个节点代理指标、单 WIFICalling sing-box、状态轮询和 30 秒稳定性检查通过；此前 iPhone WLOC 拦截与响应生成也已通过 | **Docker + 路由器 + iPhone WLOC 通过** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r8 Lite；5 个节点代理指标、单 WIFICalling sing-box、状态轮询和 30 秒稳定性检查通过；此前 iPhone WLOC 拦截与响应生成也已通过 | **Docker + 路由器 + iPhone WLOC 通过** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker 中启动 init/ubus、安装集成包、启动服务、Socket 与 v1 状态检查 | **安装矩阵通过** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | 同上 | **安装矩阵通过** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | 同上，使用原生 APK v3，非改名 IPK | **安装矩阵通过** |
@@ -435,10 +435,10 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r7` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r8` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r7_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r7_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r7.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r7.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r8_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r8_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r8.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r8_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r8_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r8.apk`
 
 固件已有合适 `/usr/bin/sing-box` 时选择 **Standard**；AX6S 等受限设备推荐 **Lite**：flash 只保存带 SHA256 固定的压缩运行时，首次调用透明解压一份到 `/tmp`；WCG 仅保留单 worker 和适度 GC 设置，不再人为设置堆上限。两种规格故意互斥，不能同时安装；两者都保留 `/etc/config/wificalling-gateway` 与 `/etc/config/wloc-service`。
 
@@ -469,22 +469,22 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r7_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r8_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r7 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r8 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r7_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r8_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r7.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r8.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -547,7 +547,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 7 \
+  --release 8 \
   --arch x86_64 \
   --service-bin "$PWD/dist/runtime/x86_64/wloc-service" \
   --ctl-bin "$PWD/dist/runtime/x86_64/wloc-ctl" \
@@ -560,7 +560,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r7"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r8"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md
+++ b/docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md
@@ -38,7 +38,7 @@ Then build the release packages:
 ```sh
 ./scripts/openwrt/build-release-packages.sh \
   --version 1.3.0 \
-  --release 7 \
+  --release 8 \
   --arch x86_64 \
   --service-bin /absolute/path/wloc-service \
   --ctl-bin /absolute/path/wloc-ctl \
@@ -69,7 +69,7 @@ Run:
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir /absolute/path/dist/wloc-openwrt-release-r7
+  --dist-dir /absolute/path/dist/wloc-openwrt-release-r8
 ```
 
 For each environment the verifier boots `/sbin/init`, waits for ubus, installs

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r7}
+version=${1:-1.3.0-r8}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=7
+release=8
 arch=x86_64
 service_bin=
 ctl_bin=
@@ -29,7 +29,7 @@ Usage: build-release-packages.sh [--plan] [options]
 
 Options:
   --version VERSION          Package version (default: 1.3.0)
-  --release RELEASE          Package release number (default: 1)
+  --release RELEASE          Package release number (default: 8)
   --arch ARCH                OpenWrt runtime architecture (default: x86_64)
   --service-bin PATH         Static wloc-service binary (required)
   --ctl-bin PATH             Static wloc-ctl binary (required)

--- a/src/app.rs
+++ b/src/app.rs
@@ -496,7 +496,6 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
         if !matches!(self.geo_source, GeoSource::Manual { .. }) {
             return Ok(());
         }
-        let refresh_auto_target = self.state.phase() != ServicePhase::Disabled;
         self.geo_source = GeoSource::Auto;
         self.manual_geo = None;
         self.geo_generation += 1;
@@ -504,12 +503,7 @@ impl<R: RuntimeControl, P: ExitProbeRuntime, G: GeoProviderRuntime> WlocService<
         if let Ok(mut slot) = self.manual_geo_pending.lock() {
             *slot = None;
         }
-        if refresh_auto_target {
-            self.force_evidence_refresh();
-        } else {
-            self.publish_patch_target();
-            self.refresh_state_file();
-        }
+        self.force_evidence_refresh();
         Ok(())
     }
 

--- a/tests/app_service.rs
+++ b/tests/app_service.rs
@@ -831,21 +831,15 @@ fn periodic_manual_health_check_does_not_probe_or_touch_auto_evidence() {
 }
 
 #[test]
-fn manual_mode_changes_advance_status_generation_without_ip_probe() {
+fn manual_mode_changes_advance_status_generation_and_auto_switch_refreshes() {
     let now = current_unix();
     let mut service = build(
         OkRuntime {
             healthy: true,
             install_fails: false,
         },
-        SequenceProbe {
-            results: vec![],
-            index: 0,
-        },
-        SequenceGeo {
-            results: vec![],
-            index: 0,
-        },
+        fresh_probe(),
+        fresh_geo(now),
     );
 
     let initial = service.status_inputs_at(now).generation;
@@ -908,6 +902,36 @@ fn switching_from_manual_to_auto_refreshes_the_auto_target() {
 
     let target = sink.lock().unwrap().expect("auto target must be refreshed");
     assert_eq!((target.latitude, target.longitude), (22.32, 114.17));
+}
+
+#[test]
+fn switching_from_manual_to_auto_while_disabled_refreshes_auto_target() {
+    let now = current_unix();
+    let sink = Arc::new(Mutex::new(None));
+    let mut service = build(
+        OkRuntime {
+            healthy: true,
+            install_fails: false,
+        },
+        SequenceProbe {
+            results: vec![Ok(EXIT_A)],
+            index: 0,
+        },
+        fresh_geo(now),
+    )
+    .with_patch_sink(Arc::clone(&sink));
+
+    service
+        .set_manual_location(&RequestParams {
+            query: None,
+            latitude: Some(51.5074),
+            longitude: Some(-0.1278),
+        })
+        .unwrap();
+    service.clear_manual_location().unwrap();
+
+    let target = sink.lock().unwrap().expect("auto target must be refreshed");
+    assert_eq!((target.latitude, target.longitude), (37.77, -122.41));
 }
 
 #[test]
@@ -996,8 +1020,17 @@ fn manual_location_overrides_auto_patch_target() {
             healthy: true,
             install_fails: false,
         },
-        fresh_probe(),
-        fresh_geo(now),
+        SequenceProbe {
+            results: vec![Ok(EXIT_A), Ok(EXIT_A)],
+            index: 0,
+        },
+        SequenceGeo {
+            results: vec![
+                Ok(Some((EXIT_A, record(now, 37.77, -122.41)))),
+                Ok(Some((EXIT_A, record(now, 37.77, -122.41)))),
+            ],
+            index: 0,
+        },
     )
     .with_patch_sink(Arc::clone(&sink));
 

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -80,9 +80,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r8_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r7.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r8.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r7_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r7.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r7.apk'; do
+	'wificalling-location-gateway_1.3.0-r8_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r8_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r8.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r8.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=7' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 7'
+grep -Fx 'PKG_RELEASE:=8' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 8'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=7' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 7'
+grep -Fx 'PKG_RELEASE:=8' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 8'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r7_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r7.apk'; do
+	'wificalling-location-gateway_1.3.0-r8_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r8.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r7}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 7'
+grep -F 'version=${1:-1.3.0-r8}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 8'
 
 printf '%s\n' 'release version tests passed'


### PR DESCRIPTION
## Summary
- standardize manual-to-automatic WLOC refresh, including while disabled
- add regression coverage for the stale/empty automatic target transition
- align package metadata, tests, README, and bilingual changelog to v1.3.0-r8

## Verification
- `./scripts/ci/verify.sh` passed
- Rust coverage: 81.39% lines
- OpenWrt Docker matrix: 8/8 standard and lite rows passed
- AX6S ImmortalWrt 24.10.6: r7 to r8 upgrade passed; service status healthy, socket present, one long-lived sing-box process

## Release assets
Built and validated separately: AArch64 AX6S, x86_64 OpenWrt 24.10, and native OpenWrt 25.12 APK; Standard and Lite variants plus SHA256SUMS.