### PR TITLE
release: v1.3.0-r13 realistic memory gate (computed need + self-heal retry) and single-popup log clear

### DIFF
--- a/.handoffs/issue-89.md
+++ b/.handoffs/issue-89.md
@@ -1,0 +1,71 @@
+# Agent handoff: Issue 89
+
+## Identity and scope
+
+- Source agent ID: zcode-memgate-r13-20260829
+- Capabilities used: openwrt,test,ci,docs
+- Branch: codex/issue-89-r13-memory-gate
+- Checkpoint parent: `6bc3ec9` (v1.3.0-r12)
+- Updated at (UTC): 2026-08-29
+- Credentials included: no
+
+## Objective
+
+Publish v1.3.0-r13 replacing the flat 32/64 MiB start-time memory thresholds
+with a computed requirement plus a bounded self-healing retry, and removing
+the redundant success popup after a log clear.
+
+## Completed
+
+- `wificalling-gateway` init: `require_start_memory` now computes the real
+  requirement — Lite cold start streams the compressed runtime through
+  `wc -c` for the exact inflated size plus an 8 MiB margin; warm and standard
+  starts reserve 8 MiB only (the runtime heap is bounded by GOMEMLIMIT).
+- A refused start schedules `schedule_memory_retry`: a locked background loop
+  (30 s x 20, 10-minute window) that retries the service start and logs the
+  outcome, so a temporarily memory-tight router self-heals instead of staying
+  down until a manual restart.
+- `wloc-monitor.js` / `wfc-monitor.js`: clearing a log now closes the confirm
+  modal and empties the list without a second popup; error notifications are
+  kept.
+- Package release metadata bumped to `1.3.0-r13` with bilingual README,
+  changelog, and release-test updates (the variant assertions now pin the
+  computed-gate markers and the retry).
+
+## Verification
+
+- `sh -n` on the init; all seven JS suites pass; full `./scripts/ci/verify.sh`
+  gate green with the updated assertions.
+- Live evidence for the design: the v1.3.0-r10 upgrade refused the gateway
+  with `insufficient available memory (52688 KiB; need 65536 KiB)` while an
+  upgrade ipk sat in /tmp, and stayed down until tmpfs was manually freed —
+  exactly the scenario the retry now self-heals.
+
+## Failed attempts
+
+- The first `gh issue create` for this capsule failed wholesale because the
+  label `role:openwrt` does not exist in the repository; recreated with valid
+  labels.
+
+## Next executable steps
+
+- Merge the release PR after CI is green.
+- Build the six Standard/Lite assets (Rust runtimes reused — no Rust change),
+  run the Docker install matrix, update and re-sign the feed.
+- Tag `v1.3.0-r13`, publish the release, and run the live AX6S r12-to-r13
+  upgrade: the cold-start gate must now pass under the old failure
+  conditions.
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to `smthdagg/wificalling-location-gateway`
+  and `smthdagg/wificalling-location-gateway-feed`.
+- Docker for feed signing and the install matrix.
+- SSH access to the AX6S test router (`192.168.31.1`, root) for the live
+  upgrade validation.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository.
+- The gate change only alters when the router starts its own services; no
+  data-handling or exposure change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes are documented here. Versions follow Semantic Versioning.
 
