### PR TITLE
docs: record v1.3.0-r13 verification evidence and align the feed README

### DIFF
--- a/.handoffs/issue-91.md
+++ b/.handoffs/issue-91.md
@@ -1,0 +1,59 @@
+# Agent handoff: Issue 91
+
+## Identity and scope
+
+- Source agent ID: zcode-docs-r13-20260829
+- Capabilities used: docs,ci
+- Branch: codex/issue-91-r13-verification-docs
+- Checkpoint parent: `9ee5a4f` (v1.3.0-r13)
+- Updated at (UTC): 2026-08-29
+- Credentials included: no
+
+## Objective
+
+Complete the GitHub-side file updates for v1.3.0-r13: add the r13
+verification record to docs/testing and align the feed repository README with
+the current release filenames.
+
+## Completed
+
+- `docs/testing/V1.3.0_R13_MEMORY_GATE.tdd.md`: the r13 verification record —
+  gates (verify.sh, ShellCheck 0 findings, JS suites), the 8/8 Docker install
+  matrix, and the live AX6S evidence (cold start passed with MemAvailable at
+  ~23.5 MiB under conditions where the old 64 MiB gate refused; signature
+  checks; config values intact).
+- Feed repository `README.md` (main branch, b467984): the package table now
+  tracks the current release filenames (1.3.0-r13) with a current-release
+  note; pushed directly on the feed repo (no PR contract there).
+- No production code changes.
+
+## Verification
+
+- `./scripts/ci/verify-handoffs.sh` passes for this capsule.
+- The verification record cites the already-executed evidence: full gate,
+  Docker ShellCheck 0 findings, 8/8 install matrix, release SHA256SUMS 6/6 on
+  download, AX6S `opkg update` signature passed.
+
+## Failed attempts
+
+- The first issue creation failed because the label `role:docs` does not
+  exist; recreated with `role:integration`.
+- The feed README push was rejected once by GitHub email-privacy restrictions
+  (global git identity); resolved by amending with the repository's noreply
+  identity — the same failure mode documented in the r11 session.
+
+## Next executable steps
+
+- Merge this docs PR; no release actions are required (v1.3.0-r13 is already
+  tagged and published).
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to `smthdagg/wificalling-location-gateway`
+  and `smthdagg/wificalling-location-gateway-feed`.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository.
+- The verification record quotes only log snippets (memory figures, gate
+  messages) with no device identifiers or location data.

--- a/docs/testing/V1.3.0_R13_MEMORY_GATE.tdd.md
+++ b/docs/testing/V1.3.0_R13_MEMORY_GATE.tdd.md
@@ -1,0 +1,50 @@
+# v1.3.0-r13 realistic memory gate — verification record
+
+## Scope
+
+Replaces the flat 32/64 MiB start-time memory thresholds with a computed
+requirement (Lite cold start: exact inflated runtime size + 8 MiB margin;
+warm/standard: 8 MiB emergency reserve — the runtime heap is bounded by
+`GOMEMLIMIT=48MiB`) plus a bounded self-healing background retry. Also removes
+the redundant success popup after a log clear. No daemon or protocol changes;
+Rust runtimes are unchanged from the r10 build.
+
+## Gates
+
+```sh
+sh -n openwrt/files/etc/init.d/wificalling-gateway
+node tests/js/*.test.js                       # 7 suites, all pass
+./scripts/ci/verify.sh                        # full gate: Python 69, packaging,
+                                              # secret scan, cargo audit/deny
+docker run --rm -v "$PWD:/repo" -w /repo koalaman/shellcheck:v0.10.0 \
+    $(find scripts -type f -name '*.sh')      # 0 findings
+```
+
+All green; the package-variant assertions now pin the computed-gate markers
+(`reserve_kib=8192`, the `gzip -dc | wc -c` measurement, and
+`schedule_memory_retry`).
+
+## Docker install matrix
+
+8/8 on the six v1.3.0-r13 assets: AX6S 24.10.5, OpenWrt 24.10.8,
+OpenWrt 25.12.3 (native apk), iStoreOS 24.10.5 × standard/lite — every case
+`installed|started|socket-ok|status-ok`.
+
+## Live AX6S evidence (r12 → r13 upgrade)
+
+- **MemAvailable before the upgrade: 24024 KiB (~23.5 MiB)** — conditions under
+  which the old 64 MiB cold-start gate categorically refused; the historical
+  log lines (`insufficient available memory (52688 KiB; need 65536 KiB)`,
+  14:07) are retained as evidence.
+- The r13 upgrade's cold start **passed the computed gate** and started the
+  gateway: `phase intercepting`, single shared sing-box, monitor running,
+  config valid, 21 nft rules, 3/3 nodes healthy, `upstream-map` present.
+- `opkg update` prints `Signature check passed` (long-lived key
+  `f7050198aa77cf15`); the live config values (manual coordinates, assigned
+  device, presets, enabled) are intact.
+
+## Release integrity
+
+- Release `SHA256SUMS` re-verified on download: 6/6 OK.
+- Feed gh-pages re-indexed and re-signed with the same long-lived key; the
+  feed README now tracks the current release filenames.


### PR DESCRIPTION
## What

Completes the GitHub-side file updates for v1.3.0-r13. Closes #91.

- Adds `docs/testing/V1.3.0_R13_MEMORY_GATE.tdd.md`: the r13 verification record — full gate, Docker ShellCheck 0 findings, 8/8 install matrix, and the live AX6S evidence (cold start passed with MemAvailable at ~23.5 MiB where the old 64 MiB gate refused; `opkg update` signature passed; config values intact).
- The feed repository README (main branch, b467984) now tracks the current release filenames (was still 1.3.0-r1); updated directly on the feed repo.
- Docs only; no production code changes.

## 中文说明

补齐 v1.3.0-r13 的 GitHub 侧文件：新增 r13 实测记录文档（完整门禁、8/8 矩阵、AX6S 在可用内存 ~23.5 MiB 下冷启动成功的实证、签名校验），并将安装源仓库 README 的包名对齐到当前版本。

Handoff capsule: `.handoffs/issue-91.md`