### PR TITLE
docs: feed restructure — rename to Smthdagg-Repo-feeds, per-project directories, master update log and verifier

### DIFF
--- a/.handoffs/issue-95.md
+++ b/.handoffs/issue-95.md
@@ -1,0 +1,71 @@
+# Agent handoff: Issue 95
+
+## Identity and scope
+
+- Source agent ID: zcode-feed-restructure-docs-20260830
+- Capabilities used: docs,ci
+- Branch: codex/issue-95-feed-restructure-docs
+- Checkpoint parent: `d6336e0`
+- Updated at (UTC): 2026-08-30
+- Credentials included: no
+
+## Objective
+
+Align all documentation with the feed restructure: the feed repository is
+renamed to `Smthdagg-Repo-feeds` and reorganized into per-project
+subdirectories (each project gets its own index and signature; the directory
+name must equal the project repository name), with a master update log and a
+verifier enforcing that every index change is recorded.
+
+## Completed
+
+- Feed repository renamed and restructured (gh-pages pushed, 1545651):
+  `wificalling-location-gateway/` holds the four r13 IPKs with a freshly
+  generated and signed 4-entry index; eight project directories reserved
+  with stub READMEs; root `README.md` documents the directory-per-project
+  rule, the exact per-project update procedure, and router feed lines;
+  root `UPDATES.md` is the master update log (historical entries backfilled);
+  `scripts/feed-verify.sh` verifies index integrity, signatures, checksums,
+  and that `UPDATES.md` covers every changed project.
+- Feed `main` branch README install URLs updated (310f436).
+- AX6S migrated to the new feed URL: `opkg update` prints `Signature check
+  passed` and the r13 packages are visible; installed version unchanged
+  (1.3.0-r13).
+- This repository's docs updated to the new flow: `RELEASE_PROCESS.md` step
+  6 (feed-repo workflow: per-project subdir, index-before-sign, UPDATES.md,
+  feed-verify, README alignment, noreply identity), `AGENTS.md` 7a (feed
+  update in the required agent workflow), `README.md` install URLs
+  (bilingual).
+
+## Verification
+
+- `feed-verify.sh` on the restructured feed: OK (it also caught and
+  fixed a checksum-cwd bug in its own first version, and the initial
+  restructure missed the two Lite IPKs — both corrected before push).
+- AX6S `opkg update` signature check passed against the new URL.
+- Full `./scripts/ci/verify.sh` gate green on this docs branch.
+
+## Failed attempts
+
+- The first gh-pages restructure moved only the two Standard IPKs (the shell
+  glob did not match the `-lite_` filenames) and shipped an index missing the
+  Lite packages; caught by the new verifier and corrected.
+- The verifier's first version checked checksums from the feed root instead
+  of the project subdirectory; fixed before push.
+- `git commit --reset-author` without `--amend` failed twice; fixed by
+  setting the repository-local noreply identity.
+
+## Next executable steps
+
+- Merge this docs PR; no release actions required.
+
+## Capabilities required for the next Agent
+
+- GitHub CLI (`gh`) with write access to `smthdagg/wificalling-location-gateway`
+  and `smthdagg/Smthdagg-Repo-feeds`.
+
+## Security and privacy notes
+
+- No credentials are included in this capsule or in the repository.
+- The signing key policy is unchanged: same long-lived key, private key never
+  leaves the release machine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,15 @@ Issue-specific ownership overrides this table. Ownership is a time-limited lease
 6. Before pausing, lease expiry, or PR creation, update `.handoffs/issue-<number>.md`, commit it, push the branch, and publish the exact commit.
 7. Open a PR containing `Closes #<number>`, evidence, risks, rollback notes, and the handoff capsule path.
 7a. For every release PR, update the private signed feed (mandatory, before
-   tagging): swap the four IPKs + `SHA256SUMS` in the feed repo `gh-pages`
-   checkout, regenerate the index with the feed repo's
-   `scripts/gen-feed-index.sh`, sign with `scripts/openwrt/sign-feed.sh`,
-   push `gh-pages`, and align the feed `README.md` package table with the
-   current release. Full sequence: `docs/releases/RELEASE_PROCESS.md`
-   step 6. The feed repo requires the account's noreply git identity.
+   tagging): work inside the project's own subdirectory of the feed repo
+   `gh-pages` branch (`wificalling-location-gateway/` — directory name must
+   equal the project repository name), regenerate that project's index with
+   the feed repo's `scripts/gen-feed-index.sh`, sign with
+   `scripts/openwrt/sign-feed.sh`, append a row to `UPDATES.md`, run the
+   feed repo's `scripts/feed-verify.sh` (must pass), push `gh-pages`, and
+   align the feed `README.md` package table with the current release. Full
+   sequence: `docs/releases/RELEASE_PROCESS.md` step 6. The feed repo
+   requires the account's noreply git identity.
 8. A different role reviews the PR. The author never self-approves a safety-sensitive change.
 
 Use `scripts/agent-takeover.sh <issue> <agent> <slug> <capabilities> [ttl-minutes]` to start or resume work. Use `scripts/agent-handoff.sh <issue> <agent> <capabilities>` to release a resumable checkpoint.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Two ways to install:
 ```sh
 # Import the feed signing key (one-time)
 wget -O /etc/opkg/keys/f7050198aa77cf15 \
-  https://raw.githubusercontent.com/smthdagg/wificalling-location-gateway-feed/main/wloc.pub
+  https://raw.githubusercontent.com/smthdagg/Smthdagg-Repo-feeds/main/wloc.pub
 # Add the feed and install
-echo "src/gz wloc https://smthdagg.github.io/wificalling-location-gateway-feed" \
+echo "src/gz wloc https://smthdagg.github.io/Smthdagg-Repo-feeds/wificalling-location-gateway" \
   >> /etc/opkg/customfeeds.conf
 opkg update && opkg install wificalling-location-gateway
 ```