+## [1.3.0-r13] - 2026-08-29
+
+Replaces the flat 32/64 MiB start-time memory thresholds with a computed
+requirement plus a bounded self-healing retry, on the proven integrated
+1.3.0-r1 Gateway baseline.
+
+- Lite cold start measures the real inflated runtime size (streamed through
+  wc -c) plus an 8 MiB margin instead of a flat 64 MiB; warm and standard
+  starts reserve 8 MiB only (the runtime heap is bounded by GOMEMLIMIT).
+- A refused start schedules a bounded background retry (30 s x 20) so a
+  temporarily memory-tight router self-heals instead of staying down until a
+  manual restart - observed live when an upgrade ipk in /tmp pushed
+  MemAvailable below the old flat gate.
+- Clearing a log closes the confirm modal and empties the list without a
+  second popup; error notifications are kept.
+
+### 中文说明
+
+在已验证的 1.3.0-r1 整合 Gateway 基线上，用"计算实际需求 + 自愈重试"取代
+平面式 32/64 MiB 启动内存阈值。
+
+- Lite 冷启动按流式测得的解压后真实大小 + 8 MiB 余量判定（不再使用固定
+  64 MiB）；热启动与 Standard 仅保留 8 MiB 紧急余量（堆增长已被 GOMEMLIMIT
+  约束）。
+- 预检拒绝后会安排有界后台重试（30 秒 x 20 次），内存缓解后自动拉起，不再
+  一直停摆到人工干预——升级时 /tmp 里的安装包把可用内存压到旧阈值以下的
+  真实场景由此自愈。
+- 清空日志后只关闭确认窗并刷新列表，不再弹第二个提示窗；报错提示保留。
+
 ## [1.3.0-r12] - 2026-08-29
 
 Adds the requested preset auto-save on the proven integrated 1.3.0-r1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A standalone Rust service handles exit geolocation, WLOC response rewriting, certificate lifecycle, precise traffic isolation, and LuCI management — all integrated into a single installable package.
 
 [![CI](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/smthdagg/wificalling-location-gateway/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0--r12-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r12)
+[![Release](https://img.shields.io/badge/release-v1.3.0--r13-blue.svg)](https://github.com/smthdagg/wificalling-location-gateway/releases/tag/v1.3.0-r13)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Rust 1.90](https://img.shields.io/badge/Rust-1.90-orange.svg?logo=rust)](Cargo.toml)
 [![OpenWrt](https://img.shields.io/badge/OpenWrt-24.10%20%7C%2025.12-00B5E2.svg?logo=openwrt)](#support-and-validation-status)
@@ -116,7 +116,7 @@ More detail: [WLOC Service API](docs/api/WLOC_SERVICE_API.md), [Threat model](do
 
 | Platform | Arch | Package manager | Current evidence | Status |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r12 service installed; one WIFICalling sing-box remained running, WLOC was `intercepting`, crash-recovery re-interception was observed, and post-test available memory remained above 32 MiB | **Docker + router + iPhone WLOC passed** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | r13 service installed; one WIFICalling sing-box remained running, WLOC was `intercepting`, crash-recovery re-interception was observed, and post-test available memory remained above 32 MiB | **Docker + router + iPhone WLOC passed** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker boot of init/ubus, integrated package install, service start, socket and v1 status checks | **Install matrix passed** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | Same as above | **Install matrix passed** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | Same, using native APK v3, not a renamed IPK | **Install matrix passed** |
@@ -135,12 +135,12 @@ The runtime packages contain architecture-specific ELF files and **must match th
 
 ### 1. Choose the right package
 
-Release `v1.3.0-r12` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
+Release `v1.3.0-r13` provides two installation variants for each of three targets. Both belong to this project and contain the same WCG, WLOC, control tools, LuCI and saved UCI schema:
 
-- Standard: `wificalling-location-gateway_1.3.0-r12_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r12_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r12.apk`
-- Lite: `wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r12.apk`
+- Standard: `wificalling-location-gateway_1.3.0-r13_aarch64_cortex-a53.ipk`, `wificalling-location-gateway_1.3.0-r13_x86_64.ipk`, `wificalling-location-gateway-1.3.0-r13.apk`
+- Lite: `wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk`, `wificalling-location-gateway-lite_1.3.0-r13_x86_64.ipk`, `wificalling-location-gateway-lite-1.3.0-r13.apk`
 
-### r12 changes
+### r13 changes
 
 - Every TPROXY install refreshes the upstream map; disable/enable and sing-box crash recovery can no longer leave interception silently broken.
 - Disabled WLOC is genuinely fail-open: the boot script withdraws the DNS hijack, TPROXY, and upstream map when the switch is off, and disabling restarts dnsmasq immediately.
@@ -176,22 +176,22 @@ Full instructions for both methods live in the
 ### 2. Redmi AX6S (Lite recommended)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk
 ```
 
-Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r12 Lite package replaces the separate sing-box package and owns its transparent wrapper.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r13 Lite package replaces the separate sing-box package and owns its transparent wrapper.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r12_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r13_x86_64.ipk
 # Or use the corresponding Lite asset when a bundled, bounded runtime is preferred.
 ```
 
 ### 4. OpenWrt 25.12 (native APK v3)
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r12.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r13.apk
 ```
 
 `--allow-untrusted` applies only to locally built packages that are not yet signed in a repository. Formal releases use repository signing; never rename an IPK into an APK.
@@ -267,7 +267,7 @@ This pins the OpenWrt 24.10.8 `mediatek/mt7622` toolchain, Rust version, and SHA
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r12"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r13"
 ```
 
 Builds use the official OpenWrt SDK pinned by digest; after dependency preparation, product compilation runs locked/offline with read-only sources in a network-disabled container. Full boundaries and results: [OpenWrt packaging and Docker matrix](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md).
@@ -423,7 +423,7 @@ flowchart TD
 
 | 平台 | 架构 | 包管理器 | 当前证据 | 状态 |
 |---|---:|---|---|---|
-| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r12 服务；只保留一个 WIFICalling sing-box，WLOC 为 `intercepting`，观察到崩溃后自动恢复拦截，测试后可用内存仍高于 32 MiB | **Docker + 路由器 + iPhone WLOC 通过** |
+| Redmi AX6S · ImmortalWrt 24.10.6 | MediaTek MT7622 / AArch64 | opkg | 已安装 r13 服务；只保留一个 WIFICalling sing-box，WLOC 为 `intercepting`，观察到崩溃后自动恢复拦截，测试后可用内存仍高于 32 MiB | **Docker + 路由器 + iPhone WLOC 通过** |
 | OpenWrt 24.10.8 | x86_64 | opkg / IPK | Docker 中启动 init/ubus、安装集成包、启动服务、Socket 与 v1 状态检查 | **安装矩阵通过** |
 | iStoreOS 24.10.5 | x86_64 | opkg / IPK | 同上 | **安装矩阵通过** |
 | OpenWrt 25.12.3 | x86_64 | apk / APK v3 | 同上，使用原生 APK v3，非改名 IPK | **安装矩阵通过** |
@@ -442,12 +442,12 @@ flowchart TD
 
 ### 1. 选择正确的安装包
 
-`v1.3.0-r12` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
+`v1.3.0-r13` 为三个目标各提供 Standard 与 Lite 两种安装规格。它们属于同一个项目，WCG、WLOC、控制工具、LuCI 与 UCI 数据结构完全一致：
 
-- Standard：`wificalling-location-gateway_1.3.0-r12_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r12_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r12.apk`
-- Lite：`wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r12.apk`
+- Standard：`wificalling-location-gateway_1.3.0-r13_aarch64_cortex-a53.ipk`、`wificalling-location-gateway_1.3.0-r13_x86_64.ipk`、`wificalling-location-gateway-1.3.0-r13.apk`
+- Lite：`wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk`、`wificalling-location-gateway-lite_1.3.0-r13_x86_64.ipk`、`wificalling-location-gateway-lite-1.3.0-r13.apk`
 
-### r12 更新说明
+### r13 更新说明
 
 - 每次 TPROXY 安装都会刷新上游映射；禁用/启用与 sing-box 崩溃恢复不会再让拦截静默失效。
 - 禁用的 WLOC 真正 fail-open：开机脚本按开关撤除 DNS 劫持、TPROXY 与上游映射，停用即重启 dnsmasq。
@@ -483,22 +483,22 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 ### 2. Redmi AX6S（推荐 Lite）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r12_aarch64_cortex-a53.ipk
+opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r12 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r13 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 
 ```sh
-opkg install /tmp/wificalling-location-gateway_1.3.0-r12_x86_64.ipk
+opkg install /tmp/wificalling-location-gateway_1.3.0-r13_x86_64.ipk
 # 需要内置、受限运行时时也可选择对应 Lite 文件。
 ```
 
 ### 4. OpenWrt 25.12（原生 APK v3）
 
 ```sh
-apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r12.apk
+apk add --allow-untrusted /tmp/wificalling-location-gateway-1.3.0-r13.apk
 ```
 
 `--allow-untrusted` 仅适用于当前未接入软件源签名的本地构建包。正式软件源发布应使用仓库签名，且不能把 IPK 重命名为 APK。
@@ -574,7 +574,7 @@ OPENWRT_CROSS_CACHE_DIR=/tmp/wloc-rust-openwrt \
 
 ```sh
 ./scripts/openwrt/verify-docker-matrix.sh \
-  --dist-dir "$PWD/dist/wloc-openwrt-release-r12"
+  --dist-dir "$PWD/dist/wloc-openwrt-release-r13"
 ```
 
 构建使用固定摘要的官方 OpenWrt SDK；依赖准备之后，产品编译采用 locked/offline、只读源码和禁网容器。完整边界和结果见 [OpenWrt 发布打包与 Docker 矩阵](docs/testing/OPENWRT_PACKAGE_DOCKER_MATRIX.md)。

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wloc-service
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/files/etc/init.d/wificalling-gateway
+++ b/openwrt/files/etc/init.d/wificalling-gateway
@@ -63,19 +63,53 @@ append_node() {
 append_ip() { DEVICE_IPS="${DEVICE_IPS}${DEVICE_IPS:+,}$1"; }
 
 require_start_memory() {
-	local minimum_available_kib=32768 available_kib
-	# Lite must first inflate its compressed executable into tmpfs.  Reserve
-	# that one-time image before asking sing-box to validate or run it.
-	if [ "$(cat /usr/share/wificalling-location-gateway/runtime-variant 2>/dev/null)" = lite ] \
-		&& [ ! -x /tmp/sing-box-lite ]; then
-		minimum_available_kib=65536
+	# Compute the real requirement instead of flat thresholds:
+	# - Lite cold start must inflate the compressed runtime into tmpfs first;
+	#   the exact inflated size is measured by streaming the archive through
+	#   wc -c, plus an 8 MiB working margin. The runtime heap is already
+	#   bounded by GOMEMLIMIT, so warm and standard starts only reserve a
+	#   small emergency margin.
+	# - A refusal schedules a bounded background retry (30 s x 20) so a
+	#   temporarily memory-tight router self-heals instead of staying down
+	#   until a manual restart (procd never re-runs a failed start_service).
+	local reserve_kib=8192 variant gz inflated_kb needed_kb
+	variant=$(cat /usr/share/wificalling-location-gateway/runtime-variant 2>/dev/null)
+	gz=/usr/share/wificalling-location-gateway/sing-box-lite.gz
+	if [ "$variant" = lite ] && [ ! -x /tmp/sing-box-lite ] && [ -s "$gz" ]; then
+		inflated_kb=$(gzip -dc "$gz" 2>/dev/null | wc -c)
+		case "$inflated_kb" in ''|*[!0-9]*) return 0;; esac
+		inflated_kb=$((inflated_kb / 1024))
+		needed_kb=$((inflated_kb + reserve_kib))
+	else
+		needed_kb=$reserve_kib
 	fi
+	local available_kib
 	available_kib=$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo 2>/dev/null || true)
 	case "$available_kib" in ''|*[!0-9]*) return 0;; esac
-	[ "$available_kib" -ge "$minimum_available_kib" ] || {
-		logger -t "$APP" "insufficient available memory (${available_kib} KiB; need ${minimum_available_kib} KiB); refusing to start before the router OOMs"
-		return 1
-	}
+	[ "$available_kib" -ge "$needed_kb" ] && return 0
+	logger -t "$APP" "insufficient available memory (${available_kib} KiB; need ${needed_kb} KiB); retrying in the background"
+	schedule_memory_retry
+	return 1
+}
+
+schedule_memory_retry() {
+	# One background retry loop at a time (mkdir lock); 30 s x 20 = 10 min
+	# window, then give up with a clear log entry.
+	local lock=/tmp/wificalling-gateway-mem-retry
+	mkdir "$lock" 2>/dev/null || return 0
+	(
+		trap 'rmdir "$lock" 2>/dev/null' EXIT HUP INT TERM
+		local attempt=0
+		while [ "$attempt" -lt 20 ]; do
+			sleep 30
+			if /etc/init.d/wificalling-gateway start >/dev/null 2>&1; then
+				logger -t "$APP" "memory retry succeeded; service started"
+				exit 0
+			fi
+			attempt=$((attempt + 1))
+		done
+		logger -t "$APP" "memory retry window exhausted; waiting for manual start"
+	) >/dev/null 2>&1 &
 }
 
 append_device() {

--- a/openwrt/luci-app-wificalling-location-gateway/Makefile
+++ b/openwrt/luci-app-wificalling-location-gateway/Makefile
@@ -5,7 +5,7 @@ LUCI_DESCRIPTION:=Unified admin UI for the Wi-Fi Calling gateway and the WLOC lo
 LUCI_DEPENDS:=+wloc-service +luci-app-wificalling-gateway +luci-base +rpcd-mod-rpcsys
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_MAINTAINER:=wificalling-location-gateway maintainers
 

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wfc-monitor.js
@@ -91,7 +91,7 @@ return view.extend({
 			ui.showModal(wlocI18n.t('Clear activity log?'), [E('p', {}, wlocI18n.t('This permanently removes only the Wi-Fi Calling activity history. Settings and system logs are not affected.')),
 				E('div', { class: 'right' }, [E('button', { class: 'btn', click: ui.hideModal }, wlocI18n.t('Cancel')),
 				E('button', { class: 'btn cbi-button-negative', click: function() {
-					clearLog('wfc').then(function() { renderLog(''); ui.hideModal(); ui.addNotification(null, E('p', {}, wlocI18n.t('Activity log cleared.')), 'info'); }).catch(function(err) { ui.hideModal(); ui.addNotification(null, E('p', {}, wlocI18n.t('Unable to clear log: ') + ' ' + err.message), 'error'); });
+					clearLog('wfc').then(function() { renderLog(''); ui.hideModal(); }).catch(function(err) { ui.hideModal(); ui.addNotification(null, E('p', {}, wlocI18n.t('Unable to clear log: ') + ' ' + err.message), 'error'); });
 				} }, wlocI18n.t('Clear log'))])]);
 		} }, wlocI18n.t('Clear log'));
 

--- a/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
+++ b/openwrt/luci-app-wificalling-location-gateway/files/www/luci-static/resources/view/wificalling-location-gateway/wloc-monitor.js
@@ -192,9 +192,11 @@ return view.extend({
 				E('div', { class: 'right' }, [E('button', { class: 'btn', click: ui.hideModal }, wlocI18n.t('Cancel')),
 				E('button', { class: 'btn cbi-button-negative', click: function() {
 					clearLog('wloc').then(function() {
+						// The emptied list and the closed modal are feedback
+						// enough; a second popup after the confirm dialog is
+						// noise.
 						renderLog('');
 						ui.hideModal();
-						ui.addNotification(null, E('p', {}, wlocI18n.t('WLOC usage log cleared.')), 'info');
 					}).catch(function(err) {
 						ui.hideModal();
 						ui.addNotification(null, E('p', {}, wlocI18n.t('Unable to clear log: ') + ' ' + err.message), 'error');

--- a/scripts/build-luci-ipk.sh
+++ b/scripts/build-luci-ipk.sh
@@ -2,7 +2,7 @@
 set -eu
 
 root=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
-version=${1:-1.3.0-r12}
+version=${1:-1.3.0-r13}
 dependency_mode=${2:-production}
 package=luci-app-wificalling-location-gateway
 source_dir="$root/openwrt/$package/files"

--- a/scripts/openwrt/build-release-packages.sh
+++ b/scripts/openwrt/build-release-packages.sh
@@ -6,7 +6,7 @@ OPENWRT_25_SDK='ghcr.io/openwrt/sdk:x86_64-25.12.3@sha256:a0ab488698b70d6585dc35
 
 repo_root=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 version=1.3.0
-release=12
+release=13
 arch=x86_64
 service_bin=
 ctl_bin=
@@ -29,7 +29,7 @@ Usage: build-release-packages.sh [--plan] [options]
 
 Options:
   --version VERSION          Package version (default: 1.3.0)
-  --release RELEASE          Package release number (default: 12)
+  --release RELEASE          Package release number (default: 13)
   --arch ARCH                OpenWrt runtime architecture (default: x86_64)
   --service-bin PATH         Static wloc-service binary (required)
   --ctl-bin PATH             Static wloc-ctl binary (required)

--- a/tests/scripts/test-openwrt-release-packaging.sh
+++ b/tests/scripts/test-openwrt-release-packaging.sh
@@ -82,9 +82,9 @@ plan=$(
 		--ctl-bin "$tmp/wloc-ctl"
 )
 
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway_1.3.0-r13_x86_64.ipk' >/dev/null ||
 	fail '24.10 must produce one architecture-specific integrated IPK'
-printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r12.apk (arch: x86_64)' >/dev/null ||
+printf '%s\n' "$plan" | grep -F 'wificalling-location-gateway-1.3.0-r13.apk (arch: x86_64)' >/dev/null ||
 	fail '25.12 must produce one architecture-specific integrated APK'
 if printf '%s\n' "$plan" | grep -E 'wloc-service[_-]|luci-app-wificalling-location-gateway[_-]' >/dev/null; then
 	fail 'formal 1.3.0 plan must not expose split component packages'

--- a/tests/scripts/test-package-variants.sh
+++ b/tests/scripts/test-package-variants.sh
@@ -32,10 +32,10 @@ plan=$(
 )
 
 for expected in \
-	'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' \
-	'wificalling-location-gateway-lite_1.3.0-r12_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r12.apk' \
-	'wificalling-location-gateway-lite-1.3.0-r12.apk'; do
+	'wificalling-location-gateway_1.3.0-r13_x86_64.ipk' \
+	'wificalling-location-gateway-lite_1.3.0-r13_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r13.apk' \
+	'wificalling-location-gateway-lite-1.3.0-r13.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "dual-variant plan is missing $expected"
 done
@@ -84,10 +84,12 @@ grep -F 'GOMAXPROCS=1' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway"
 	fail 'Lite runtime profile must retain single-worker scheduling'
 grep -F 'GOGC=50' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
 	fail 'Lite runtime profile must reclaim memory before AX6S reaches OOM pressure'
-grep -F 'minimum_available_kib=32768' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
-	fail 'Gateway must reserve enough RAM to avoid an installation-time OOM'
-grep -F 'minimum_available_kib=65536' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
-	fail 'Lite cold start must reserve RAM for its tmpfs runtime image'
+grep -F 'reserve_kib=8192' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'Gateway memory preflight must reserve an 8 MiB emergency margin'
+grep -F 'gzip -dc "$gz" 2>/dev/null | wc -c' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'Lite cold start must measure the real inflated runtime size instead of a flat threshold'
+grep -F 'schedule_memory_retry' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
+	fail 'A memory-gated start must self-heal via a bounded background retry'
 grep -F 'MemAvailable' "$repo_root/openwrt/files/etc/init.d/wificalling-gateway" >/dev/null ||
 	fail 'Gateway memory preflight must use the kernel available-memory metric'
 grep -F 'rm -f /tmp/sing-box-lite /tmp/sing-box-lite.sha256' "$ax6s_builder" >/dev/null ||

--- a/tests/scripts/test-release-version.sh
+++ b/tests/scripts/test-release-version.sh
@@ -18,12 +18,12 @@ grep -F 'webpki-roots = "=1.0.9"' "$repo_root/Cargo.toml" >/dev/null ||
 	fail 'version bumps must not rewrite pinned dependency versions'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/Makefile" >/dev/null ||
 	fail 'OpenWrt runtime version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=12' "$repo_root/openwrt/Makefile" >/dev/null ||
-	fail 'OpenWrt runtime release must be 12'
+grep -Fx 'PKG_RELEASE:=13' "$repo_root/openwrt/Makefile" >/dev/null ||
+	fail 'OpenWrt runtime release must be 13'
 grep -Fx 'PKG_VERSION:=1.3.0' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
 	fail 'LuCI package version must be 1.3.0'
-grep -Fx 'PKG_RELEASE:=12' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
-	fail 'LuCI package release must be 12'
+grep -Fx 'PKG_RELEASE:=13' "$repo_root/openwrt/luci-app-wificalling-location-gateway/Makefile" >/dev/null ||
+	fail 'LuCI package release must be 13'
 
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-service"
 printf '#!/bin/sh\nexit 0\n' > "$tmp/wloc-ctl"
@@ -33,13 +33,13 @@ plan=$(
 		--arch x86_64 --service-bin "$tmp/wloc-service" --ctl-bin "$tmp/wloc-ctl"
 )
 for expected in \
-	'wificalling-location-gateway_1.3.0-r12_x86_64.ipk' \
-	'wificalling-location-gateway-1.3.0-r12.apk'; do
+	'wificalling-location-gateway_1.3.0-r13_x86_64.ipk' \
+	'wificalling-location-gateway-1.3.0-r13.apk'; do
 	printf '%s\n' "$plan" | grep -F "$expected" >/dev/null ||
 		fail "release plan is missing $expected"
 done
 
-grep -F 'version=${1:-1.3.0-r12}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
-	fail 'AX6S standalone builder default must be 1.3.0 release 12'
+grep -F 'version=${1:-1.3.0-r13}' "$repo_root/scripts/build-luci-ipk.sh" >/dev/null ||
+	fail 'AX6S standalone builder default must be 1.3.0 release 13'
 
 printf '%s\n' 'release version tests passed'


### PR DESCRIPTION
## What

Release v1.3.0-r13 on the stable integrated 1.3.0-r1 baseline: realistic memory gate + single-popup log clear. Closes #89.

- `require_start_memory` computes the real requirement: Lite cold start streams the compressed runtime through `wc -c` for the exact inflated size + 8 MiB margin; warm/standard starts reserve 8 MiB only (the runtime heap is bounded by GOMEMLIMIT=48MiB). The flat 32/64 MiB thresholds sat inside the AX6S normal operating band (30-60 MiB free with PassWall) and blocked starts they should have allowed.
- A refused start schedules a locked background retry (30 s x 20, 10-minute window): a temporarily memory-tight router self-heals instead of staying down until a manual restart — procd never re-runs a failed start_service, which is exactly what happened live during the r10 upgrade (`insufficient available memory (52688 KiB; need 65536 KiB)` while an upgrade ipk sat in /tmp).
- Clearing a log closes the confirm modal and empties the list without a second popup; error notifications are kept.
- Package release metadata bumped to `1.3.0-r13`; bilingual README, changelog, and release tests pin the new gate markers.

## Validation

- `sh -n` on the init; all seven JS suites pass; full `./scripts/ci/verify.sh` gate green with the updated assertions.
- Six Standard/Lite assets, Docker install matrix, signed feed, and the live AX6S r12→r13 upgrade (cold-start gate exercised under the old failure conditions) follow the merge per the release process.

## 中文说明

发布 v1.3.0-r13（1.3.0-r1 整合基线）：用"计算实际需求 + 有界自愈重试"取代平面式 32/64 MiB 启动内存阈值——Lite 冷启动流式实测解压大小 + 8 MiB 余量，热启动/Standard 仅保留 8 MiB 紧急余量；预检拒绝后台自动重试 10 分钟，不再停摆到人工干预。清空日志只关确认窗、不再弹第二个提示。完整门禁通过；合并后按流程发六包、跑矩阵、实机升级并更新签名 feed。

Handoff capsule: `.handoffs/issue-89.md`