### PR TITLE
docs: standardize post-upgrade memory cleanup and the private feed update workflow

### DIFF
--- a/.handoffs/issue-93.md
+++ b/.handoffs/issue-93.md
@@ -1,0 +1,65 @@
+# Agent handoff: Issue 93
+
+## Identity and scope
+
+- Source agent ID: zcode-upgrade-hygiene-docs-20260830
+- Capabilities used: docs,ci
+- Branch: codex/issue-93-upgrade-hygiene-docs
+- Checkpoint parent: `8e28249` (r13 docs)
+- Updated at (UTC): 2026-08-30
+- Credentials included: no
+
+## Objective
+
+Write the post-upgrade memory/temp hygiene and the private signed feed
+update into the project's standard documents, after the live incident where
+an upgrade IPK left in /tmp pushed MemAvailable below the cold-start memory
+gate, and after the feed index generator was found to be documented at a
+path that does not exist in this repository.
+
+## Completed
+
+- `AGENTS.md` (AX6S upgrade and debugging cleanup gate): the signed-feed
+  upgrade is now the standard path (creates no /tmp artifact); local IPK
+  installs must delete the file in the same command chain; ad-hoc debug
+  backup directories must not survive the session; the post-test memory
+  requirement now references the computed cold-start gate of
+  `require_start_memory` (inflated Lite runtime + 8 MiB) instead of the old
+  flat 32 MiB; `drop_caches` is allowed only as a final measurement
+  normalization after zero leaked files/processes are confirmed.
+- `docs/releases/RELEASE_PROCESS.md`: mandatory post-upgrade hygiene step 5a
+  in the release checklist (remove uploaded installers and session backup
+  dirs, normalize the measurement, verify MemAvailable above the cold-start
+  requirement and service health).
+- `README.md` (bilingual): AX6S upgrade guidance now says /tmp is RAM,
+  prefers the feed upgrade, and requires delete-after-install for local IPKs.
+- `docs/releases/RELEASE_PROCESS.md` step 6 and `AGENTS.md` required
+  workflow now include the private signed feed update as a mandatory
+  standard step: the index generator lives in the feed repository
+  (`scripts/gen-feed-index.sh` on the feed main branch), index regeneration
+  before signing is mandatory, the feed `README.md` package table must be
+  aligned with the current release, and feed pushes require the account's
+  noreply git identity.
+
+## Verification
+
+- `./scripts/ci/verify-handoffs.sh` passes; docs-only change, no production
+  code touched. The live incident that motivated this standard is documented
+  in `docs/testing/V1.3.0_R13_MEMORY_GATE.tdd.md`.
+
+## Failed attempts
+
+- None; the three documents applied cleanly.
+
+## Next executable steps
+
+- Merge this docs PR. The workflow applies to every future live upgrade and
+  to release steps 5/5a.
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to the repository.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,13 @@ Issue-specific ownership overrides this table. Ownership is a time-limited lease
 5. Keep commits focused and use Conventional Commits.
 6. Before pausing, lease expiry, or PR creation, update `.handoffs/issue-<number>.md`, commit it, push the branch, and publish the exact commit.
 7. Open a PR containing `Closes #<number>`, evidence, risks, rollback notes, and the handoff capsule path.
+7a. For every release PR, update the private signed feed (mandatory, before
+   tagging): swap the four IPKs + `SHA256SUMS` in the feed repo `gh-pages`
+   checkout, regenerate the index with the feed repo's
+   `scripts/gen-feed-index.sh`, sign with `scripts/openwrt/sign-feed.sh`,
+   push `gh-pages`, and align the feed `README.md` package table with the
+   current release. Full sequence: `docs/releases/RELEASE_PROCESS.md`
+   step 6. The feed repo requires the account's noreply git identity.
 8. A different role reviews the PR. The author never self-approves a safety-sensitive change.
 
 Use `scripts/agent-takeover.sh <issue> <agent> <slug> <capabilities> [ttl-minutes]` to start or resume work. Use `scripts/agent-handoff.sh <issue> <agent> <capabilities>` to release a resumable checkpoint.
