### PR TITLE
release: v1.3.0-r12 auto-save applied manual locations into the saved-locations list

### DIFF
--- a/.handoffs/issue-87.md
+++ b/.handoffs/issue-87.md
@@ -1,0 +1,63 @@
+# Agent handoff: Issue 87
+
+## Identity and scope
+
+- Source agent ID: zcode-preset-autosave-r12-20260829
+- Capabilities used: test,ci,docs
+- Branch: codex/issue-87-r12-preset-autosave
+- Checkpoint parent: `492dc72` (v1.3.0-r11)
+- Updated at (UTC): 2026-08-29
+- Credentials included: no
+
+## Objective
+
+Publish v1.3.0-r12 adding the requested preset auto-save: applying a manual
+location (search result or raw coordinates) automatically upserts an entry in
+the saved-locations table so it can be re-applied or deleted with one tap.
+
+## Completed
+
+- `wloc.js`: the Apply-coordinates success path upserts a `config preset`
+  section — a search result is stored under its city label (tracked as
+  `lastSearch` and only used when the applied coordinates match it), raw
+  coordinates under "lat, lon"; dedupe prefers an exact coordinate match and
+  then an exact label match, so re-applying a place updates the entry instead
+  of duplicating it.
+- The saved-locations table refreshes immediately after apply
+  (`renderPresets()`), with a bilingual confirmation message and a new i18n
+  key.
+- Package release metadata bumped to `1.3.0-r12` with bilingual README,
+  changelog, and release-test updates; no daemon or protocol changes.
+
+## Verification
+
+- All seven `tests/js/*.test.js` suites pass (the edited handler sits next to
+  the mode-switch atomicity assertions).
+- Full `./scripts/ci/verify.sh` gate green.
+
+## Failed attempts
+
+- None; the first patch applied cleanly.
+
+## Next executable steps
+
+- Merge the release PR after CI is green.
+- Build the six Standard/Lite assets (Rust runtimes reused from the r10/r11
+  build — no Rust change), run the Docker install matrix, update and re-sign
+  the feed.
+- Tag `v1.3.0-r12`, publish the release, and run the live AX6S r11-to-r12
+  upgrade.
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to `smthdagg/wificalling-location-gateway`
+  and `smthdagg/wificalling-location-gateway-feed`.
+- Docker for feed signing and the install matrix.
+- SSH access to the AX6S test router (`192.168.31.1`, root) for the live
+  upgrade validation.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository.
+- Presets remain plain UCI sections on the router; no location data leaves the
+  device beyond the existing search flow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r12] - 2026-08-29
+
+Adds the requested preset auto-save on the proven integrated 1.3.0-r1
+Gateway baseline.
+
+- Applying a manual location automatically upserts it into the
+  saved-locations table: a search result is stored under its city label,
+  raw coordinates under "lat, lon"; re-applying the same place updates the
+  existing entry instead of duplicating it (dedupe by coordinates first).
+- The table refreshes immediately after apply; bilingual confirmation.
+- No daemon or protocol changes; presets remain plain UCI sections.
+
+### 中文说明
+
+在已验证的 1.3.0-r1 整合 Gateway 基线上增加用户期望的预设自动保存。
+
+- 应用手动定位时自动写入"已保存的位置"表：搜索结果以城市名保存，手输坐标
+  以"纬度, 经度"保存；同一地点重复应用会更新既有条目而不是产生重复
+  （先按坐标去重，再按标签）。
+- 应用后表格立即刷新并给出双语确认；守护进程与协议无变更，预设仍为普通
+  UCI 配置段。
+
 ## [1.3.0-r11] - 2026-08-29
 
 LuCI error-path hardening on the proven integrated 1.3.0-r1 Gateway baseline.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r11-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r11)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r12-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r12)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -116,7 +116,7 @@ More detail: [WLOC Service API](docs/api/WLOC_SERVICE_API.md), [Threat model](do
 
 | Platform | Arch | Package manager | Current evidence | Status |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r11 service installed; one WIFICalling sing-box remained running, WLOC was `intercepting`, crash-recovery re-interception was observed, and post-test available memory remained above 32 MiB | **Docker + router + iPhone WLOC passed** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r12 service installed; one WIFICalling sing-box remained running, WLOC was `intercepting`, crash-recovery re-interception was observed, and post-test available memory remained above 32 MiB | **Docker + router + iPhone WLOC passed** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker boot of init/ubus, integrated package install, service start, socket and v1 status checks | **Install matrix passed** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | Same as above | **Install matrix passed** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | Same, using native APK v3, not a renamed IPK | **Install matrix passed** |
@@ -135,12 +135,12 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r11` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r12` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r11_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r11_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r11.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r11_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r11_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r11.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r12_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r12_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r12.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r12.apk`
 
-### r11 changes
+### r12 changes
 
 - Every TPROXY install refreshes the upstream map; disable/enable and sing-box crash recovery can no longer leave interception silently broken.
 - Disabled WLOC is genuinely fail-open: the boot script withdraws the DNS hijack, TPROXY, and upstream map when the switch is off, and disabling restarts dnsmasq immediately.
@@ -176,22 +176,22 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r11_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk
 ```
 
-Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r11 Lite package replaces the separate sing-box package and owns its transparent wrapper.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r12 Lite package replaces the separate sing-box package and owns its transparent wrapper.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r11_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r12_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r11.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r12.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -267,7 +267,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r11"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r12"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -423,7 +423,7 @@ flowchart TD
 
 | 平台 | 架构 | 包管理器 | 当前证据 | 状态 |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r11 服务；只保留一个 WIFICalling sing-box，WLOC 为 `intercepting`，观察到崩溃后自动恢复拦截，测试后可用内存仍高于 32 MiB | **Docker + 路由器 + iPhone WLOC 通过** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r12 服务；只保留一个 WIFICalling sing-box，WLOC 为 `intercepting`，观察到崩溃后自动恢复拦截，测试后可用内存仍高于 32 MiB | **Docker + 路由器 + iPhone WLOC 通过** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker 中启动 init/ubus、安装集成包、启动服务、Socket 与 v1 状态检查 | **安装矩阵通过** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | 同上 | **安装矩阵通过** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | 同上，使用原生 APK v3，非改名 IPK | **安装矩阵通过** |
@@ -442,12 +442,12 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r11` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r12` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r11_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r11_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r11.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r11_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r11_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r11.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r12_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r12_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r12.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r12.apk`
 
-### r11 更新说明
+### r12 更新说明
 
 - 每次 TPROXY 安装都会刷新上游映射；禁用/启用与 sing-box 崩溃恢复不会再让拦截静默失效。
 - 禁用的 WLOC 真正 fail-open：开机脚本按开关撤除 DNS 劫持、TPROXY 与上游映射，停用即重启 dnsmasq。
@@ -483,22 +483,22 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r11_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r11 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r12 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r11_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r12_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r11.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r12.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -574,7 +574,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r11"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r12"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc.js
@@ -229,6 +229,7 @@ return view.extend({
 					var city = found.city || q;
 					var lat = String(Number(found.latitude).toFixed(6));
 					var lon = String(Number(found.longitude).toFixed(6));
+					lastSearch = { label: city, lat: lat, lon: lon };
 					document.getElementById('wloc-coord-lat').value = lat;
 					document.getElementById('wloc-coord-lon').value = lon;
 					searchResult.innerHTML = '';
@@ -243,6 +244,10 @@ return view.extend({
 			}
 		}, wlocI18n.t('Search'));
 
+		// The last successful place search: applying its result auto-saves the
+		// city label into the saved-locations table (raw coordinates save as
+		// "lat, lon" instead).
+		var lastSearch = null;
 		var coordLat = E('input', { 'class': 'cbi-input-text', 'id': 'wloc-coord-lat', 'type': 'text', 'placeholder': '51.5074' });
 		var coordLon = E('input', { 'class': 'cbi-input-text', 'id': 'wloc-coord-lon', 'type': 'text', 'placeholder': '-0.1278' });
 		var coordBtn = E('button', {
@@ -262,9 +267,28 @@ return view.extend({
 					uci.set('wloc-service', 'main', 'manual_lat', lat);
 					uci.set('wloc-service', 'main', 'manual_lon', lon);
 					uci.set('wloc-service', 'main', 'geo_source', 'manual');
+					// Auto-save the applied place into the saved-locations table:
+					// a search result keeps its city label, raw coordinates are
+					// stored as "lat, lon"; an existing entry with the same label
+					// is updated in place instead of duplicated.
+					var autoLabel = (lastSearch && lastSearch.lat === lat && lastSearch.lon === lon)
+						? lastSearch.label : (lat + ', ' + lon);
+					var existingSid = null;
+					uci.sections('wloc-service', 'preset').forEach(function(s) {
+						// Prefer an exact coordinate match (re-applying a place
+						// must not duplicate it), then an exact label match.
+						if (String(s.latitude) === lat && String(s.longitude) === lon) existingSid = s['.name'];
+						else if (!existingSid && s.label === autoLabel) existingSid = s['.name'];
+					});
+					var sid = existingSid || uci.add('wloc-service', 'preset');
+					uci.set('wloc-service', sid, 'label', autoLabel);
+					uci.set('wloc-service', sid, 'latitude', lat);
+					uci.set('wloc-service', sid, 'longitude', lon);
+					lastSearch = null;
 					uci.save('wloc-service');
 					ui.changes.apply(true);
-					notify(wlocI18n.t('Applied'), wlocI18n.t('Coordinates are now the active location.'));
+					renderPresets();
+					notify(wlocI18n.t('Applied'), wlocI18n.t('Coordinates are now the active location and were saved to the list below.'));
 				}).catch(function(err) {
 					// Re-enable the button or it stays dead until a page reload.
 					coordBtn.disabled = false;

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/wificalling-location-gateway/i18n.js
@@ -134,6 +134,7 @@ var ZH = {
 	'Applied': '已应用',
 	'Search result is now the active location. Verify on the iPhone.': '搜索结果已成为当前生效位置。请在 iPhone 上验证。',
 	'Coordinates are now the active location.': '坐标已成为当前生效位置。',
+	'Coordinates are now the active location and were saved to the list below.': '坐标已成为当前生效位置，并已自动存入下方列表。',
 	'Search failed': '搜索失败',
 	'Place not found': '未找到该地名',
 	'Apply failed': '应用失败',

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r11}
+version=${1:-1.3.0-r12}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=11
+release=12
 arch=x86_64
 service_bin=
 ctl_bin=
@@ -29,7 +29,7 @@ Usage: build-release-packages.sh [--plan] [options]
 
 Options:
   --version VERSION          Package version (default: 1.3.0)
-  --release RELEASE          Package release number (default: 11)
+  --release RELEASE          Package release number (default: 12)
   --arch ARCH                OpenWrt runtime architecture (default: x86_64)
   --service-bin PATH         Static wloc-service binary (required)
   --ctl-bin PATH             Static wloc-ctl binary (required)

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -82,9 +82,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r11_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r11.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r12.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r11_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r11_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r11.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r11.apk'; do
+	'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r12.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r12.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=11' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 11'
+grep -Fx 'PKG_RELEASE:=12' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 12'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=11' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 11'
+grep -Fx 'PKG_RELEASE:=12' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 12'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r11_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r11.apk'; do
+	'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r12.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r11}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 11'
+grep -F 'version=${1:-1.3.0-r12}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 12'
 
 printf '%s\n' 'release version tests passed'


### PR DESCRIPTION
## What

Release v1.3.0-r12 on the stable integrated 1.3.0-r1 baseline: applying a manual location now automatically upserts it into the saved-locations table. Closes #87.

- A search result is saved under its city label; raw coordinates under "lat, lon".
- Dedupe prefers an exact coordinate match, then an exact label match — re-applying the same place updates the entry instead of duplicating it.
- The saved-locations table refreshes immediately after apply, with a bilingual confirmation; presets remain plain UCI `config preset` sections (apply/delete unchanged).

## Validation

- All seven `tests/js/*.test.js` suites pass; full `./scripts/ci/verify.sh` gate green.
- Six Standard/Lite assets, Docker install matrix, signed feed, and the live AX6S r11→r12 upgrade follow the merge per the release process.

## 中文说明

发布 v1.3.0-r12（1.3.0-r1 整合基线）：应用手动定位时自动写入"已保存的位置"——搜索结果按城市名保存、手输坐标按"纬度, 经度"保存，重复应用按坐标/标签去重更新；应用后表格立即刷新。完整门禁通过，无守护进程或协议变更。

Handoff capsule: `.handoffs/issue-87.md`