### PR TITLE
matrix: raise the boot budget for the apk pre-install path

### DIFF
--- a/.handoffs/issue-83.md
+++ b/.handoffs/issue-83.md
@@ -1,0 +1,47 @@
+# Agent handoff: Issue 83
+
+## Identity and scope
+
+- Source agent ID: zcode-matrix-budget-r11-20260829
+- Capabilities used: test,ci
+- Branch: codex/issue-83-matrix-boot-budget
+- Checkpoint parent: `ceaa910` (v1.3.0-r11 merge)
+- Updated at (UTC): 2026-08-29
+- Credentials included: no
+
+## Objective
+
+Raise the install-matrix boot budget from 45 s to 90 s so the OpenWrt 25.12
+apk case (which pre-installs the package before init) completes on a
+slow-network run, as observed during the v1.3.0-r11 release verification.
+
+## Completed
+
+- `scripts/openwrt/verify-docker-matrix.sh`: boot wait raised to 90 attempts
+  with a comment documenting the apk pre-install stall; no production packages
+  or scripts changed.
+
+## Verification
+
+- `sh -n` passes; the r11 matrix was executed against the raised budget and
+  completed 8/8 (recorded in the release run).
+
+## Failed attempts
+
+- Three release-matrix runs aborted with 'did not finish booting' on the
+  25.12 apk case while the network to downloads.openwrt.org was slow; the
+  bare container booted in ~5 s, isolating the stall to the apk
+  pre-installation phase (measured ~52 s to ubus).
+
+## Next executable steps
+
+- Merge this harness fix so release runs are not network-fragile.
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to the repository.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository; the change
+  touches only a test-harness timeout.

--- a/scripts/openwrt/verify-docker-matrix.sh
+++ b/scripts/openwrt/verify-docker-matrix.sh
@@ -112,7 +112,10 @@ run_case() {
 	fi
 
 	ready=0
-	for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45; do
+	# 90 s: the apk case pre-installs the package before init, and a slow
+	# network can stall that dependency resolution past 45 s without the
+	# package being at fault.
+	for _attempt in $(seq 1 90); do
 		if docker exec "$container" /bin/sh -c 'ubus list system >/dev/null 2>&1'; then
 			ready=1
 			break


### PR DESCRIPTION
## What

The install matrix waited 45 s for ubus; the OpenWrt 25.12 case pre-installs the package with apk before init and a slow network stalled that phase past 45 s, aborting the matrix with "did not finish booting" despite healthy packages (observed three times during the v1.3.0-r11 release run; bare container boots in ~5 s, the apk path measured ~52 s). The boot budget is raised to 90 s with a comment. Test-harness only; Closes #83.

## Validation

`sh -n` clean; the r11 matrix passes 8/8 with the raised budget.

Handoff capsule: `.handoffs/issue-83.md`