@@ -66,7 +73,12 @@ or a release is accepted:
    maintain an explicit list of files created by the session and remove those
    files after installation/testing, including failed or superseded IPKs. Use
    short, bounded commands or a cleanup trap so SSH command truncation cannot
-   silently skip cleanup.
+   silently skip cleanup. The standard upgrade path is the signed feed
+   (`opkg update && opkg upgrade <package>`), which creates no `/tmp` artifact
+   at all; when a local IPK must be uploaded, the install command chain must
+   delete it in the same session (`opkg install /tmp/x.ipk && rm -f /tmp/x.ipk`),
+   and any ad-hoc debug backup directory (e.g. `wloc-*-backup-*`) must be
+   removed before the session ends.
 3. Never run a blanket `rm -rf /tmp` on a live gateway. Preserve the active
    `/tmp/sing-box-lite`, its checksum marker, `/var/run` sockets/configuration,
    PassWall runtime state, and user files; remove only session-owned temporary
@@ -77,9 +89,13 @@ or a release is accepted:
    any second long-lived sing-box owned by an explicitly enabled service such
    as PassWall must be identified and included in the memory budget.
 5. Repeat `free` and `df -h /tmp /overlay`. The post-test available memory must
-   return to the pre-test baseline within 10 MiB and remain at least 32 MiB;
-   otherwise block the release and investigate. Do not use `drop_caches` to hide
-   leaked files or processes.
+   return to the pre-test baseline within 10 MiB and remain above the computed
+   cold-start requirement of `require_start_memory` (inflated Lite runtime +
+   8 MiB; roughly 38 MiB on the AX6S); otherwise block the release and
+   investigate. Do not use `drop_caches` to hide leaked files or processes;
+   after zero leaked files/processes are confirmed, one final
+   `sync; echo 3 > /proc/sys/vm/drop_caches` is allowed to normalize the
+   measurement before re-reading `MemAvailable`.
 6. If OOM or a service crash occurs, save the relevant `logread`/kernel OOM
    evidence before cleanup, identify the triggering operation, then clean and
    re-measure. A test is not complete while stale packages or temporary

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Full instructions for both methods live in the
 opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk
 ```
 
-Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r13 Lite package replaces the separate sing-box package and owns its transparent wrapper.
+Back up both UCI files first. On storage-constrained AX6S units, stop the services and remove the old integrated and sing-box packages before installing Lite; do not delete the saved UCI files. The r13 Lite package replaces the separate sing-box package and owns its transparent wrapper. `/tmp` is RAM: prefer the signed-feed upgrade (`opkg update && opkg upgrade wificalling-location-gateway-lite`), and when installing a local IPK, delete it right after installation (`opkg install /tmp/x.ipk && rm -f /tmp/x.ipk`) — leftover files in `/tmp` can push available memory below the cold-start memory gate.
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10 (IPK)
 
@@ -486,7 +486,7 @@ OpenWrt 25.x 的 `.apk` 手动安装命令）。
 opkg install /tmp/wificalling-location-gateway-lite_1.3.0-r13_aarch64_cortex-a53.ipk
 ```
 
-安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r13 Lite 会替代独立 sing-box 包并拥有透明启动包装器。
+安装前先备份两份 UCI 配置。AX6S 空间不足时，先停止服务并卸载旧整合包和旧 sing-box 包，再安装 Lite；不要删除 UCI 配置。r13 Lite 会替代独立 sing-box 包并拥有透明启动包装器。/tmp 是内存：优先使用签名软件源升级（`opkg update && opkg upgrade wificalling-location-gateway-lite`）；本地上传 IPK 安装后请立即删除（`opkg install /tmp/x.ipk && rm -f /tmp/x.ipk`）——/tmp 残留文件可能把可用内存压到冷启动内存门禁以下。
 
 ### 3. OpenWrt 24.10 / iStoreOS 24.10（IPK）
 

--- a/docs/releases/RELEASE_PROCESS.md
+++ b/docs/releases/RELEASE_PROCESS.md
@@ -71,11 +71,34 @@ This is also implemented as `scripts/openwrt/sign-feed.sh`.
 5. **Install test**: `verify-docker-matrix.sh --dist-dir
    dist/openwrt-release` (four environments) and a live upgrade on the
    AX6S test router.