@@ -170,7 +170,7 @@ opkg update && opkg install wificalling-location-gateway
 and verify it against `SHA256SUMS` from the same release directory first.
 
 Full instructions for both methods live in the
-[feed repository](https://github.com/smthdagg/wificalling-location-gateway-feed)
+[feed repository](https://github.com/smthdagg/Smthdagg-Repo-feeds)
 (including the manual `.apk` install commands for OpenWrt 25.x).
 
 ### 2. Redmi AX6S (Lite recommended)
@@ -465,9 +465,9 @@ Lite 后缀只表示运行时所有权与内存策略不同，不是新项目，
 ```sh
 # 导入源签名公钥（一次性）
 wget -O /etc/opkg/keys/f7050198aa77cf15 \
-  https://raw.githubusercontent.com/smthdagg/wificalling-location-gateway-feed/main/wloc.pub
+  https://raw.githubusercontent.com/smthdagg/Smthdagg-Repo-feeds/main/wloc.pub
 # 添加源并安装
-echo "src/gz wloc https://smthdagg.github.io/wificalling-location-gateway-feed" \
+echo "src/gz wloc https://smthdagg.github.io/Smthdagg-Repo-feeds/wificalling-location-gateway" \
   >> /etc/opkg/customfeeds.conf
 opkg update && opkg install wificalling-location-gateway
 ```
@@ -477,7 +477,7 @@ opkg update && opkg install wificalling-location-gateway
 下载对应文件，并先校验同一发布目录中的 `SHA256SUMS`。
 
 两种方式的完整说明见
-[feed 仓库](https://github.com/smthdagg/wificalling-location-gateway-feed)（含
+[feed 仓库](https://github.com/smthdagg/Smthdagg-Repo-feeds)（含
 OpenWrt 25.x 的 `.apk` 手动安装命令）。
 
 ### 2. Redmi AX6S（推荐 Lite）

--- a/docs/releases/RELEASE_PROCESS.md
+++ b/docs/releases/RELEASE_PROCESS.md
@@ -14,9 +14,10 @@ was already never committed or shared).
 - Private key: `~/.zcode/keys/wloc-signing.key` on the release machine
   (mode `0600`, never committed to git, never copied elsewhere)
 - Public key: `~/.zcode/keys/wloc-signing.pub`; published as `wloc.pub`
-  in the feed repository (`smthdagg/wificalling-location-gateway-feed`,
-  `gh-pages` branch serves the package source, `main` branch serves the
-  key file for `wget`)
+  in the feed repository (`smthdagg/Smthdagg-Repo-feeds`,
+  `gh-pages` branch serves per-project package directories (the WLOC
+  packages live in `wificalling-location-gateway/`), `main` branch serves
+  the key file for `wget` and the index generator script)
 - The public key is also referenced in the project README installation
   instructions. It must not change between releases.
 
@@ -86,16 +87,22 @@ This is also implemented as `scripts/openwrt/sign-feed.sh`.
    the index generator lives in the feed repository, not here. Standard
    sequence (use the repository's noreply git identity — the feed repo
    rejects pushes from personal-email commits):
-   a. `git clone --branch main https://github.com/smthdagg/wificalling-location-gateway-feed.git /tmp/wloc-feed-main`
-      and `git clone --branch gh-pages https://github.com/smthdagg/wificalling-location-gateway-feed.git /tmp/wloc-feed`.
-   b. In the `gh-pages` checkout: remove the previous release packages and
-      `Packages*`/`SHA256SUMS`, copy the four new IPKs plus this repo's
-      `SHA256SUMS`.
-   c. `/tmp/wloc-feed-main/scripts/gen-feed-index.sh /tmp/wloc-feed`
-      (regenerates `Packages`/`Packages.gz`), then
-      `scripts/openwrt/sign-feed.sh /tmp/wloc-feed` (same long-lived key as
-      always) — signing without regenerating the index is forbidden.
-   d. Commit and push `gh-pages`; the feed `main` branch changes only if
+   a. `git clone --branch main https://github.com/smthdagg/Smthdagg-Repo-feeds.git /tmp/wloc-feed-main`
+      and `git clone --branch gh-pages https://github.com/smthdagg/Smthdagg-Repo-feeds.git /tmp/wloc-feed`.
+   b. In the `gh-pages` checkout: work inside the project subdirectory
+      (`wificalling-location-gateway/` — directory name must equal the
+      project repository name): remove superseded packages, copy the new
+      IPKs.
+   c. `/tmp/wloc-feed-main/scripts/gen-feed-index.sh
+      /tmp/wloc-feed/wificalling-location-gateway` (regenerates that
+      project's `Packages`/`Packages.gz`), then
+      `scripts/openwrt/sign-feed.sh /tmp/wloc-feed/wificalling-location-gateway`
+      (same long-lived key as always) — signing without regenerating the
+      index is forbidden.
+   d. Append a row to `UPDATES.md` (master update log), run
+      `/tmp/wloc-feed-main/scripts/feed-verify.sh /tmp/wloc-feed` (it must
+      pass: index integrity, signatures, checksums, log coverage), then
+      commit and push `gh-pages`. The feed `main` branch changes only if
       `wloc.pub` or its docs change — also align the feed `README.md`
       package table with the current release filenames.
    e. `wloc.pub` does **not** change between releases.


### PR DESCRIPTION
## What

Aligns all documentation with the feed restructure (the feed repo work is already pushed: gh-pages `1545651`, feed main `310f436`). Closes #95.

- The feed repository is renamed to `Smthdagg-Repo-feeds` and reorganized into **per-project directories**: each project gets its own directory (name = project repository name), its own `Packages` index and signature — projects never share an index. `wificalling-location-gateway/` holds the four r13 IPKs (aarch64 + x86_64); eight project directories are reserved with stub READMEs.
- `UPDATES.md` is the master update log: every feed change appends a row (date, project, version, action) and historical entries are backfilled.
- `scripts/feed-verify.sh` (feed repo) enforces the "verify the record" rule: index integrity, valid signatures, per-package SHA256, and that `UPDATES.md` covers every project whose index changed after the log was last updated.
- This repo's `RELEASE_PROCESS.md` step 6, `AGENTS.md` 7a, and `README.md` install URLs (bilingual) are updated to the new repo name, the per-project subdirectory flow, and the noreply-identity requirement for feed pushes.

## Validation

- `feed-verify.sh` on the restructured feed: OK (it caught two real issues during the restructure — a missing Lite pair and a checksum cwd bug — both fixed before push).
- AX6S migrated: `opkg update` prints `Signature check passed` against the new URL; r13 packages visible.
- Full `./scripts/ci/verify.sh` gate green on this docs branch.

## 中文说明

私有源重构完成并写入标准文档：feed 仓库更名为 `Smthdagg-Repo-feeds`，按项目分子目录（目录名 = 项目仓库名），每个项目独立索引与签名；新增总更新记录 `UPDATES.md` 与校验脚本 `feed-verify.sh`（索引完整性、签名、SHA256、日志覆盖强制校验）；AX6S 已迁移到新源地址并通过签名验证。本 PR 同步主仓库全部相关文档（中英）。

Handoff capsule: `.handoffs/issue-95.md`