-6. **Feed**: swap the release files in the feed repo `gh-pages` branch,
-   regenerate `Packages`/`Packages.gz`
-   (`scripts/gen-feed-index.sh`), sign with
-   `scripts/openwrt/sign-feed.sh` (same key as always), push `gh-pages`
-   and `main`. The `wloc.pub` does **not** change.
+5a. **Post-upgrade hygiene (AX6S, mandatory)**: remove every uploaded
+   installer package from `/tmp` in the same session that installed it
+   (`opkg install /tmp/x.ipk && rm -f /tmp/x.ipk`), delete any ad-hoc debug
+   backup directories created during the session, then
+   `sync; echo 3 > /proc/sys/vm/drop_caches` and re-read `MemAvailable`: it
+   must stay above the computed cold-start requirement of
+   `require_start_memory` (inflated Lite runtime + 8 MiB). Verify service
+   health (`wloc-health.sh`), the package version, and a single sing-box
+   process. Prefer the signed-feed upgrade
+   (`opkg update && opkg upgrade <package>`), which creates no `/tmp`
+   artifact at all.
+6. **Feed (private signed package source — mandatory, before tagging)**:
+   the index generator lives in the feed repository, not here. Standard
+   sequence (use the repository's noreply git identity — the feed repo
+   rejects pushes from personal-email commits):
+   a. `git clone --branch main https://github.com/smthdagg/wificalling-location-gateway-feed.git /tmp/wloc-feed-main`
+      and `git clone --branch gh-pages https://github.com/smthdagg/wificalling-location-gateway-feed.git /tmp/wloc-feed`.
+   b. In the `gh-pages` checkout: remove the previous release packages and
+      `Packages*`/`SHA256SUMS`, copy the four new IPKs plus this repo's
+      `SHA256SUMS`.
+   c. `/tmp/wloc-feed-main/scripts/gen-feed-index.sh /tmp/wloc-feed`
+      (regenerates `Packages`/`Packages.gz`), then
+      `scripts/openwrt/sign-feed.sh /tmp/wloc-feed` (same long-lived key as
+      always) — signing without regenerating the index is forbidden.
+   d. Commit and push `gh-pages`; the feed `main` branch changes only if
+      `wloc.pub` or its docs change — also align the feed `README.md`
+      package table with the current release filenames.
+   e. `wloc.pub` does **not** change between releases.
 7. **GitHub**: tag `v<version>`, create the Release with the three
    packages, `SHA256SUMS`, and the signed `Packages`/`Packages.gz`(+`.sig`)
    assets, bilingual notes (English first, Chinese after).


### PR DESCRIPTION
## What

Writes two operational standards into the project's documents. Closes #93.

- **Post-upgrade memory/temp hygiene**: the signed-feed upgrade is the standard path (creates no /tmp artifact); local IPK installs must delete the file in the same command chain; ad-hoc debug backup dirs must not survive the session; post-test MemAvailable must exceed the computed cold-start requirement (inflated Lite runtime + 8 MiB); `drop_caches` only as a final measurement normalization after zero leaks are confirmed.
- **Private signed feed update as a mandatory release step**: every release PR updates the feed (swap IPKs + SHA256SUMS → regenerate index with the feed repo's `scripts/gen-feed-index.sh` → `sign-feed.sh` → push gh-pages → align the feed README table with the current release). RELEASE_PROCESS step 6 corrected — the index generator was documented at a path that does not exist in this repository. Feed pushes require the account's noreply git identity (email-privacy rejection hit twice).

## Validation

- `./scripts/ci/verify-handoffs.sh` green; full `./scripts/ci/verify.sh` gate green. Docs only; no production code changes.

## 中文说明

将两项运维标准写入项目文档：(1) 升级后内存/临时文件清理（feed 升级为标准路径、本地包即装即删、调试备份不残留、可用内存须高于冷启动需求、drop_caches 仅作归一测量）；(2) 私有签名源更新列入每次发布的标准步骤（换包 → 重建索引 → 签名 → 推 gh-pages → 对齐 README 包名），并修正发布文档中索引生成器的路径错误与推送身份要求。

Handoff capsule: `.handoffs/issue-93.md`